### PR TITLE
Add required rosdeps to mapviz

### DIFF
--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -16,13 +16,15 @@
   <depend>roscpp</depend>
   <depend>rqt_gui</depend>
   <depend>rqt_gui_cpp</depend>
-  <depend>opencv2</depend>
   <depend>pluginlib</depend>
   <depend>tf</depend>
   <depend>transform_util</depend>
   <depend>libqt4-dev</depend>
   <depend>qt4-qmake</depend>
   <depend>yaml_util</depend>
+  <depend>glut</depend>
+  <depend>libopencv-dev</depend>
+  <depend>libglew-dev</depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>


### PR DESCRIPTION
Building the `mapviz` package requires [GLUT](https://www.opengl.org/resources/libraries/glut/) and [GLEW](https://www.opengl.org/sdk/libs/GLEW/) for OpenGL. This update adds them to the dependencies list.

In addition, the `rosdep` key for OpenCV is correctly `libopencv-dev`, a metapackage that installs a bunch of `libopencv-*-dev` packages. (Note that the `opencv3` key **will not** provide the appropriate packages, and will probably break the build.)