### PR TITLE
Update marker_plugin to correctly handle marker orientation.

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
@@ -111,6 +111,8 @@ namespace mapviz_plugins
       float scale_y;
       float scale_z;
 
+      transform_util::Transform local_transform;
+      
       bool transformed;
     };
 


### PR DESCRIPTION
This commit fixes issue #78 by adding support for setting the orientation of a marker.