### PR TITLE
Add select frame dialog

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -56,7 +56,8 @@ file (GLOB UI_FILES
   src/configitem.ui
   src/mapviz.ui
   src/pluginselect.ui
-  src/rqt_mapviz.ui)
+  src/rqt_mapviz.ui
+)
 file (GLOB HEADER_FILES
   include/mapviz/color_button.h
   include/mapviz/config_item.h
@@ -64,14 +65,17 @@ file (GLOB HEADER_FILES
   include/mapviz/mapviz.h
   include/mapviz/mapviz_plugin.h
   include/mapviz/rqt_mapviz.h
+  include/mapviz/select_frame_dialog.h
   include/mapviz/select_topic_dialog.h
-  include/mapviz/widgets.h)
+  include/mapviz/widgets.h
+)
 file (GLOB SRC_FILES
   src/mapviz.cpp
   src/color_button.cpp
   src/config_item.cpp
   src/map_canvas.cpp
   src/rqt_mapviz.cpp
+  src/select_frame_dialog.cpp
   src/select_topic_dialog.cpp
 )
 QT4_ADD_RESOURCES(RCC_SRCS src/resources/icons.qrc)

--- a/mapviz/include/mapviz/select_frame_dialog.h
+++ b/mapviz/include/mapviz/select_frame_dialog.h
@@ -1,0 +1,129 @@
+// *****************************************************************************
+//
+// Copyright (c) 2014, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#ifndef MAPVIZ_SELECT_FRAME_DIALOG_H_
+#define MAPVIZ_SELECT_FRAME_DIALOG_H_
+
+#include <string>
+#include <vector>
+
+#include <boost/shared_ptr.hpp>
+
+#include <QDialog>
+
+QT_BEGIN_NAMESPACE
+class QLineEdit;
+class QListWidget;
+class QPushButton;
+QT_END_NAMESPACE
+
+namespace tf {
+class TransformListener;
+}  // namespace tf
+
+namespace mapviz
+{
+/**
+ * Provides a dialog for the user to select one or more TF frames.
+ * Several static functions are provided that can be used instead of
+ * instantiating the class directly.
+ */
+class SelectFrameDialog : public QDialog
+{
+  Q_OBJECT;
+
+ public:
+  /**
+   * Present the user with a dialog to select a single frame.
+   *
+   * If the user cancels the selection or doesn't make a valid
+   * selection, the returned string be empty.
+   */
+  static std::string selectFrame(
+    boost::shared_ptr<tf::TransformListener> tf_listener,
+    QWidget *parent=0);
+
+  /**
+   * Present the user with a dialog to select a multiple TF frames.
+   *
+   * If the user cancels the selection or doesn't make a valid
+   * selection, the returned vector will be empty.
+   */
+  static std::vector<std::string> selectFrames(
+    boost::shared_ptr<tf::TransformListener> tf_listener,
+    QWidget *parent=0);
+
+  /**
+   * Constructor for the SelectFrameDialog.
+   */
+  SelectFrameDialog(boost::shared_ptr<tf::TransformListener> tf_listener,
+                    QWidget *parent=0);
+  
+  /**
+   * Choose whether the user can select one (allow=false) or multiple
+   * (allow=true) frames.  The default is false.
+   */
+  void allowMultipleFrames(bool allow);
+
+  /**
+   * Returns the currently selected frame.  If multiple frames are
+   * allowed, this will only return the first selected element.  If
+   * there is no selection, the returned info will have an empty frame
+   * name and datatype.
+   */
+  std::string selectedFrame() const;
+  /**
+   * Returns the currently selected frames.  If there is no selection,
+   * the returned vector will be empty.
+   */
+  std::vector<std::string> selectedFrames() const;
+
+ private:
+  void timerEvent(QTimerEvent *);
+  void closeEvent(QCloseEvent *);
+
+  std::vector<std::string> filterFrames(
+    const std::vector<std::string> &) const;
+
+ private Q_SLOTS:
+  void fetchFrames();
+  void updateDisplayedFrames();
+
+ private:
+  boost::shared_ptr<tf::TransformListener> tf_;
+  std::vector<std::string> known_frames_;
+  std::vector<std::string> displayed_frames_;
+  int fetch_frames_timer_id_;
+
+  QPushButton *ok_button_;
+  QPushButton *cancel_button_;
+  QListWidget *list_widget_;
+  QLineEdit *name_filter_;
+};  // class SelectFrameDialog
+}  // namespace mapviz
+#endif  // MAPVIZ_SELECT_FRAME_DIALOG_H_

--- a/mapviz/src/select_frame_dialog.cpp
+++ b/mapviz/src/select_frame_dialog.cpp
@@ -1,0 +1,251 @@
+// *****************************************************************************
+//
+// Copyright (c) 2014, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#include <mapviz/select_frame_dialog.h>
+
+#include <algorithm>
+#include <set>
+
+#include <QListWidget>
+#include <QLineEdit>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QTimerEvent>
+
+#include <tf/transform_listener.h>
+
+namespace mapviz
+{
+std::string SelectFrameDialog::selectFrame(
+  boost::shared_ptr<tf::TransformListener> tf_listener,
+  QWidget *parent)
+{
+  SelectFrameDialog dialog(tf_listener, parent);
+  dialog.allowMultipleFrames(false);
+  if (dialog.exec() == QDialog::Accepted) {
+    return dialog.selectedFrame();
+  } else {
+    return "";
+  }
+}
+
+std::vector<std::string> SelectFrameDialog::selectFrames(
+  boost::shared_ptr<tf::TransformListener> tf_listener,
+  QWidget *parent)
+{
+  SelectFrameDialog dialog(tf_listener, parent);
+  dialog.allowMultipleFrames(true);
+  if (dialog.exec() == QDialog::Accepted) {
+    return dialog.selectedFrames();
+  } else {
+    return std::vector<std::string>();
+  }
+}
+
+SelectFrameDialog::SelectFrameDialog(
+  boost::shared_ptr<tf::TransformListener> tf_listener,
+  QWidget *parent)
+  :
+  tf_(tf_listener),
+  ok_button_(new QPushButton("&Ok")),
+  cancel_button_(new QPushButton("&Cancel")),
+  list_widget_(new QListWidget()),
+  name_filter_(new QLineEdit())
+{
+  QHBoxLayout *filter_box = new QHBoxLayout();
+  filter_box->addWidget(new QLabel("Filter:"));
+  filter_box->addWidget(name_filter_);
+
+  QHBoxLayout *button_box = new QHBoxLayout();
+  button_box->addStretch(1);
+  button_box->addWidget(cancel_button_);
+  button_box->addWidget(ok_button_);
+
+  QVBoxLayout *vbox = new QVBoxLayout();
+  vbox->addWidget(list_widget_);
+  vbox->addLayout(filter_box);
+  vbox->addLayout(button_box);
+  setLayout(vbox);
+
+  connect(ok_button_, SIGNAL(clicked(bool)),
+          this, SLOT(accept()));
+  connect(cancel_button_, SIGNAL(clicked(bool)),
+          this, SLOT(reject()));
+  connect(name_filter_, SIGNAL(textChanged(const QString &)),
+          this, SLOT(updateDisplayedFrames()));
+
+  ok_button_->setDefault(true);
+  
+  allowMultipleFrames(false);
+  setWindowTitle("Select frames...");
+
+  resize(600, 600);
+  
+  fetch_frames_timer_id_ = startTimer(1000);
+  fetchFrames();
+}
+
+void SelectFrameDialog::timerEvent(QTimerEvent *event)
+{  
+  if (event->timerId() == fetch_frames_timer_id_) {
+    fetchFrames();
+  }
+}
+
+void SelectFrameDialog::closeEvent(QCloseEvent *event)
+{
+  // We don't need to keep making requests from the ROS master.
+  killTimer(fetch_frames_timer_id_);
+  QDialog::closeEvent(event);
+}
+
+void SelectFrameDialog::allowMultipleFrames(
+  bool allow)
+{
+  if (allow) {
+    list_widget_->setSelectionMode(QAbstractItemView::MultiSelection);
+  } else {
+    list_widget_->setSelectionMode(QAbstractItemView::SingleSelection);
+  }
+}
+
+std::string SelectFrameDialog::selectedFrame() const
+{
+  std::vector<std::string> selection = selectedFrames();
+  if (selection.empty()) {
+    return "";
+  } else {
+    return selection.front();
+  }
+}
+
+std::vector<std::string> SelectFrameDialog::selectedFrames() const
+{
+  QModelIndexList qt_selection = list_widget_->selectionModel()->selectedIndexes();
+
+  std::vector<std::string> selection;
+  selection.resize(qt_selection.size());
+  for (int i = 0; i < qt_selection.size(); i++) {
+    if (!qt_selection[i].isValid()) {
+      continue;
+    }
+    
+    int row = qt_selection[i].row();
+    if (row < 0 || static_cast<size_t>(row) >= displayed_frames_.size()) {
+      continue;
+    }
+    
+    selection[i] = displayed_frames_[row];
+  }
+
+  return selection;
+}
+
+void SelectFrameDialog::fetchFrames()
+{
+  if (!tf_) { return; }
+  
+  known_frames_.clear();
+  tf_->getFrameStrings(known_frames_);
+  std::sort(known_frames_.begin(), known_frames_.end());
+  updateDisplayedFrames();
+}
+
+std::vector<std::string> SelectFrameDialog::filterFrames(
+  const std::vector<std::string> &frames) const
+{
+  QString frame_filter = name_filter_->text();
+  std::vector<std::string> filtered;
+
+  for (size_t i = 0; i < frames.size(); i++) {
+    QString frame_name = QString::fromStdString(frames[i]);
+    if (!frame_filter.isEmpty() &&
+        !frame_name.contains(frame_filter, Qt::CaseInsensitive)) {
+      continue;
+    }
+
+    filtered.push_back(frames[i]);
+  }
+  
+  return filtered;  
+}
+
+void SelectFrameDialog::updateDisplayedFrames()
+{
+  std::vector<std::string> next_displayed_frames = filterFrames(known_frames_);
+  
+  // It's a lot more work to keep track of the additions/removals like
+  // this compared to resetting the QListWidget's items each time, but
+  // it allows Qt to properly track the selection and current items
+  // across updates, which results in much less frustration for the user.
+  
+  std::set<std::string> prev_names;
+  prev_names.insert(displayed_frames_.begin(), displayed_frames_.end());
+  
+  std::set<std::string> next_names;
+  next_names.insert(next_displayed_frames.begin(), next_displayed_frames.end());
+
+  std::set<std::string> added_names;
+  std::set_difference(next_names.begin(), next_names.end(),
+                      prev_names.begin(), prev_names.end(),
+                      std::inserter(added_names, added_names.end()));
+
+  std::set<std::string> removed_names;
+  std::set_difference(prev_names.begin(), prev_names.end(),
+                      next_names.begin(), next_names.end(),
+                      std::inserter(removed_names, removed_names.end()));
+
+  // Remove all the removed names
+  size_t removed = 0;
+  for (size_t i = 0; i < displayed_frames_.size(); i++) {
+    if (removed_names.count(displayed_frames_[i]) == 0) {
+      continue;
+    }
+
+    QListWidgetItem *item = list_widget_->takeItem(i - removed);
+    delete item;
+    removed++;
+  }
+
+  // Now we can add the new items.
+  for (size_t i = 0; i < next_displayed_frames.size(); i++) {
+    if (added_names.count(next_displayed_frames[i]) == 0) {
+      continue;
+    }
+
+    list_widget_->insertItem(i, QString::fromStdString(next_displayed_frames[i]));
+    if (list_widget_->count() == 1) {
+      list_widget_->setCurrentRow(0);
+    }
+  }
+
+  displayed_frames_.swap(next_displayed_frames);  
+}
+}  // namespace mapviz

--- a/mapviz_plugins/include/mapviz_plugins/grid_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/grid_plugin.h
@@ -79,20 +79,19 @@ namespace mapviz_plugins
     void PrintWarning(const std::string& message);
 
   protected Q_SLOTS:
+    void SelectFrame();
+    void FrameEdited();
     void SetAlpha(double alpha);
     void SetX(double x);
     void SetY(double y);
     void SetSize(double size);
     void SetRows(int rows);
     void SetColumns(int columns);
-    void SetFrame(QString frame);
-    void UpdateFrames();
     void DrawIcon();
 
   private:
     Ui::grid_config ui_;
     QWidget* config_widget_;
-    QTimer frame_timer_;
 
     double alpha_;
 

--- a/mapviz_plugins/src/grid_config.ui
+++ b/mapviz_plugins/src/grid_config.ui
@@ -16,7 +16,7 @@
   <property name="styleSheet">
    <string notr="true"/>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
    <property name="verticalSpacing">
     <number>4</number>
    </property>
@@ -94,31 +94,6 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QDoubleSpinBox" name="y">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="buttonSymbols">
-      <enum>QAbstractSpinBox::UpDownArrows</enum>
-     </property>
-     <property name="suffix">
-      <string/>
-     </property>
-     <property name="minimum">
-      <double>-999999999.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>999999999.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>0.000000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="7" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
@@ -164,7 +139,83 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Rows:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Columns:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Alpha:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="select_frame">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Select</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="frame">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QDoubleSpinBox" name="alpha">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="maximum">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.010000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="2">
     <widget class="QDoubleSpinBox" name="x">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -189,7 +240,32 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="6" column="1" colspan="2">
+    <widget class="QDoubleSpinBox" name="y">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::UpDownArrows</enum>
+     </property>
+     <property name="suffix">
+      <string/>
+     </property>
+     <property name="minimum">
+      <double>-999999999.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>999999999.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="2">
     <widget class="QDoubleSpinBox" name="size">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::UpDownArrows</enum>
@@ -202,20 +278,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Rows:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
+   <item row="8" column="1" colspan="2">
     <widget class="QSpinBox" name="rows">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
@@ -228,20 +291,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Columns:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
+   <item row="9" column="1" colspan="2">
     <widget class="QSpinBox" name="columns">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
@@ -254,60 +304,6 @@
      </property>
      <property name="value">
       <number>1</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>25</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>9</pointsize>
-      </font>
-     </property>
-     <property name="editable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Alpha:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QDoubleSpinBox" name="alpha">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="maximum">
-      <double>1.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.010000000000000</double>
-     </property>
-     <property name="value">
-      <double>1.000000000000000</double>
      </property>
     </widget>
    </item>

--- a/mapviz_plugins/src/robot_image_plugin.cpp
+++ b/mapviz_plugins/src/robot_image_plugin.cpp
@@ -35,7 +35,6 @@
 #include <vector>
 
 // QT libraries
-#include <QDialog>
 #include <QGLWidget>
 #include <QPalette>
 #include <QImage>
@@ -43,6 +42,8 @@
 
 // ROS libraries
 #include <ros/master.h>
+
+#include <mapviz/select_frame_dialog.h>
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
@@ -104,24 +105,10 @@ namespace mapviz_plugins
 
   void RobotImagePlugin::SelectFrame()
   {
-    QDialog dialog;
-    Ui::topicselect ui;
-    ui.setupUi(&dialog);
-
-    std::vector<std::string> frames;
-    tf_->getFrameStrings(frames);
-
-    for (unsigned int i = 0; i < frames.size(); i++)
+    std::string frame = mapviz::SelectFrameDialog::selectFrame(tf_);
+    if (!frame.empty())
     {
-      ui.displaylist->addItem(frames[i].c_str());
-    }
-    ui.displaylist->setCurrentRow(0);
-
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted && ui.displaylist->selectedItems().count() == 1)
-    {
-      ui_.frame->setText(ui.displaylist->selectedItems().first()->text());
+      ui_.frame->setText(QString::fromStdString(frame));
       FrameEdited();
     }
   }

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -35,12 +35,13 @@
 #include <vector>
 
 // QT libraries
-#include <QDialog>
 #include <QGLWidget>
 #include <QPalette>
 
 // ROS libraries
 #include <ros/master.h>
+
+#include <mapviz/select_frame_dialog.h>
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
@@ -125,24 +126,10 @@ namespace mapviz_plugins
 
   void TfFramePlugin::SelectFrame()
   {
-    QDialog dialog;
-    Ui::topicselect ui;
-    ui.setupUi(&dialog);
-
-    std::vector<std::string> frames;
-    tf_->getFrameStrings(frames);
-
-    for (unsigned int i = 0; i < frames.size(); i++)
+    std::string frame = mapviz::SelectFrameDialog::selectFrame(tf_);
+    if (!frame.empty())
     {
-      ui.displaylist->addItem(frames[i].c_str());
-    }
-    ui.displaylist->setCurrentRow(0);
-
-    dialog.exec();
-
-    if (dialog.result() == QDialog::Accepted && ui.displaylist->selectedItems().count() == 1)
-    {
-      ui_.frame->setText(ui.displaylist->selectedItems().first()->text());
+      ui_.frame->setText(QString::fromStdString(frame));
       FrameEdited();
     }
   }


### PR DESCRIPTION
This commit adds a class called SelectFrameDialog that plugins can use
to present the user with a dialog to choose a TF frame. The dialog
sorts the frames by name and provides an edit box that the user can
use to filter the frames to a specific substring.