### PR TITLE
(tile_map) Fixing conflict between Boost signals and QT.

### DIFF
--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -19,6 +19,9 @@ add_definitions(${QT_DEFINITIONS})
 
 set(QT_USE_QTOPENGL TRUE)
 
+# Fix conflict between Boost signals used by tf and QT signals used by mapviz
+add_definitions(-DQT_NO_KEYWORDS)
+
 rosbuild_add_boost_directories()
 
 file (GLOB TILE_SRC_FILES 

--- a/tile_map/src/tile_map_plugin.cpp
+++ b/tile_map/src/tile_map_plugin.cpp
@@ -243,4 +243,3 @@ namespace tile_map
     emitter << YAML::Key << "source" << YAML::Value << boost::trim_copy(ui_.source_combo->currentText().toStdString());
   }
 }
-


### PR DESCRIPTION
This fixes a conflict between Boost and QT signals that prevents compiling using rosbuild under hydro.