### PR TITLE
90 degree rotation wasn't initialized properly

### DIFF
--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -31,6 +31,7 @@
 
 // C++ standard libraries
 #include <cmath>
+#include <math_util/constants.h>
 
 namespace mapviz
 {
@@ -47,6 +48,7 @@ MapCanvas::MapCanvas(QWidget* parent) :
   capture_frames_(false),
   initialized_(false),
   fix_orientation_(false),
+  rotate_90_(false),
   mouse_pressed_(false),
   mouse_x_(0),
   mouse_y_(0),
@@ -346,28 +348,26 @@ void MapCanvas::TransformTarget()
   {
     tf_->lookupTransform(fixed_frame_, target_frame_, ros::Time(0), transform_);
 
-    double roll, pitch, yaw;
-    transform_.getBasis().getRPY(roll, pitch, yaw);
-
-    if (!fix_orientation_)
-    {
-      glRotatef(-yaw * 57.2957795, 0, 0, 1);
-    }
-    
-    if (rotate_90_)
-    {
-      glRotatef(90, 0, 0, 1);
-    }
-
-    glTranslatef(-transform_.getOrigin().getX(), -transform_.getOrigin().getY(), 0);
-
-    tf::Point point(view_center_x_, view_center_y_, 0);
-
     // If the viewer orientation is fixed don't rotate the center point.
     if (fix_orientation_)
     {
       transform_.setRotation(tf::Transform::getIdentity().getRotation());
     }
+
+    if (rotate_90_)
+    {
+      transform_.setRotation(
+          transform_.getRotation() + tf::createQuaternionFromYaw(math_util::_half_pi));
+    }
+
+    double roll, pitch, yaw;
+    transform_.getBasis().getRPY(roll, pitch, yaw);
+
+    glRotatef(-yaw * 57.2957795, 0, 0, 1);
+
+    glTranslatef(-transform_.getOrigin().getX(), -transform_.getOrigin().getY(), 0);
+
+    tf::Point point(view_center_x_, view_center_y_, 0);
 
     tf::Point center = transform_ * point;
 


### PR DESCRIPTION
This was causing the view to be rotated by 90 degrees on startup although the checkbox was unchecked, and the lat/lon coordinates printed in the status bar were also incorrect.