### PR TITLE
set the z component of path points to 0 to avoid uninitialized values

### DIFF
--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -140,7 +140,7 @@ namespace mapviz_plugins
       tf::Point point(
         path->poses[i].pose.position.x,
         path->poses[i].pose.position.y,
-        path->poses[i].pose.position.z);
+        0);
 
       points_.push_back(point);
       transformed_points_.push_back(point);


### PR DESCRIPTION
set the z component of path points to 0 to avoid uninitialized values.  For issue #18