### PR TITLE
Adding support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required 
+dist: trusty 
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+env:
+  matrix:
+    - USE_DEB=true ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu ADDITIONAL_DEBS="ros-indigo-marti-can-msgs ros-indigo-marti-common-msgs ros-indigo-marti-data-structures ros-indigo-marti-nav-msgs ros-indigo-marti-perception-msgs ros-indigo-marti-sensor-msgs ros-indigo-marti-visualization-msgs ros-indigo-marti-data-structures ros-indigo-swri-console-util ros-indigo-swri-geometry-util ros-indigo-swri-image-util ros-indigo-swri-math-util ros-indigo-swri-opencv-util ros-indigo-swri-prefix-tools ros-indigo-swri-roscpp ros-indigo-swri-serial-util ros-indigo-swri-string-util ros-indigo-swri-system-util ros-indigo-swri-transform-util ros-indigo-swri-yaml-util"
+    - USE_DEB=true ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu ADDITIONAL_DEBS="ros-indigo-marti-can-msgs ros-indigo-marti-common-msgs ros-indigo-marti-data-structures ros-indigo-marti-nav-msgs ros-indigo-marti-perception-msgs ros-indigo-marti-sensor-msgs ros-indigo-marti-visualization-msgs ros-indigo-marti-data-structures ros-indigo-swri-console-util ros-indigo-swri-geometry-util ros-indigo-swri-image-util ros-indigo-swri-math-util ros-indigo-swri-opencv-util ros-indigo-swri-prefix-tools ros-indigo-swri-roscpp ros-indigo-swri-serial-util ros-indigo-swri-string-util ros-indigo-swri-system-util ros-indigo-swri-transform-util ros-indigo-swri-yaml-util"
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - source .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 


### PR DESCRIPTION
With these changes, Github will now use Travis CI to build marti_messages on commits.

Note that a repository administrator will need to enable support for this repository on https://travis-ci.org/, and the .travis.yml file should be modified appropriately for other ROS/Ubuntu distributions.

This should address issue #280.