### PR TITLE
Adding color button widget and updating plugins.

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -58,6 +58,7 @@ file (GLOB UI_FILES
   src/pluginselect.ui
   src/rqt_mapviz.ui)
 file (GLOB HEADER_FILES
+  include/mapviz/color_button.h
   include/mapviz/config_item.h
   include/mapviz/map_canvas.h
   include/mapviz/mapviz.h
@@ -66,6 +67,7 @@ file (GLOB HEADER_FILES
   include/mapviz/widgets.h)
 file (GLOB SRC_FILES
   src/mapviz.cpp
+  src/color_button.cpp
   src/config_item.cpp
   src/map_canvas.cpp
   src/rqt_mapviz.cpp)

--- a/mapviz/include/mapviz/color_button.h
+++ b/mapviz/include/mapviz/color_button.h
@@ -1,0 +1,73 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+#ifndef MAPVIZ_COLOR_BUTTON_H_
+#define MAPVIZ_COLOR_BUTTON_H_
+
+#include <QPushButton>
+#include <QColor>
+
+namespace mapviz
+{
+/**
+ * The ColorButton widget provides a color display that the user can
+ * click on to select a new color.  You can use this widget in Qt
+ * Designer by placing a QPushButton and promoting it to a custom
+ * widget.  You have to setup the promoted widget once in each .ui file:
+ *
+ * Base class name: QPushButton
+ * Promoted class name: mapviz::ColorButton
+ * Include file name: mapviz/color_button.h
+ * Global Include: True
+ */
+class ColorButton : public QPushButton
+{
+  Q_OBJECT;
+
+  QColor color_;
+  
+ public:
+  ColorButton(QWidget *parent=0);
+  
+  const QColor& color() const { return color_; }
+
+ Q_SIGNALS:
+  // Emitted when the color is changed by user interaction.
+  void colorEdited(const QColor &color);
+  // Emitted when the color is changed by user interaction or programatically.
+  void colorChanged(const QColor &color);
+
+ public Q_SLOTS:
+  void setColor(const QColor &color);
+
+ private Q_SLOTS:
+  void handleClicked();
+};  // class ColorButton
+}  // namespace mapviz
+#endif  // MAPVIZ_COLOR_BUTTON_H_

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -109,7 +109,7 @@ namespace mapviz
     void Force720p(bool on);
     void Force480p(bool on);
     void SetResizable(bool on);
-    void SelectBackgroundColor();
+    void SelectBackgroundColor(const QColor &color);
     void SetCaptureDirectory();
     void Hover(double x, double y, double scale);
 

--- a/mapviz/src/color_button.cpp
+++ b/mapviz/src/color_button.cpp
@@ -1,0 +1,75 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+#include <mapviz/color_button.h>
+
+#include <QColorDialog>
+
+namespace mapviz
+{
+ColorButton::ColorButton(QWidget *parent)
+  :
+  QPushButton(parent)
+{
+  setColor(Qt::black);
+  QObject::connect(this, SIGNAL(clicked(bool)),
+                   this, SLOT(handleClicked()));
+}
+
+void ColorButton::setColor(const QColor &color)
+{
+  if (!color.isValid() || color == color_) {
+    return;
+  }
+  
+  color_ = color;
+  // This was a very strange bug.  On initialization, the constructor
+  // would set the stylesheet to black, then the external owner would
+  // call setColor to change the color to something else.  We would
+  // properly set the internal color_ and stylesheet, but it would
+  // continue to display black.  If the user changed the color, it
+  // would change properly.  Calling setStylesheet() twice fixes the
+  // behavior.
+  setStyleSheet("background: " + color_.name());
+  setStyleSheet("background: " + color_.name());
+  Q_EMIT colorChanged(color_);
+}
+
+void ColorButton::handleClicked()
+{
+  // Note: We do not pass ourself as the parent or else the dialog
+  // will inherit our color as the background!
+  QColor new_color = QColorDialog::getColor(color_);
+  if (!new_color.isValid() || new_color == color_) {
+    return;
+  }
+  setColor(new_color);
+  Q_EMIT colorEdited(new_color);
+}
+}  // namespace mapviz

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -147,12 +147,13 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
   connect(canvas_, SIGNAL(Hover(double,double,double)), this, SLOT(Hover(double,double,double)));
   connect(ui_.configs, SIGNAL(ItemsMoved()), this, SLOT(ReorderDisplays()));
   connect(ui_.actionExit, SIGNAL(triggered()), this, SLOT(close()));
+  connect(ui_.bg_color, SIGNAL(colorEdited(const QColor &)), this, SLOT(SelectBackgroundColor(const QColor &)));
 
   connect(rec_button_, SIGNAL(toggled(bool)), this, SLOT(ToggleRecord(bool)));
   connect(stop_button_, SIGNAL(clicked()), this, SLOT(StopRecord()));
   connect(screenshot_button_, SIGNAL(clicked()), this, SLOT(Screenshot()));
 
-  ui_.bg_color->setStyleSheet("background: " + background_.name() + ";");
+  ui_.bg_color->setColor(background_);
   canvas_->SetBackground(background_);
 }
 
@@ -593,7 +594,7 @@ void Mapviz::Open(const std::string& filename)
       std::string color;
       doc["background"] >> color;
       background_ = QColor(color.c_str());
-      ui_.bg_color->setStyleSheet("background: " + background_.name() + ";");
+      ui_.bg_color->setColor(background_);
       canvas_->SetBackground(background_);
     }
 
@@ -1232,17 +1233,10 @@ void Mapviz::ReorderDisplays()
   canvas_->ReorderDisplays();
 }
 
-void Mapviz::SelectBackgroundColor()
+void Mapviz::SelectBackgroundColor(const QColor &color)
 {
-  QColorDialog dialog(background_, this);
-  dialog.exec();
-
-  if (dialog.result() == QDialog::Accepted)
-  {
-    background_ = dialog.selectedColor();
-    ui_.bg_color->setStyleSheet("background: " + background_.name() + ";");
-    canvas_->SetBackground(background_);
-  }
+  background_ = color;
+  canvas_->SetBackground(background_);
 }
 
 void Mapviz::SetCaptureDirectory()

--- a/mapviz/src/mapviz.ui
+++ b/mapviz/src/mapviz.ui
@@ -1,770 +1,755 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>mapviz</class>
-    <widget class="QMainWindow" name="mapviz">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>710</width>
-                <height>600</height>
-            </rect>
-        </property>
-        <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-            </sizepolicy>
-        </property>
-        <property name="minimumSize">
-            <size>
-                <width>600</width>
-                <height>400</height>
-            </size>
-        </property>
-        <property name="windowTitle">
-            <string>mapviz</string>
-        </property>
-        <!--<property name="unifiedTitleAndToolBarOnMac">
-         <bool>false</bool>
-        </property>-->
-        <widget class="QMenuBar" name="menubar">
-            <property name="geometry">
-                <rect>
-                    <x>0</x>
-                    <y>0</y>
-                    <width>710</width>
-                    <height>25</height>
-                </rect>
-            </property>
-            <widget class="QMenu" name="menuFile">
-                <property name="title">
-                    <string>&amp;File</string>
-                </property>
-                <addaction name="actionOpen_config"/>
-                <addaction name="separator"/>
-                <addaction name="actionSave_config"/>
-                <addaction name="separator"/>
-                <addaction name="actionSet_Capture_Directory"/>
-                <addaction name="actionExit"/>
-            </widget>
-            <widget class="QMenu" name="menu_View">
-                <property name="title">
-                    <string>&amp;View</string>
-                </property>
-                <addaction name="actionFix_Orientation"/>
-                <addaction name="actionRotate_90"/>
-                <addaction name="separator"/>
-                <addaction name="actionForce_720p"/>
-                <addaction name="actionForce_480p"/>
-                <addaction name="actionResizable"/>
-                <addaction name="separator"/>
-                <addaction name="actionConfig_Dock"/>
-                <addaction name="actionShow_Status_Bar"/>
-                <addaction name="actionShow_Capture_Tools"/>
-            </widget>
-            <addaction name="menuFile"/>
-            <addaction name="menu_View"/>
-        </widget>
-        <widget class="QStatusBar" name="statusbar">
-            <property name="enabled">
-                <bool>true</bool>
-            </property>
-        </widget>
-        <widget class="QDockWidget" name="configdock">
-            <property name="minimumSize">
-                <size>
-                    <width>332</width>
-                    <height>301</height>
-                </size>
-            </property>
-            <property name="features">
-                <set>QDockWidget::DockWidgetMovable</set>
-            </property>
-            <property name="allowedAreas">
-                <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
-            </property>
-            <property name="windowTitle">
-                <string>Config</string>
-            </property>
-            <attribute name="dockWidgetArea">
-                <number>1</number>
-            </attribute>
-            <widget class="QWidget" name="dockWidgetContents">
-                <layout class="QVBoxLayout" name="verticalLayout">
-                    <property name="spacing">
-                        <number>0</number>
-                    </property>
-                    <property name="leftMargin">
-                        <number>2</number>
-                    </property>
-                    <property name="topMargin">
-                        <number>0</number>
-                    </property>
-                    <property name="rightMargin">
-                        <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                        <number>0</number>
-                    </property>
-                    <item>
-                        <widget class="QWidget" name="widget_2" native="true">
-                            <layout class="QGridLayout" name="gridLayout">
-                                <item row="0" column="0">
-                                    <widget class="QLabel" name="label">
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>85</width>
-                                                <height>16777215</height>
-                                            </size>
-                                        </property>
-                                        <property name="font">
-                                            <font>
-                                                <family>Sans Serif</family>
-                                                <pointsize>9</pointsize>
-                                            </font>
-                                        </property>
-                                        <property name="text">
-                                            <string>Fixed Frame:</string>
-                                        </property>
-                                    </widget>
-                                </item>
-                                <item row="1" column="0" rowspan="2">
-                                    <widget class="QLabel" name="label_2">
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>85</width>
-                                                <height>16777215</height>
-                                            </size>
-                                        </property>
-                                        <property name="font">
-                                            <font>
-                                                <family>Sans Serif</family>
-                                                <pointsize>9</pointsize>
-                                            </font>
-                                        </property>
-                                        <property name="text">
-                                            <string>Target Frame:</string>
-                                        </property>
-                                    </widget>
-                                </item>
-                                <item row="5" column="0">
-                                    <widget class="QLabel" name="label_3">
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>85</width>
-                                                <height>16777215</height>
-                                            </size>
-                                        </property>
-                                        <property name="font">
-                                            <font>
-                                                <family>Sans Serif</family>
-                                                <pointsize>9</pointsize>
-                                            </font>
-                                        </property>
-                                        <property name="text">
-                                            <string>Background:</string>
-                                        </property>
-                                    </widget>
-                                </item>
-                                <item row="5" column="1">
-                                    <widget class="QPushButton" name="bg_color">
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>24</width>
-                                                <height>24</height>
-                                            </size>
-                                        </property>
-                                        <property name="toolTip">
-                                            <string>Set the background color</string>
-                                        </property>
-                                        <property name="autoFillBackground">
-                                            <bool>false</bool>
-                                        </property>
-                                        <property name="styleSheet">
-                                            <string notr="true"/>
-                                        </property>
-                                        <property name="text">
-                                            <string/>
-                                        </property>
-                                    </widget>
-                                </item>
-                                <item row="1" column="1" rowspan="2" colspan="2">
-                                    <widget class="QComboBox" name="targetframe">
-                                        <property name="sizePolicy">
-                                            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                                                <horstretch>0</horstretch>
-                                                <verstretch>0</verstretch>
-                                            </sizepolicy>
-                                        </property>
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>16777215</width>
-                                                <height>25</height>
-                                            </size>
-                                        </property>
-                                        <property name="font">
-                                            <font>
-                                                <family>Sans Serif</family>
-                                                <pointsize>9</pointsize>
-                                            </font>
-                                        </property>
-                                        <property name="toolTip">
-                                            <string>The reference frame for the camera view</string>
-                                        </property>
-                                        <property name="editable">
-                                            <bool>true</bool>
-                                        </property>
-                                    </widget>
-                                </item>
-                                <item row="0" column="1" colspan="2">
-                                    <widget class="QComboBox" name="fixedframe">
-                                        <property name="sizePolicy">
-                                            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                                                <horstretch>0</horstretch>
-                                                <verstretch>0</verstretch>
-                                            </sizepolicy>
-                                        </property>
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>16777215</width>
-                                                <height>25</height>
-                                            </size>
-                                        </property>
-                                        <property name="font">
-                                            <font>
-                                                <family>Sans Serif</family>
-                                                <pointsize>9</pointsize>
-                                            </font>
-                                        </property>
-                                        <property name="toolTip">
-                                            <string>The reference frame used to denote the &quot;world&quot; frame
+ <class>mapviz</class>
+ <widget class="QMainWindow" name="mapviz">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>732</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>400</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>mapviz</string>
+  </property>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>732</width>
+     <height>27</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>&amp;File</string>
+    </property>
+    <addaction name="actionOpen_config"/>
+    <addaction name="separator"/>
+    <addaction name="actionSave_config"/>
+    <addaction name="separator"/>
+    <addaction name="actionSet_Capture_Directory"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <widget class="QMenu" name="menu_View">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="actionFix_Orientation"/>
+    <addaction name="actionRotate_90"/>
+    <addaction name="separator"/>
+    <addaction name="actionForce_720p"/>
+    <addaction name="actionForce_480p"/>
+    <addaction name="actionResizable"/>
+    <addaction name="separator"/>
+    <addaction name="actionConfig_Dock"/>
+    <addaction name="actionShow_Status_Bar"/>
+    <addaction name="actionShow_Capture_Tools"/>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="menu_View"/>
+  </widget>
+  <widget class="QStatusBar" name="statusbar">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QDockWidget" name="configdock">
+   <property name="minimumSize">
+    <size>
+     <width>332</width>
+     <height>301</height>
+    </size>
+   </property>
+   <property name="features">
+    <set>QDockWidget::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
+   </property>
+   <property name="windowTitle">
+    <string>Config</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>2</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QWidget" name="widget_2" native="true">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="maximumSize">
+           <size>
+            <width>85</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <family>Sans Serif</family>
+            <pointsize>9</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string>Fixed Frame:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0" rowspan="2">
+         <widget class="QLabel" name="label_2">
+          <property name="maximumSize">
+           <size>
+            <width>85</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <family>Sans Serif</family>
+            <pointsize>9</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string>Target Frame:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="maximumSize">
+           <size>
+            <width>85</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <family>Sans Serif</family>
+            <pointsize>9</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string>Background:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="mapviz::ColorButton" name="bg_color">
+          <property name="maximumSize">
+           <size>
+            <width>24</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Set the background color</string>
+          </property>
+          <property name="autoFillBackground">
+           <bool>false</bool>
+          </property>
+          <property name="styleSheet">
+           <string notr="true"/>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1" rowspan="2" colspan="2">
+         <widget class="QComboBox" name="targetframe">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <family>Sans Serif</family>
+            <pointsize>9</pointsize>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>The reference frame for the camera view</string>
+          </property>
+          <property name="editable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QComboBox" name="fixedframe">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <family>Sans Serif</family>
+            <pointsize>9</pointsize>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>The reference frame used to denote the &quot;world&quot; frame
                                             </string>
-                                        </property>
-                                        <property name="editable">
-                                            <bool>true</bool>
-                                        </property>
-                                    </widget>
-                                </item>
-                                <item row="3" column="0" colspan="3">
-                                    <widget class="QCheckBox" name="uselatesttransforms">
-                                        <property name="toolTip">
-                                            <string>Use the current time when transforming data instead of using the
+          </property>
+          <property name="editable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0" colspan="3">
+         <widget class="QCheckBox" name="uselatesttransforms">
+          <property name="toolTip">
+           <string>Use the current time when transforming data instead of using the
                                                 timestamps associated with the data
                                             </string>
-                                        </property>
-                                        <property name="layoutDirection">
-                                            <enum>Qt::LeftToRight</enum>
-                                        </property>
-                                        <property name="text">
-                                            <string>Use Latest Transforms</string>
-                                        </property>
-                                        <property name="checked">
-                                            <bool>true</bool>
-                                        </property>
-                                    </widget>
-                                </item>
-                            </layout>
-                        </widget>
-                    </item>
-                    <item>
-                        <widget class="mapviz::PluginConfigList" name="configs">
-                            <property name="horizontalScrollBarPolicy">
-                                <enum>Qt::ScrollBarAsNeeded</enum>
-                            </property>
-                            <property name="dragEnabled">
-                                <bool>true</bool>
-                            </property>
-                            <property name="dragDropMode">
-                                <enum>QAbstractItemView::InternalMove</enum>
-                            </property>
-                            <property name="defaultDropAction">
-                                <enum>Qt::MoveAction</enum>
-                            </property>
-                        </widget>
-                    </item>
-                    <item>
-                        <widget class="QWidget" name="widget" native="true">
-                            <layout class="QHBoxLayout" name="horizontalLayout">
-                                <property name="topMargin">
-                                    <number>4</number>
-                                </property>
-                                <property name="bottomMargin">
-                                    <number>4</number>
-                                </property>
-                                <item>
-                                    <widget class="QPushButton" name="addbutton">
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>80</width>
-                                                <height>16777215</height>
-                                            </size>
-                                        </property>
-                                        <property name="toolTip">
-                                            <string>Add a new display</string>
-                                        </property>
-                                        <property name="text">
-                                            <string>Add</string>
-                                        </property>
-                                    </widget>
-                                </item>
-                                <item>
-                                    <widget class="QPushButton" name="removebutton">
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>80</width>
-                                                <height>16777215</height>
-                                            </size>
-                                        </property>
-                                        <property name="toolTip">
-                                            <string>Remove the selected display</string>
-                                        </property>
-                                        <property name="text">
-                                            <string>Remove</string>
-                                        </property>
-                                    </widget>
-                                </item>
-                            </layout>
-                        </widget>
-                    </item>
-                </layout>
-            </widget>
-        </widget>
-        <action name="actionExit">
-            <property name="text">
-                <string>Exit</string>
-            </property>
-        </action>
-        <action name="actionOpen_config">
-            <property name="text">
-                <string>Open Config</string>
-            </property>
-        </action>
-        <action name="actionSave_config">
-            <property name="text">
-                <string>Save Config</string>
-            </property>
-        </action>
-        <action name="actionConfig_Dock">
-            <property name="checkable">
-                <bool>true</bool>
-            </property>
-            <property name="checked">
-                <bool>true</bool>
-            </property>
-            <property name="text">
-                <string>Show Config Panel</string>
-            </property>
-            <property name="statusTip">
-                <string>Show the display configuration panel</string>
-            </property>
-        </action>
-        <action name="actionFix_Orientation">
-            <property name="checkable">
-                <bool>true</bool>
-            </property>
-            <property name="text">
-                <string>Fix Orientation</string>
-            </property>
-            <property name="statusTip">
-                <string>Fix the orientation of the camera</string>
-            </property>
-        </action>
-        <action name="actionForce_720p">
-            <property name="checkable">
-                <bool>true</bool>
-            </property>
-            <property name="text">
-                <string>Force 720p</string>
-            </property>
-            <property name="statusTip">
-                <string>Lock the display canvas to 720p</string>
-            </property>
-        </action>
-        <action name="actionForce_480p">
-            <property name="checkable">
-                <bool>true</bool>
-            </property>
-            <property name="text">
-                <string>Force 480p</string>
-            </property>
-            <property name="statusTip">
-                <string>Lock the display canvas to 480p</string>
-            </property>
-        </action>
-        <action name="actionResizable">
-            <property name="checkable">
-                <bool>true</bool>
-            </property>
-            <property name="checked">
-                <bool>true</bool>
-            </property>
-            <property name="text">
-                <string>Resizable</string>
-            </property>
-            <property name="statusTip">
-                <string>Make the window resizable</string>
-            </property>
-        </action>
-        <action name="actionSet_Capture_Directory">
-            <property name="text">
-                <string>Set Capture Directory</string>
-            </property>
-            <property name="statusTip">
-                <string>Set the capture directory for screeshots and videos</string>
-            </property>
-        </action>
-        <action name="actionShow_Status_Bar">
-            <property name="checkable">
-                <bool>true</bool>
-            </property>
-            <property name="checked">
-                <bool>true</bool>
-            </property>
-            <property name="text">
-                <string>Show Status Bar</string>
-            </property>
-            <property name="statusTip">
-                <string>Show the status bar</string>
-            </property>
-        </action>
-        <action name="actionShow_Capture_Tools">
-            <property name="checkable">
-                <bool>true</bool>
-            </property>
-            <property name="checked">
-                <bool>true</bool>
-            </property>
-            <property name="text">
-                <string>Show Capture Tools</string>
-            </property>
-            <property name="statusTip">
-                <string>Show the capture tools on the status bar</string>
-            </property>
-        </action>
-        <action name="actionRotate_90">
-            <property name="checkable">
-                <bool>true</bool>
-            </property>
-            <property name="text">
-                <string>Rotate 90°</string>
-            </property>
-            <property name="statusTip">
-                <string>Rotate the camera by 90 degrees</string>
-            </property>
-        </action>
-    </widget>
-    <customwidgets>
-        <customwidget>
-            <class>mapviz::PluginConfigList</class>
-            <extends>QListWidget</extends>
-            <header>mapviz/widgets.h</header>
-        </customwidget>
-    </customwidgets>
-    <tabstops>
-        <tabstop>fixedframe</tabstop>
-        <tabstop>targetframe</tabstop>
-        <tabstop>uselatesttransforms</tabstop>
-        <tabstop>bg_color</tabstop>
-        <tabstop>configs</tabstop>
-        <tabstop>addbutton</tabstop>
-        <tabstop>removebutton</tabstop>
-    </tabstops>
-    <resources>
-        <include location="resources/icons.qrc"/>
-    </resources>
-    <connections>
-        <connection>
-            <sender>addbutton</sender>
-            <signal>clicked()</signal>
-            <receiver>mapviz</receiver>
-            <slot>SelectNewDisplay()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>107</x>
-                    <y>573</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>327</x>
-                    <y>471</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>removebutton</sender>
-            <signal>clicked()</signal>
-            <receiver>mapviz</receiver>
-            <slot>RemoveDisplay()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>224</x>
-                    <y>573</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>328</x>
-                    <y>407</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionConfig_Dock</sender>
-            <signal>toggled(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>ToggleConfigPanel(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>399</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>fixedframe</sender>
-            <signal>editTextChanged(QString)</signal>
-            <receiver>mapviz</receiver>
-            <slot>FixedFrameSelected(QString)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>185</x>
-                    <y>62</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>428</x>
-                    <y>192</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>targetframe</sender>
-            <signal>editTextChanged(QString)</signal>
-            <receiver>mapviz</receiver>
-            <slot>TargetFrameSelected(QString)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>206</x>
-                    <y>94</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>428</x>
-                    <y>330</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionFix_Orientation</sender>
-            <signal>toggled(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>ToggleFixOrientation(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>399</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionOpen_config</sender>
-            <signal>activated()</signal>
-            <receiver>mapviz</receiver>
-            <slot>OpenConfig()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>399</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionSave_config</sender>
-            <signal>activated()</signal>
-            <receiver>mapviz</receiver>
-            <slot>SaveConfig()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>399</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionForce_720p</sender>
-            <signal>toggled(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>Force720p(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>399</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionForce_480p</sender>
-            <signal>toggled(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>Force480p(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>399</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionResizable</sender>
-            <signal>toggled(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>SetResizable(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>399</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>bg_color</sender>
-            <signal>clicked()</signal>
-            <receiver>mapviz</receiver>
-            <slot>SelectBackgroundColor()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>123</x>
-                    <y>171</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>375</x>
-                    <y>136</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>uselatesttransforms</sender>
-            <signal>toggled(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>ToggleUseLatestTransforms(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>58</x>
-                    <y>130</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>460</x>
-                    <y>242</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionSet_Capture_Directory</sender>
-            <signal>activated()</signal>
-            <receiver>mapviz</receiver>
-            <slot>SetCaptureDirectory()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>354</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionShow_Status_Bar</sender>
-            <signal>toggled(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>ToggleStatusBar(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>354</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionShow_Capture_Tools</sender>
-            <signal>triggered(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>ToggleCaptureTools(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>354</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionRotate_90</sender>
-            <signal>toggled(bool)</signal>
-            <receiver>mapviz</receiver>
-            <slot>ToggleRotate90(bool)</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>354</x>
-                    <y>299</y>
-                </hint>
-            </hints>
-        </connection>
-    </connections>
-    <slots>
-        <slot>SelectNewDisplay()</slot>
-        <slot>RemoveDisplay()</slot>
-        <slot>ToggleConfigPanel(bool)</slot>
-        <slot>FixedFrameSelected(QString)</slot>
-        <slot>TargetFrameSelected(QString)</slot>
-        <slot>ToggleFixOrientation(bool)</slot>
-        <slot>MoveDisplay(QModelIndexList)</slot>
-        <slot>OpenConfig()</slot>
-        <slot>SaveConfig()</slot>
-        <slot>Force720p(bool)</slot>
-        <slot>Force480p(bool)</slot>
-        <slot>SetResizable(bool)</slot>
-        <slot>SelectBackgroundColor()</slot>
-        <slot>ToggleUseLatestTransforms(bool)</slot>
-        <slot>SetCaptureDirectory()</slot>
-        <slot>ToggleStatusBar(bool)</slot>
-        <slot>ToggleCaptureTools(bool)</slot>
-        <slot>ToggleRotate90(bool)</slot>
-    </slots>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="text">
+           <string>Use Latest Transforms</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="mapviz::PluginConfigList" name="configs">
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAsNeeded</enum>
+       </property>
+       <property name="dragEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="dragDropMode">
+        <enum>QAbstractItemView::InternalMove</enum>
+       </property>
+       <property name="defaultDropAction">
+        <enum>Qt::MoveAction</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QWidget" name="widget" native="true">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="addbutton">
+          <property name="maximumSize">
+           <size>
+            <width>80</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Add a new display</string>
+          </property>
+          <property name="text">
+           <string>Add</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="removebutton">
+          <property name="maximumSize">
+           <size>
+            <width>80</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Remove the selected display</string>
+          </property>
+          <property name="text">
+           <string>Remove</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
+   </property>
+  </action>
+  <action name="actionOpen_config">
+   <property name="text">
+    <string>Open Config</string>
+   </property>
+  </action>
+  <action name="actionSave_config">
+   <property name="text">
+    <string>Save Config</string>
+   </property>
+  </action>
+  <action name="actionConfig_Dock">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Config Panel</string>
+   </property>
+   <property name="statusTip">
+    <string>Show the display configuration panel</string>
+   </property>
+  </action>
+  <action name="actionFix_Orientation">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Fix Orientation</string>
+   </property>
+   <property name="statusTip">
+    <string>Fix the orientation of the camera</string>
+   </property>
+  </action>
+  <action name="actionForce_720p">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Force 720p</string>
+   </property>
+   <property name="statusTip">
+    <string>Lock the display canvas to 720p</string>
+   </property>
+  </action>
+  <action name="actionForce_480p">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Force 480p</string>
+   </property>
+   <property name="statusTip">
+    <string>Lock the display canvas to 480p</string>
+   </property>
+  </action>
+  <action name="actionResizable">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Resizable</string>
+   </property>
+   <property name="statusTip">
+    <string>Make the window resizable</string>
+   </property>
+  </action>
+  <action name="actionSet_Capture_Directory">
+   <property name="text">
+    <string>Set Capture Directory</string>
+   </property>
+   <property name="statusTip">
+    <string>Set the capture directory for screeshots and videos</string>
+   </property>
+  </action>
+  <action name="actionShow_Status_Bar">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Status Bar</string>
+   </property>
+   <property name="statusTip">
+    <string>Show the status bar</string>
+   </property>
+  </action>
+  <action name="actionShow_Capture_Tools">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Capture Tools</string>
+   </property>
+   <property name="statusTip">
+    <string>Show the capture tools on the status bar</string>
+   </property>
+  </action>
+  <action name="actionRotate_90">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Rotate 90°</string>
+   </property>
+   <property name="statusTip">
+    <string>Rotate the camera by 90 degrees</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mapviz::PluginConfigList</class>
+   <extends>QListWidget</extends>
+   <header>mapviz/widgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>mapviz::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">mapviz/color_button.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>fixedframe</tabstop>
+  <tabstop>targetframe</tabstop>
+  <tabstop>uselatesttransforms</tabstop>
+  <tabstop>bg_color</tabstop>
+  <tabstop>configs</tabstop>
+  <tabstop>addbutton</tabstop>
+  <tabstop>removebutton</tabstop>
+ </tabstops>
+ <resources>
+  <include location="resources/icons.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>addbutton</sender>
+   <signal>clicked()</signal>
+   <receiver>mapviz</receiver>
+   <slot>SelectNewDisplay()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>107</x>
+     <y>573</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>327</x>
+     <y>471</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>removebutton</sender>
+   <signal>clicked()</signal>
+   <receiver>mapviz</receiver>
+   <slot>RemoveDisplay()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>224</x>
+     <y>573</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>328</x>
+     <y>407</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionConfig_Dock</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleConfigPanel(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>fixedframe</sender>
+   <signal>editTextChanged(QString)</signal>
+   <receiver>mapviz</receiver>
+   <slot>FixedFrameSelected(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>185</x>
+     <y>62</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>428</x>
+     <y>192</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>targetframe</sender>
+   <signal>editTextChanged(QString)</signal>
+   <receiver>mapviz</receiver>
+   <slot>TargetFrameSelected(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>206</x>
+     <y>94</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>428</x>
+     <y>330</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionFix_Orientation</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleFixOrientation(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionOpen_config</sender>
+   <signal>activated()</signal>
+   <receiver>mapviz</receiver>
+   <slot>OpenConfig()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionSave_config</sender>
+   <signal>activated()</signal>
+   <receiver>mapviz</receiver>
+   <slot>SaveConfig()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionForce_720p</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>Force720p(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionForce_480p</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>Force480p(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionResizable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>SetResizable(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>uselatesttransforms</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleUseLatestTransforms(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>58</x>
+     <y>130</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>460</x>
+     <y>242</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionSet_Capture_Directory</sender>
+   <signal>activated()</signal>
+   <receiver>mapviz</receiver>
+   <slot>SetCaptureDirectory()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionShow_Status_Bar</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleStatusBar(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionShow_Capture_Tools</sender>
+   <signal>triggered(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleCaptureTools(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionRotate_90</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleRotate90(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>SelectNewDisplay()</slot>
+  <slot>RemoveDisplay()</slot>
+  <slot>ToggleConfigPanel(bool)</slot>
+  <slot>FixedFrameSelected(QString)</slot>
+  <slot>TargetFrameSelected(QString)</slot>
+  <slot>ToggleFixOrientation(bool)</slot>
+  <slot>MoveDisplay(QModelIndexList)</slot>
+  <slot>OpenConfig()</slot>
+  <slot>SaveConfig()</slot>
+  <slot>Force720p(bool)</slot>
+  <slot>Force480p(bool)</slot>
+  <slot>SetResizable(bool)</slot>
+  <slot>ToggleUseLatestTransforms(bool)</slot>
+  <slot>SetCaptureDirectory()</slot>
+  <slot>ToggleStatusBar(bool)</slot>
+  <slot>ToggleCaptureTools(bool)</slot>
+  <slot>ToggleRotate90(bool)</slot>
+ </slots>
 </ui>

--- a/mapviz_plugins/include/mapviz_plugins/gps_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/gps_plugin.h
@@ -32,7 +32,6 @@
 #include <QGLWidget>
 #include <QObject>
 #include <QWidget>
-#include <QColor>
 
 // ROS libraries
 #include <ros/ros.h>
@@ -90,21 +89,19 @@ namespace mapviz_plugins
 
   protected Q_SLOTS:
     void SelectTopic();
-    void SelectColor();
     void TopicEdited();
     void PositionToleranceChanged(double value);
     void AngleToleranceChanged(double value);
     void BufferSizeChanged(int value);
     void SetDrawStyle(QString style);
+    void DrawIcon();
 
   private:
     bool DrawArrows();
     bool TransformPoint(StampedPoint& point);
-    void DrawIcon();
 
     Ui::gps_config ui_;
     QWidget* config_widget_;
-    QColor color_;
 
     DrawStyle draw_style_;
 

--- a/mapviz_plugins/include/mapviz_plugins/grid_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/grid_plugin.h
@@ -41,7 +41,6 @@
 #include <QObject>
 #include <QWidget>
 #include <QTimer>
-#include <QColor>
 
 // ROS libraries
 #include <ros/ros.h>
@@ -80,7 +79,6 @@ namespace mapviz_plugins
     void PrintWarning(const std::string& message);
 
   protected Q_SLOTS:
-    void SelectColor();
     void SetAlpha(double alpha);
     void SetX(double x);
     void SetY(double y);
@@ -89,12 +87,12 @@ namespace mapviz_plugins
     void SetColumns(int columns);
     void SetFrame(QString frame);
     void UpdateFrames();
+    void DrawIcon();
 
   private:
     Ui::grid_config ui_;
     QWidget* config_widget_;
     QTimer frame_timer_;
-    QColor color_;
 
     double alpha_;
 
@@ -122,7 +120,6 @@ namespace mapviz_plugins
 
     void RecalculateGrid();
     void Transform(std::list<tf::Point>& src, std::list<tf::Point>& dst);
-    void DrawIcon();
   };
 }
 

--- a/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
@@ -89,14 +89,14 @@ namespace mapviz_plugins
       void SelectTopic();
       void TopicEdited();
       void AlphaEdited();
-      void SelectMinColor();
-      void SelectMaxColor();
       void ColorTransformerChanged(int index);
       void MinValueChanged(double value);
       void MaxValueChanged(double value);
       void PointSizeChanged(int value);
       void BufferSizeChanged(int value);
       void UseRainbowChanged(int check_state);
+      void UpdateColors();    
+      void DrawIcon();
 
     private:
       struct StampedPoint
@@ -118,15 +118,12 @@ namespace mapviz_plugins
       };
 
       void laserScanCallback(const sensor_msgs::LaserScanConstPtr& scan);
-      void UpdateColors();
       QColor CalculateColor(const StampedPoint& point, bool has_intensity);
-      void DrawIcon();
 
       Ui::laserscan_config ui_;
       QWidget* config_widget_;
 
       std::string topic_;
-      QColor min_color_, max_color_;
       double alpha_;
       double min_value_, max_value_;
       unsigned int point_size_;

--- a/mapviz_plugins/include/mapviz_plugins/navsat_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/navsat_plugin.h
@@ -32,7 +32,6 @@
 #include <QGLWidget>
 #include <QObject>
 #include <QWidget>
-#include <QColor>
 
 // ROS libraries
 #include <ros/ros.h>
@@ -90,20 +89,18 @@ namespace mapviz_plugins
 
   protected Q_SLOTS:
     void SelectTopic();
-    void SelectColor();
     void TopicEdited();
     void PositionToleranceChanged(double value);
     void AngleToleranceChanged(double value);
     void BufferSizeChanged(int value);
     void SetDrawStyle(QString style);
+    void DrawIcon();
 
   private:
     bool TransformPoint(StampedPoint& point);
-    void DrawIcon();
 
     Ui::navsat_config ui_;
     QWidget* config_widget_;
-    QColor color_;
 
     DrawStyle draw_style_;
 

--- a/mapviz_plugins/include/mapviz_plugins/odometry_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/odometry_plugin.h
@@ -41,7 +41,6 @@
 #include <QGLWidget>
 #include <QObject>
 #include <QWidget>
-#include <QColor>
 
 // ROS libraries
 #include <ros/ros.h>
@@ -100,22 +99,20 @@ namespace mapviz_plugins
 
   protected Q_SLOTS:
     void SelectTopic();
-    void SelectColor();
     void TopicEdited();
     void PositionToleranceChanged(double value);
     void AngleToleranceChanged(double value);
     void BufferSizeChanged(int value);
     void SetDrawStyle(QString style);
+    void DrawIcon();
 
   private:
     void DrawCovariance();
     bool DrawArrows();
     bool TransformPoint(StampedPoint& point);
-    void DrawIcon();
 
     Ui::odometry_config ui_;
     QWidget* config_widget_;
-    QColor color_;
 
     DrawStyle draw_style_;
 

--- a/mapviz_plugins/include/mapviz_plugins/path_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/path_plugin.h
@@ -40,7 +40,6 @@
 #include <QGLWidget>
 #include <QObject>
 #include <QWidget>
-#include <QColor>
 
 // ROS libraries
 #include <ros/ros.h>
@@ -81,9 +80,9 @@ namespace mapviz_plugins
     void PrintWarning(const std::string& message);
 
   protected Q_SLOTS:
-    void SelectColor();
     void SelectTopic();
     void TopicEdited();
+    void DrawIcon();
 
   private:
     Ui::path_config ui_;
@@ -101,11 +100,9 @@ namespace mapviz_plugins
 
     bool transformed_;
 
-    QColor color_;
     float line_width_;
 
     void pathCallback(const nav_msgs::PathConstPtr path);
-    void DrawIcon();
   };
 }
 

--- a/mapviz_plugins/include/mapviz_plugins/tf_frame_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/tf_frame_plugin.h
@@ -41,7 +41,6 @@
 #include <QGLWidget>
 #include <QObject>
 #include <QWidget>
-#include <QColor>
 
 // ROS libraries
 #include <ros/ros.h>
@@ -101,19 +100,17 @@ namespace mapviz_plugins
   protected Q_SLOTS:
     void SelectFrame();
     void FrameEdited();
-    void SelectColor();
     void PositionToleranceChanged(double value);
     void BufferSizeChanged(int value);
     void SetDrawStyle(QString style);
+    void DrawIcon();
 
   private:
     bool DrawArrows();
     bool TransformPoint(StampedPoint& point);
-    void DrawIcon();
 
     Ui::tf_frame_config ui_;
     QWidget* config_widget_;
-    QColor color_;
 
     DrawStyle draw_style_;
 

--- a/mapviz_plugins/src/gps_config.ui
+++ b/mapviz_plugins/src/gps_config.ui
@@ -146,7 +146,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QPushButton" name="selectcolor">
+    <widget class="mapviz::ColorButton" name="color">
      <property name="maximumSize">
       <size>
        <width>24</width>
@@ -233,6 +233,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mapviz::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">mapviz/color_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <slots>

--- a/mapviz_plugins/src/gps_plugin.cpp
+++ b/mapviz_plugins/src/gps_plugin.cpp
@@ -25,7 +25,6 @@
 
 // QT libraries
 #include <QDialog>
-#include <QColorDialog>
 #include <QGLWidget>
 #include <QPalette>
 
@@ -49,30 +48,30 @@ namespace mapviz_plugins
 {
   GpsPlugin::GpsPlugin() :
     config_widget_(new QWidget()),
-    color_(Qt::green),
     draw_style_(LINES)
   {
     ui_.setupUi(config_widget_);
+
+    ui_.color->setColor(Qt::green);
 
     // Set background white
     QPalette p(config_widget_->palette());
     p.setColor(QPalette::Background, Qt::white);
     config_widget_->setPalette(p);
 
-    // Initialize color selector color
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
-
     // Set status text red
     QPalette p3(ui_.status->palette());
     p3.setColor(QPalette::Text, Qt::red);
     ui_.status->setPalette(p3);
 
-    QObject::connect(ui_.selectcolor, SIGNAL(clicked()), this, SLOT(SelectColor()));
     QObject::connect(ui_.selecttopic, SIGNAL(clicked()), this, SLOT(SelectTopic()));
     QObject::connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
-    QObject::connect(ui_.positiontolerance, SIGNAL(valueChanged(double)), this, SLOT(PositionToleranceChanged(double)));
+    QObject::connect(ui_.positiontolerance, SIGNAL(valueChanged(double)),
+                     this, SLOT(PositionToleranceChanged(double)));
     QObject::connect(ui_.buffersize, SIGNAL(valueChanged(int)), this, SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this, SLOT(SetDrawStyle(QString)));
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
+            this, SLOT(DrawIcon()));
   }
 
   GpsPlugin::~GpsPlugin()
@@ -89,7 +88,7 @@ namespace mapviz_plugins
       QPainter painter(&icon);
       painter.setRenderHint(QPainter::Antialiasing, true);
       
-      QPen pen(color_);
+      QPen pen(ui_.color->color());
       
       if (draw_style_ == POINTS)
       {
@@ -162,20 +161,6 @@ namespace mapviz_plugins
     {
       ui_.topic->setText(ui.displaylist->selectedItems().first()->text());
       TopicEdited();
-    }
-  }
-
-  void GpsPlugin::SelectColor()
-  {
-    QColorDialog dialog(color_, config_widget_);
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted)
-    {
-      color_ = dialog.selectedColor();
-      ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
-      DrawIcon();
-      canvas_->update();
     }
   }
 
@@ -306,6 +291,8 @@ namespace mapviz_plugins
   bool GpsPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
+            canvas_, SLOT(update()));          
 
     DrawIcon();
 
@@ -314,11 +301,11 @@ namespace mapviz_plugins
 
   void GpsPlugin::Draw(double x, double y, double scale)
   {
-    glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 0.5);
+    QColor color = ui_.color->color();
 
     bool transformed = false;
 
-    glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 1.0);
+    glColor4f(color.redF(), color.greenF(), color.blueF(), 1.0);
 
     if (draw_style_ == ARROWS)
     {
@@ -478,8 +465,7 @@ namespace mapviz_plugins
 
     std::string color;
     node["color"] >> color;
-    color_ = QColor(color.c_str());
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
+    ui_.color->setColor(QColor(color.c_str()));
 
     std::string draw_style;
     node["draw_style"] >> draw_style;
@@ -514,8 +500,7 @@ namespace mapviz_plugins
     std::string topic = ui_.topic->text().toStdString();
     emitter << YAML::Key << "topic" << YAML::Value << topic;
 
-    std::string color = color_.name().toStdString();
-    emitter << YAML::Key << "color" << YAML::Value << color;
+    emitter << YAML::Key << "color" << YAML::Value << ui_.color->color().name().toStdString();
 
     std::string draw_style = ui_.drawstyle->currentText().toStdString();
     emitter << YAML::Key << "draw_style" << YAML::Value << draw_style;

--- a/mapviz_plugins/src/grid_config.ui
+++ b/mapviz_plugins/src/grid_config.ui
@@ -50,7 +50,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QPushButton" name="selectcolor">
+    <widget class="mapviz::ColorButton" name="color">
      <property name="maximumSize">
       <size>
        <width>24</width>
@@ -313,6 +313,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mapviz::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">mapviz/color_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <slots>

--- a/mapviz_plugins/src/grid_plugin.cpp
+++ b/mapviz_plugins/src/grid_plugin.cpp
@@ -34,7 +34,6 @@
 #include <vector>
 
 // QT libraries
-#include <QColorDialog>
 #include <QGLWidget>
 #include <QPalette>
 
@@ -50,7 +49,6 @@ namespace mapviz_plugins
 {
   GridPlugin::GridPlugin() :
     config_widget_(new QWidget()),
-    color_(Qt::red),
     alpha_(1.0),
     top_left_(0, 0, 0),
     size_(1),
@@ -61,20 +59,18 @@ namespace mapviz_plugins
   {
     ui_.setupUi(config_widget_);
 
+    ui_.color->setColor(Qt::red);
+    
     // Set background white
     QPalette p(config_widget_->palette());
     p.setColor(QPalette::Background, Qt::white);
     config_widget_->setPalette(p);
-
-    // Initialize color selector color
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
 
     // Set status text red
     QPalette p3(ui_.status->palette());
     p3.setColor(QPalette::Text, Qt::red);
     ui_.status->setPalette(p3);
 
-    QObject::connect(ui_.selectcolor, SIGNAL(clicked()), this, SLOT(SelectColor()));
     QObject::connect(ui_.alpha, SIGNAL(valueChanged(double)), this, SLOT(SetAlpha(double)));
     QObject::connect(ui_.x, SIGNAL(valueChanged(double)), this, SLOT(SetX(double)));
     QObject::connect(ui_.y, SIGNAL(valueChanged(double)), this, SLOT(SetY(double)));
@@ -82,6 +78,7 @@ namespace mapviz_plugins
     QObject::connect(ui_.rows, SIGNAL(valueChanged(int)), this, SLOT(SetRows(int)));
     QObject::connect(ui_.columns, SIGNAL(valueChanged(int)), this, SLOT(SetColumns(int)));
     QObject::connect(ui_.frame, SIGNAL(editTextChanged(QString)), this, SLOT(SetFrame(QString)));
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)), this, SLOT(DrawIcon()));
   }
 
   GridPlugin::~GridPlugin()
@@ -106,7 +103,7 @@ namespace mapviz_plugins
       QPainter painter(&icon);
       painter.setRenderHint(QPainter::Antialiasing, true);
       
-      QPen pen(QColor(color_.rgb()));
+      QPen pen(QColor(ui_.color->color()));
       
       pen.setWidth(2);
       pen.setCapStyle(Qt::SquareCap);
@@ -126,10 +123,8 @@ namespace mapviz_plugins
   void GridPlugin::SetAlpha(double alpha)
   {
     alpha_ = alpha;
-    color_.setAlpha(alpha_);
-    DrawIcon();
     if (canvas_)
-    canvas_->update();
+      canvas_->update();
   }
 
   void GridPlugin::SetX(double x)
@@ -226,24 +221,6 @@ namespace mapviz_plugins
     }
   }
 
-  void GridPlugin::SelectColor()
-  {
-    QColorDialog dialog(color_, config_widget_);
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted)
-    {
-      color_ = dialog.selectedColor();
-      color_.setAlpha(alpha_);
-      ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
-
-      DrawIcon();
-
-      if (canvas_)
-      canvas_->update();
-    }
-  }
-
   void GridPlugin::PrintError(const std::string& message)
   {
     if (message == ui_.status->text().toStdString())
@@ -304,8 +281,10 @@ namespace mapviz_plugins
   {
     if (transformed_)
     {
+      QColor color = ui_.color->color();
+      
       glLineWidth(3);
-      glColor4f(color_.redF(), color_.greenF(), color_.blueF(), alpha_);
+      glColor4f(color.redF(), color.greenF(), color.blueF(), alpha_);
       glBegin(GL_LINES);
 
         std::list<tf::Point>::iterator transformed_left_it = transformed_left_points_.begin();
@@ -407,8 +386,7 @@ namespace mapviz_plugins
   {
     std::string color;
     node["color"] >> color;
-    color_ = QColor(color.c_str());
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
+    ui_.color->setColor(QColor(color.c_str()));
 
     std::string frame;
     node["frame"] >> frame;
@@ -440,8 +418,7 @@ namespace mapviz_plugins
 
   void GridPlugin::SaveConfig(YAML::Emitter& emitter, const std::string& path)
   {
-    std::string color = color_.name().toStdString();
-    emitter << YAML::Key << "color" << YAML::Value << color;
+    emitter << YAML::Key << "color" << YAML::Value << ui_.color->color().name().toStdString();
 
     emitter << YAML::Key << "alpha" << YAML::Value << alpha_;
 

--- a/mapviz_plugins/src/laserscan_config.ui
+++ b/mapviz_plugins/src/laserscan_config.ui
@@ -275,7 +275,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="selectMinColor">
+        <widget class="mapviz::ColorButton" name="min_color">
          <property name="maximumSize">
           <size>
            <width>24</width>
@@ -304,7 +304,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="selectMaxColor">
+        <widget class="mapviz::ColorButton" name="max_color">
          <property name="maximumSize">
           <size>
            <width>24</width>
@@ -348,6 +348,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mapviz::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">mapviz/color_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <slots>

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -67,8 +67,6 @@ namespace mapviz_plugins
   LaserScanPlugin::LaserScanPlugin() :
       config_widget_(new QWidget()),
           topic_(""),
-          min_color_(Qt::white),
-          max_color_(Qt::black),
           alpha_(1.0),
           min_value_(0.0),
           max_value_(100.0),
@@ -87,9 +85,9 @@ namespace mapviz_plugins
     ui_.status->setPalette(p3);
 
     // Initialize color selector colors
-    ui_.selectMinColor->setStyleSheet("background: " + min_color_.name() + ";");
-    ui_.selectMaxColor->setStyleSheet("background: " + max_color_.name() + ";");
-
+    ui_.min_color->setColor(Qt::white);
+    ui_.max_color->setColor(Qt::black);
+    
     // Set color transformer choices
     ui_.color_transformer->addItem(QString("Flat Color"), QVariant(0));
     ui_.color_transformer->addItem(QString("Intensity"), QVariant(1));
@@ -114,14 +112,14 @@ namespace mapviz_plugins
         SIGNAL(currentIndexChanged(int)),
         this,
         SLOT(ColorTransformerChanged(int)));
-    QObject::connect(ui_.selectMaxColor,
-        SIGNAL(clicked()),
+    QObject::connect(ui_.max_color,
+        SIGNAL(colorEdited(const QColor &)),
         this,
-        SLOT(SelectMaxColor()));
-    QObject::connect(ui_.selectMinColor,
-        SIGNAL(clicked()),
+        SLOT(UpdateColors()));
+    QObject::connect(ui_.min_color,
+        SIGNAL(colorEdited(const QColor &)),
         this,
-        SLOT(SelectMinColor()));
+        SLOT(UpdateColors()));
     QObject::connect(ui_.minValue,
         SIGNAL(valueChanged(double)),
         this,
@@ -142,6 +140,16 @@ namespace mapviz_plugins
         SIGNAL(stateChanged(int)),
         this,
         SLOT(UseRainbowChanged(int)));
+
+    QObject::connect(ui_.max_color,
+        SIGNAL(colorEdited(const QColor &)),
+        this,
+        SLOT(DrawIcon()));
+    QObject::connect(ui_.min_color,
+        SIGNAL(colorEdited(const QColor &)),
+        this,
+        SLOT(DrawIcon()));
+
     PrintInfo("Constructed LaserScanPlugin");
   }
 
@@ -163,19 +171,19 @@ namespace mapviz_plugins
       pen.setWidth(4);
       pen.setCapStyle(Qt::RoundCap);
 
-      pen.setColor(min_color_);
+      pen.setColor(ui_.min_color->color());
       painter.setPen(pen);
       painter.drawPoint(2, 13);
 
-      pen.setColor(min_color_);
+      pen.setColor(ui_.min_color->color());
       painter.setPen(pen);
       painter.drawPoint(4, 6);
 
-      pen.setColor(min_color_);
+      pen.setColor(ui_.max_color->color());
       painter.setPen(pen);
       painter.drawPoint(12, 9);
 
-      pen.setColor(min_color_);
+      pen.setColor(ui_.max_color->color());
       painter.setPen(pen);
       painter.drawPoint(13, 2);
 
@@ -210,7 +218,7 @@ namespace mapviz_plugins
     }
     else  // No intensity or  (color_transformer == COLOR_FLAT)
     {
-      return min_color_;
+      return ui_.min_color->color();
     }
     if (max_value_ > min_value_)
       val = (val - min_value_) / (max_value_ - min_value_);
@@ -223,11 +231,13 @@ namespace mapviz_plugins
     }
     else
     {
+      const QColor min_color = ui_.min_color->color();
+      const QColor max_color = ui_.max_color->color();
       // RGB Interpolation
       int red, green, blue;
-      red = val * max_color_.red() + ((1.0 - val) * min_color_.red());
-      green = val * max_color_.green() + ((1.0 - val) * min_color_.green());
-      blue = val * max_color_.blue() + ((1.0 - val) * min_color_.blue());
+      red =   val * max_color.red()   + ((1.0 - val) * min_color.red());
+      green = val * max_color.green() + ((1.0 - val) * min_color.green());
+      blue =  val * max_color.blue()  + ((1.0 - val) * min_color.blue());
       return QColor(red, green, blue, 255);
     }
   }
@@ -243,6 +253,7 @@ namespace mapviz_plugins
         point_it->color = CalculateColor(*point_it, scan_it->has_intensity);
       }
     }
+    canvas_->update();
   }
 
   void LaserScanPlugin::SelectTopic()
@@ -293,48 +304,16 @@ namespace mapviz_plugins
     }
   }
 
-  void LaserScanPlugin::SelectMinColor()
-  {
-    QColorDialog dialog(min_color_, config_widget_);
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted)
-    {
-      min_color_ = dialog.selectedColor();
-      ui_.selectMinColor->setStyleSheet("background: " + min_color_.name() + ";");
-      DrawIcon();
-      UpdateColors();
-      canvas_->update();
-    }
-  }
-
-  void LaserScanPlugin::SelectMaxColor()
-  {
-    QColorDialog dialog(max_color_, config_widget_);
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted)
-    {
-      max_color_ = dialog.selectedColor();
-      ui_.selectMaxColor->setStyleSheet("background: " + max_color_.name() + ";");
-      DrawIcon();
-      UpdateColors();
-      canvas_->update();
-    }
-  }
-
   void LaserScanPlugin::MinValueChanged(double value)
   {
     min_value_ = value;
     UpdateColors();
-    canvas_->update();
   }
 
   void LaserScanPlugin::MaxValueChanged(double value)
   {
     max_value_ = value;
     UpdateColors();
-    canvas_->update();
   }
 
   void LaserScanPlugin::BufferSizeChanged(int value)
@@ -508,20 +487,19 @@ namespace mapviz_plugins
   {
     if (check_state == Qt::Checked)
     {
-      ui_.selectMaxColor->setVisible(false);
-      ui_.selectMinColor->setVisible(false);
+      ui_.max_color->setVisible(false);
+      ui_.min_color->setVisible(false);
       ui_.maxColorLabel->setVisible(false);
       ui_.minColorLabel->setVisible(false);
     }
     else
     {
-      ui_.selectMaxColor->setVisible(true);
-      ui_.selectMinColor->setVisible(true);
+      ui_.max_color->setVisible(true);
+      ui_.min_color->setVisible(true);
       ui_.maxColorLabel->setVisible(true);
       ui_.minColorLabel->setVisible(true);
     }
     UpdateColors();
-    canvas_->update();
   }
 
   void LaserScanPlugin::Transform()
@@ -551,7 +529,6 @@ namespace mapviz_plugins
     if (ui_.color_transformer->currentIndex() == COLOR_Z)
     {
       UpdateColors();
-      canvas_->update();
     }
   }
 
@@ -587,13 +564,11 @@ namespace mapviz_plugins
 
     std::string min_color_str;
     node["min_color"] >> min_color_str;
-    min_color_ = QColor(min_color_str.c_str());
-    ui_.selectMinColor->setStyleSheet("background: " + min_color_.name() + ";");
+    ui_.min_color->setColor(QColor(min_color_str.c_str()));
 
     std::string max_color_str;
     node["max_color"] >> max_color_str;
-    max_color_ = QColor(max_color_str.c_str());
-    ui_.selectMaxColor->setStyleSheet("background: " + max_color_.name() + ";");
+    ui_.max_color->setColor(QColor(max_color_str.c_str()));
 
     node["value_min"] >> min_value_;
     ui_.minValue->setValue(min_value_);
@@ -617,8 +592,8 @@ namespace mapviz_plugins
     switch (index)
     {
       case COLOR_FLAT:
-        ui_.selectMinColor->setVisible(true);
-        ui_.selectMaxColor->setVisible(false);
+        ui_.min_color->setVisible(true);
+        ui_.max_color->setVisible(false);
         ui_.maxColorLabel->setVisible(false);
         ui_.minColorLabel->setVisible(false);
         ui_.minValueLabel->setVisible(false);
@@ -633,8 +608,8 @@ namespace mapviz_plugins
       case COLOR_Y:  // Y Axis
       case COLOR_Z:  // Z axis
       default:
-        ui_.selectMinColor->setVisible(!ui_.use_rainbow->isChecked());
-        ui_.selectMaxColor->setVisible(!ui_.use_rainbow->isChecked());
+        ui_.min_color->setVisible(!ui_.use_rainbow->isChecked());
+        ui_.max_color->setVisible(!ui_.use_rainbow->isChecked());
         ui_.maxColorLabel->setVisible(!ui_.use_rainbow->isChecked());
         ui_.minColorLabel->setVisible(!ui_.use_rainbow->isChecked());
         ui_.minValueLabel->setVisible(true);
@@ -645,7 +620,6 @@ namespace mapviz_plugins
         break;
     }
     UpdateColors();
-    canvas_->update();
   }
 
   /**
@@ -671,9 +645,9 @@ namespace mapviz_plugins
     emitter << YAML::Key << "color_transformer" <<
                YAML::Value << ui_.color_transformer->currentText().toStdString();
     emitter << YAML::Key << "min_color" <<
-               YAML::Value << min_color_.name().toStdString();
+               YAML::Value << ui_.min_color->color().name().toStdString();
     emitter << YAML::Key << "max_color" <<
-               YAML::Value << max_color_.name().toStdString();
+               YAML::Value << ui_.max_color->color().name().toStdString();
     emitter << YAML::Key << "value_min" <<
                YAML::Value << ui_.minValue->text().toDouble();
     emitter << YAML::Key << "value_max" <<

--- a/mapviz_plugins/src/navsat_config.ui
+++ b/mapviz_plugins/src/navsat_config.ui
@@ -146,7 +146,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QPushButton" name="selectcolor">
+    <widget class="mapviz::ColorButton" name="color">
      <property name="maximumSize">
       <size>
        <width>24</width>
@@ -228,6 +228,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mapviz::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">mapviz/color_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <slots>

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -25,7 +25,6 @@
 
 // QT libraries
 #include <QDialog>
-#include <QColorDialog>
 #include <QGLWidget>
 #include <QPalette>
 
@@ -49,30 +48,29 @@ namespace mapviz_plugins
 {
   NavSatPlugin::NavSatPlugin() :
     config_widget_(new QWidget()),
-    color_(Qt::green),
     draw_style_(LINES)
   {
     ui_.setupUi(config_widget_);
+
+    ui_.color->setColor(Qt::green);
 
     // Set background white
     QPalette p(config_widget_->palette());
     p.setColor(QPalette::Background, Qt::white);
     config_widget_->setPalette(p);
 
-    // Initialize color selector color
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
-
     // Set status text red
     QPalette p3(ui_.status->palette());
     p3.setColor(QPalette::Text, Qt::red);
     ui_.status->setPalette(p3);
 
-    QObject::connect(ui_.selectcolor, SIGNAL(clicked()), this, SLOT(SelectColor()));
     QObject::connect(ui_.selecttopic, SIGNAL(clicked()), this, SLOT(SelectTopic()));
     QObject::connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
     QObject::connect(ui_.positiontolerance, SIGNAL(valueChanged(double)), this, SLOT(PositionToleranceChanged(double)));
     QObject::connect(ui_.buffersize, SIGNAL(valueChanged(int)), this, SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this, SLOT(SetDrawStyle(QString)));
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
+            this, SLOT(DrawIcon()));
   }
 
   NavSatPlugin::~NavSatPlugin()
@@ -89,7 +87,7 @@ namespace mapviz_plugins
       QPainter painter(&icon);
       painter.setRenderHint(QPainter::Antialiasing, true);
 
-      QPen pen(color_);
+      QPen pen(ui_.color->color());
 
       if (draw_style_ == POINTS)
       {
@@ -149,20 +147,6 @@ namespace mapviz_plugins
     {
       ui_.topic->setText(ui.displaylist->selectedItems().first()->text());
       TopicEdited();
-    }
-  }
-
-  void NavSatPlugin::SelectColor()
-  {
-    QColorDialog dialog(color_, config_widget_);
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted)
-    {
-      color_ = dialog.selectedColor();
-      ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
-      DrawIcon();
-      canvas_->update();
     }
   }
 
@@ -291,6 +275,9 @@ namespace mapviz_plugins
   {
     canvas_ = canvas;
 
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
+            canvas_, SLOT(update()));          
+
     DrawIcon();
 
     return true;
@@ -298,11 +285,11 @@ namespace mapviz_plugins
 
   void NavSatPlugin::Draw(double x, double y, double scale)
   {
-    glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 0.5);
-
+    QColor color = ui_.color->color();
+    
     bool transformed = false;
 
-    glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 1.0);
+    glColor4f(color.redF(), color.greenF(), color.blueF(), 1.0);
 
     if (draw_style_ == LINES)
     {
@@ -399,8 +386,7 @@ namespace mapviz_plugins
 
     std::string color;
     node["color"] >> color;
-    color_ = QColor(color.c_str());
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
+    ui_.color->setColor(QColor(color.c_str()));
 
     std::string draw_style;
     node["draw_style"] >> draw_style;
@@ -430,7 +416,7 @@ namespace mapviz_plugins
     std::string topic = ui_.topic->text().toStdString();
     emitter << YAML::Key << "topic" << YAML::Value << topic;
 
-    std::string color = color_.name().toStdString();
+    std::string color = ui_.color->color().name().toStdString();
     emitter << YAML::Key << "color" << YAML::Value << color;
 
     std::string draw_style = ui_.drawstyle->currentText().toStdString();

--- a/mapviz_plugins/src/odometry_config.ui
+++ b/mapviz_plugins/src/odometry_config.ui
@@ -146,7 +146,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QPushButton" name="selectcolor">
+    <widget class="mapviz::ColorButton" name="color">
      <property name="maximumSize">
       <size>
        <width>24</width>
@@ -253,6 +253,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mapviz::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">mapviz/color_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <slots>

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -34,7 +34,6 @@
 #include <vector>
 
 // QT libraries
-#include <QColorDialog>
 #include <QDialog>
 #include <QGLWidget>
 #include <QPainter>
@@ -60,30 +59,29 @@ namespace mapviz_plugins
 {
   OdometryPlugin::OdometryPlugin() :
     config_widget_(new QWidget()),
-    color_(Qt::green),
     draw_style_(LINES)
   {
     ui_.setupUi(config_widget_);
 
+    ui_.color->setColor(Qt::green);
+    
     // Set background white
     QPalette p(config_widget_->palette());
     p.setColor(QPalette::Background, Qt::white);
     config_widget_->setPalette(p);
-
-    // Initialize color selector color
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
 
     // Set status text red
     QPalette p3(ui_.status->palette());
     p3.setColor(QPalette::Text, Qt::red);
     ui_.status->setPalette(p3);
 
-    QObject::connect(ui_.selectcolor, SIGNAL(clicked()), this, SLOT(SelectColor()));
     QObject::connect(ui_.selecttopic, SIGNAL(clicked()), this, SLOT(SelectTopic()));
     QObject::connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
     QObject::connect(ui_.positiontolerance, SIGNAL(valueChanged(double)), this, SLOT(PositionToleranceChanged(double)));
     QObject::connect(ui_.buffersize, SIGNAL(valueChanged(int)), this, SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this, SLOT(SetDrawStyle(QString)));
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
+            this, SLOT(DrawIcon()));
   }
 
   OdometryPlugin::~OdometryPlugin()
@@ -100,7 +98,7 @@ namespace mapviz_plugins
       QPainter painter(&icon);
       painter.setRenderHint(QPainter::Antialiasing, true);
       
-      QPen pen(color_);
+      QPen pen(ui_.color->color());
       
       if (draw_style_ == POINTS)
       {
@@ -173,20 +171,6 @@ namespace mapviz_plugins
     {
       ui_.topic->setText(ui.displaylist->selectedItems().first()->text());
       TopicEdited();
-    }
-  }
-
-  void OdometryPlugin::SelectColor()
-  {
-    QColorDialog dialog(color_, config_widget_);
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted)
-    {
-      color_ = dialog.selectedColor();
-      ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
-      DrawIcon();
-      canvas_->update();
     }
   }
 
@@ -346,6 +330,9 @@ namespace mapviz_plugins
   bool OdometryPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
+
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
+            canvas_, SLOT(update()));          
     
     DrawIcon();
 
@@ -354,7 +341,9 @@ namespace mapviz_plugins
 
   void OdometryPlugin::Draw(double x, double y, double scale)
   {
-    glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 0.5);
+    QColor color = ui_.color->color();
+    
+    glColor4f(color.redF(), color.greenF(), color.blueF(), 0.5);
 
     bool transformed = false;
 
@@ -363,7 +352,7 @@ namespace mapviz_plugins
       DrawCovariance();
     }
 
-    glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 1.0);
+    glColor4f(color.redF(), color.greenF(), color.blueF(), 1.0);
 
     if (draw_style_ == ARROWS)
     {
@@ -544,8 +533,7 @@ namespace mapviz_plugins
 
     std::string color;
     node["color"] >> color;
-    color_ = QColor(color.c_str());
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
+    ui_.color->setColor(QColor(color.c_str()));
 
     std::string draw_style;
     node["draw_style"] >> draw_style;
@@ -587,7 +575,7 @@ namespace mapviz_plugins
     std::string topic = ui_.topic->text().toStdString();
     emitter << YAML::Key << "topic" << YAML::Value << topic;
 
-    std::string color = color_.name().toStdString();
+    std::string color = ui_.color->color().name().toStdString();
     emitter << YAML::Key << "color" << YAML::Value << color;
 
     std::string draw_style = ui_.drawstyle->currentText().toStdString();

--- a/mapviz_plugins/src/path_config.ui
+++ b/mapviz_plugins/src/path_config.ui
@@ -113,7 +113,7 @@
     </widget>
    </item>
    <item row="3" column="2">
-    <widget class="QPushButton" name="selectColor">
+    <widget class="mapviz::ColorButton" name="path_color">
      <property name="maximumSize">
       <size>
        <width>24</width>
@@ -127,6 +127,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mapviz::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">mapviz/color_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <slots>

--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -36,7 +36,6 @@
 // QT libraries
 #include <QDialog>
 #include <QGLWidget>
-#include <QColorDialog>
 
 // ROS libraries
 #include <ros/master.h>
@@ -50,10 +49,10 @@ namespace mapviz_plugins
   PathPlugin::PathPlugin() :
     config_widget_(new QWidget()),
     transformed_(false),
-    color_(Qt::green),
     line_width_(2)
   {
     ui_.setupUi(config_widget_);
+    ui_.path_color->setColor(Qt::green);
 
     // Set background white
     QPalette p(config_widget_->palette());
@@ -65,9 +64,10 @@ namespace mapviz_plugins
     p3.setColor(QPalette::Text, Qt::red);
     ui_.status->setPalette(p3);
 
-    QObject::connect(ui_.selectColor, SIGNAL(clicked()), this, SLOT(SelectColor()));
-    QObject::connect(ui_.selecttopic, SIGNAL(clicked()), this, SLOT(SelectTopic()));
-    QObject::connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
+    connect(ui_.selecttopic, SIGNAL(clicked()), this, SLOT(SelectTopic()));
+    connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
+    connect(ui_.path_color, SIGNAL(colorEdited(const QColor &)),
+            this, SLOT(DrawIcon()));
   }
 
   PathPlugin::~PathPlugin()
@@ -84,7 +84,7 @@ namespace mapviz_plugins
       QPainter painter(&icon);
       painter.setRenderHint(QPainter::Antialiasing, true);
 
-      QPen pen(QColor(color_.rgb()));
+      QPen pen(ui_.path_color->color());
 
       pen.setWidth(2);
       pen.setCapStyle(Qt::SquareCap);
@@ -101,23 +101,6 @@ namespace mapviz_plugins
       painter.drawPoint(13, 2);
 
       icon_->SetPixmap(icon);
-    }
-  }
-
-  void PathPlugin::SelectColor()
-  {
-    QColorDialog dialog(color_, config_widget_);
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted)
-    {
-      color_ = dialog.selectedColor();
-      ui_.selectColor->setStyleSheet("background: " + color_.name() + ";");
-
-      DrawIcon();
-
-      if (canvas_)
-      canvas_->update();
     }
   }
 
@@ -242,6 +225,8 @@ namespace mapviz_plugins
   bool PathPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
+    connect(ui_.path_color, SIGNAL(colorEdited(const QColor &)),
+            canvas_, SLOT(update()));          
 
     DrawIcon();
 
@@ -252,8 +237,10 @@ namespace mapviz_plugins
   {
     if (transformed_ && has_message_)
     {
+      QColor color = ui_.path_color->color();
+
       glLineWidth(line_width_);
-      glColor4f(color_.redF(), color_.greenF(), color_.blueF(), color_.alphaF());
+      glColor4f(color.redF(), color.greenF(), color.blueF(), color.alphaF());
       glBegin(GL_LINE_STRIP);
 
         std::list<tf::Point>::iterator transformed_it = transformed_points_.begin();
@@ -266,7 +253,7 @@ namespace mapviz_plugins
 
       glPointSize(line_width_*4);
 
-      QColor dark = color_.darker(200);
+      QColor dark = color.darker(200);
 
       glColor4f(dark.redF(), dark.greenF(), dark.blueF(), dark.alphaF());
       glBegin(GL_POINTS);
@@ -317,10 +304,8 @@ namespace mapviz_plugins
     {
       std::string color;
       node["color"] >> color;
-      color_ = QColor(color.c_str());
+      ui_.path_color->setColor(QColor(color.c_str()));
     }
-
-    ui_.selectColor->setStyleSheet("background: " + color_.name() + ";");
 
     TopicEdited();
   }
@@ -330,7 +315,7 @@ namespace mapviz_plugins
     std::string topic = ui_.topic->text().toStdString();
     emitter << YAML::Key << "topic" << YAML::Value << topic;
 
-    std::string color = color_.name().toStdString();
+    std::string color = ui_.path_color->color().name().toStdString();
     emitter << YAML::Key << "color" << YAML::Value << color;
   }
 }

--- a/mapviz_plugins/src/tf_frame_config.ui
+++ b/mapviz_plugins/src/tf_frame_config.ui
@@ -146,7 +146,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QPushButton" name="selectcolor">
+    <widget class="mapviz::ColorButton" name="color">
      <property name="maximumSize">
       <size>
        <width>24</width>
@@ -233,6 +233,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>mapviz::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">mapviz/color_button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <slots>

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -35,7 +35,6 @@
 #include <vector>
 
 // QT libraries
-#include <QColorDialog>
 #include <QDialog>
 #include <QGLWidget>
 #include <QPalette>
@@ -55,30 +54,29 @@ namespace mapviz_plugins
 {
   TfFramePlugin::TfFramePlugin() :
     config_widget_(new QWidget()),
-    color_(Qt::green),
     draw_style_(LINES)
   {
     ui_.setupUi(config_widget_);
 
+    ui_.color->setColor(Qt::green);
+    
     // Set background white
     QPalette p(config_widget_->palette());
     p.setColor(QPalette::Background, Qt::white);
     config_widget_->setPalette(p);
-
-    // Initialize color selector color
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
 
     // Set status text red
     QPalette p3(ui_.status->palette());
     p3.setColor(QPalette::Text, Qt::red);
     ui_.status->setPalette(p3);
 
-    QObject::connect(ui_.selectcolor, SIGNAL(clicked()), this, SLOT(SelectColor()));
     QObject::connect(ui_.selectframe, SIGNAL(clicked()), this, SLOT(SelectFrame()));
     QObject::connect(ui_.frame, SIGNAL(editingFinished()), this, SLOT(FrameEdited()));
     QObject::connect(ui_.positiontolerance, SIGNAL(valueChanged(double)), this, SLOT(PositionToleranceChanged(double)));
     QObject::connect(ui_.buffersize, SIGNAL(valueChanged(int)), this, SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this, SLOT(SetDrawStyle(QString)));
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
+            this, SLOT(DrawIcon()));
   }
 
   TfFramePlugin::~TfFramePlugin()
@@ -95,7 +93,7 @@ namespace mapviz_plugins
       QPainter painter(&icon);
       painter.setRenderHint(QPainter::Antialiasing, true);
       
-      QPen pen(color_);
+      QPen pen(ui_.color->color());
       
       if (draw_style_ == POINTS)
       {
@@ -179,21 +177,7 @@ namespace mapviz_plugins
     DrawIcon();
     canvas_->update();
   }
-  
-  void TfFramePlugin::SelectColor()
-  {
-    QColorDialog dialog(color_, config_widget_);
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted)
-    {
-      color_ = dialog.selectedColor();
-      ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
-      DrawIcon();
-      canvas_->update();
-    }
-  }
-  
+    
   void TfFramePlugin::PositionToleranceChanged(double value)
   {
     position_tolerance_ = value;
@@ -297,6 +281,9 @@ namespace mapviz_plugins
   {
     canvas_ = canvas;
 
+    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
+            canvas_, SLOT(update()));          
+
     timer_ = node_.createTimer(ros::Duration(0.1), &TfFramePlugin::TimerCallback, this);
 
     DrawIcon();
@@ -306,11 +293,11 @@ namespace mapviz_plugins
 
   void TfFramePlugin::Draw(double x, double y, double scale)
   {
-    glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 0.5);
-
+    QColor color = ui_.color->color();
+    
     bool transformed = false;
 
-    glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 1.0);
+    glColor4f(color.redF(), color.greenF(), color.blueF(), 1.0);
 
     if (draw_style_ == ARROWS)
     {
@@ -459,8 +446,7 @@ namespace mapviz_plugins
 
     std::string color;
     node["color"] >> color;
-    color_ = QColor(color.c_str());
-    ui_.selectcolor->setStyleSheet("background: " + color_.name() + ";");
+    ui_.color->setColor(QColor(color.c_str()));
 
     std::string draw_style;
     node["draw_style"] >> draw_style;
@@ -487,10 +473,8 @@ namespace mapviz_plugins
 
   void TfFramePlugin::SaveConfig(YAML::Emitter& emitter, const std::string& path)
   {
-    emitter << YAML::Key << "frame" << YAML::Value << ui_.frame->text().toStdString();
-    
-    std::string color = color_.name().toStdString();
-    emitter << YAML::Key << "color" << YAML::Value << color;
+    emitter << YAML::Key << "frame" << YAML::Value << ui_.frame->text().toStdString();    
+    emitter << YAML::Key << "color" << YAML::Value << ui_.color->color().name().toStdString();
 
     std::string draw_style = ui_.drawstyle->currentText().toStdString();
     emitter << YAML::Key << "draw_style" << YAML::Value << draw_style;


### PR DESCRIPTION
This commit adds a subclass of QPushButton called ColorButton that
implements a widget for displaying and selecting colors.  We've been
doing this manually everywhere with duplicated code.  This is a simple
abstraction but allows us to elminate a lot of duplication, especially
in plugins that have multiple color selections.