### PR TITLE
use correct operator when combining quaternions

### DIFF
--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -357,7 +357,7 @@ void MapCanvas::TransformTarget()
     if (rotate_90_)
     {
       transform_.setRotation(
-          transform_.getRotation() + tf::createQuaternionFromYaw(math_util::_half_pi));
+          tf::createQuaternionFromYaw(-math_util::_half_pi) * transform_.getRotation());
     }
 
     double roll, pitch, yaw;


### PR DESCRIPTION
use correct operator when combining quaternions