### PR TITLE
Update map canvas at a fixed rate.

### DIFF
--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -46,6 +46,7 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 #include <QColor>
+#include <QTimer>
 
 // ROS libraries
 #include <ros/ros.h>
@@ -76,6 +77,8 @@ namespace mapviz
     void UpdateView();
     void ReorderDisplays();
     QPointF MapGlCoordToFixedFrame(const QPointF& point);
+
+    double frameRate() const;
 
     float ViewScale() const { return view_scale_; }
     float OffsetX() const { return offset_x_; }
@@ -130,6 +133,9 @@ namespace mapviz
   Q_SIGNALS:
     void Hover(double x, double y, double scale);
 
+  public Q_SLOTS:
+    void setFrameRate(const double fps);
+
   protected:
     void initializeGL();
     void resizeGL(int w, int h);
@@ -154,6 +160,8 @@ namespace mapviz
     bool initialized_;
     bool fix_orientation_;
     bool rotate_90_;
+
+    QTimer frame_rate_timer_;
 
     QColor bg_color_;
 

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -75,6 +75,10 @@ MapCanvas::MapCanvas(QWidget* parent) :
   setMouseTracking(true);
   
   transform_.setIdentity();
+
+  QObject::connect(&frame_rate_timer_, SIGNAL(timeout()), this, SLOT(update()));
+  setFrameRate(50.0);
+  frame_rate_timer_.start();
 }
 
 MapCanvas::~MapCanvas()
@@ -444,4 +448,19 @@ void MapCanvas::Recenter()
   view_right_ = (width() * view_scale_ * 0.5);
   view_bottom_ = (height() * view_scale_ * 0.5);
 }
+
+void MapCanvas::setFrameRate(const double fps)
+{
+  if (fps <= 0.0) {
+    ROS_ERROR("Invalid frame rate: %f", fps);
+    return;
+  }
+
+  frame_rate_timer_.setInterval(1000.0/fps);    
 }
+
+double MapCanvas::frameRate() const
+{
+  return 1000.0 / frame_rate_timer_.interval();
+}
+}  // namespace mapviz

--- a/mapviz_plugins/src/disparity_plugin.cpp
+++ b/mapviz_plugins/src/disparity_plugin.cpp
@@ -98,27 +98,21 @@ namespace mapviz_plugins
   void DisparityPlugin::SetOffsetX(int offset)
   {
     offset_x_ = offset;
-    canvas_->update();
   }
 
   void DisparityPlugin::SetOffsetY(int offset)
   {
     offset_y_ = offset;
-    canvas_->update();
   }
 
   void DisparityPlugin::SetWidth(int width)
   {
     width_ = width;
-
-    canvas_->update();
   }
 
   void DisparityPlugin::SetHeight(int height)
   {
     height_ = height;
-
-    canvas_->update();
   }
 
   void DisparityPlugin::SetAnchor(QString anchor)
@@ -159,8 +153,6 @@ namespace mapviz_plugins
     {
       anchor_ = BOTTOM_RIGHT;
     }
-
-    canvas_->update();
   }
 
   void DisparityPlugin::SetUnits(QString units)
@@ -173,8 +165,6 @@ namespace mapviz_plugins
     {
       units_ = PERCENT;
     }
-
-    canvas_->update();
   }
 
   void DisparityPlugin::SelectTopic()
@@ -257,8 +247,6 @@ namespace mapviz_plugins
     last_height_ = 0;
 
     has_image_ = true;
-
-    canvas_->update();
   }
 
   void DisparityPlugin::PrintError(const std::string& message)

--- a/mapviz_plugins/src/gps_plugin.cpp
+++ b/mapviz_plugins/src/gps_plugin.cpp
@@ -135,7 +135,6 @@ namespace mapviz_plugins
     }
 
     DrawIcon();
-    canvas_->update();
   }
 
   void GpsPlugin::SelectTopic()
@@ -207,8 +206,6 @@ namespace mapviz_plugins
     }
 
     cur_point_ = stamped_point;
-
-    canvas_->update();
   }
 
   void GpsPlugin::PositionToleranceChanged(double value)
@@ -227,8 +224,6 @@ namespace mapviz_plugins
         points_.pop_front();
       }
     }
-
-    canvas_->update();
   }
 
   void GpsPlugin::PrintError(const std::string& message)
@@ -277,9 +272,6 @@ namespace mapviz_plugins
   bool GpsPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
-    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
-            canvas_, SLOT(update()));          
-
     DrawIcon();
 
     return true;

--- a/mapviz_plugins/src/grid_plugin.cpp
+++ b/mapviz_plugins/src/grid_plugin.cpp
@@ -122,8 +122,6 @@ namespace mapviz_plugins
   void GridPlugin::SetAlpha(double alpha)
   {
     alpha_ = alpha;
-    if (canvas_)
-      canvas_->update();
   }
 
   void GridPlugin::SetX(double x)
@@ -178,11 +176,6 @@ namespace mapviz_plugins
     initialized_ = true;
 
     RecalculateGrid();
-
-    if (canvas_)
-    {
-      canvas_->update();
-    }
   }
 
   void GridPlugin::PrintError(const std::string& message)
@@ -310,9 +303,6 @@ namespace mapviz_plugins
       right_points_.push_back(right_point);
       transformed_right_points_.push_back(transform_ * right_point);
     }
-
-    if (canvas_)
-    canvas_->update();
   }
 
   void GridPlugin::Transform()
@@ -371,9 +361,6 @@ namespace mapviz_plugins
 
     node["columns"] >> columns_;
     ui_.columns->setValue(columns_);
-
-    if (canvas_)
-      canvas_->update();
   }
 
   void GridPlugin::SaveConfig(YAML::Emitter& emitter, const std::string& path)

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -95,27 +95,21 @@ namespace mapviz_plugins
   void ImagePlugin::SetOffsetX(int offset)
   {
     offset_x_ = offset;
-    canvas_->update();
   }
 
   void ImagePlugin::SetOffsetY(int offset)
   {
     offset_y_ = offset;
-    canvas_->update();
   }
 
   void ImagePlugin::SetWidth(int width)
   {
     width_ = width;
-
-    canvas_->update();
   }
 
   void ImagePlugin::SetHeight(int height)
   {
     height_ = height;
-
-    canvas_->update();
   }
 
   void ImagePlugin::SetAnchor(QString anchor)
@@ -156,8 +150,6 @@ namespace mapviz_plugins
     {
       anchor_ = BOTTOM_RIGHT;
     }
-
-    canvas_->update();
   }
 
   void ImagePlugin::SetUnits(QString units)
@@ -170,8 +162,6 @@ namespace mapviz_plugins
     {
       units_ = PERCENT;
     }
-
-    canvas_->update();
   }
 
   void ImagePlugin::SelectTopic()
@@ -225,8 +215,6 @@ namespace mapviz_plugins
     last_height_ = 0;
 
     has_image_ = true;
-
-    canvas_->update();
   }
 
   void ImagePlugin::PrintError(const std::string& message)

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -255,7 +255,6 @@ namespace mapviz_plugins
         point_it->color = CalculateColor(*point_it, scan_it->has_intensity);
       }
     }
-    canvas_->update();
   }
 
   void LaserScanPlugin::SelectTopic()
@@ -313,15 +312,11 @@ namespace mapviz_plugins
         scans_.pop_front();
       }
     }
-
-    canvas_->update();
   }
 
   void LaserScanPlugin::PointSizeChanged(int value)
   {
     point_size_ = value;
-
-    canvas_->update();
   }
 
   void LaserScanPlugin::laserScanCallback(const sensor_msgs::LaserScanConstPtr& msg)
@@ -380,8 +375,6 @@ namespace mapviz_plugins
         scans_.pop_front();
       }
     }
-
-    canvas_->update();
   }
 
   void LaserScanPlugin::PrintError(const std::string& message)

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -247,8 +247,6 @@ namespace mapviz_plugins
     {
       markers_[marker.ns].erase(marker.id);
     }
-
-    canvas_->update();
   }
 
   void MarkerPlugin::handleMarkerArray(const visualization_msgs::MarkerArray &markers)

--- a/mapviz_plugins/src/multires_image_plugin.cpp
+++ b/mapviz_plugins/src/multires_image_plugin.cpp
@@ -145,8 +145,6 @@ namespace mapviz_plugins
 
         MultiresView* view = new MultiresView(tile_set_, canvas_);
         tile_view_ = view;
-
-        canvas_->update();
       }
       else
       {

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -122,7 +122,6 @@ namespace mapviz_plugins
     }
 
     DrawIcon();
-    canvas_->update();
   }
 
   void NavSatPlugin::SelectTopic()
@@ -190,8 +189,6 @@ namespace mapviz_plugins
     }
 
     cur_point_ = stamped_point;
-
-    canvas_->update();
   }
 
   void NavSatPlugin::PositionToleranceChanged(double value)
@@ -210,8 +207,6 @@ namespace mapviz_plugins
         points_.pop_front();
       }
     }
-
-    canvas_->update();
   }
 
   void NavSatPlugin::PrintError(const std::string& message)
@@ -260,12 +255,7 @@ namespace mapviz_plugins
   bool NavSatPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
-
-    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
-            canvas_, SLOT(update()));          
-
     DrawIcon();
-
     return true;
   }
 

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -145,7 +145,6 @@ namespace mapviz_plugins
     }
 
     DrawIcon();
-    canvas_->update();
   }
 
   void OdometryPlugin::SelectTopic()
@@ -246,8 +245,6 @@ namespace mapviz_plugins
         }
       }
     }
-
-    canvas_->update();
   }
 
   void OdometryPlugin::PositionToleranceChanged(double value)
@@ -266,8 +263,6 @@ namespace mapviz_plugins
         points_.pop_front();
       }
     }
-
-    canvas_->update();
   }
 
   void OdometryPlugin::PrintError(const std::string& message)
@@ -316,9 +311,6 @@ namespace mapviz_plugins
   bool OdometryPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
-
-    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
-            canvas_, SLOT(update()));          
     
     DrawIcon();
 

--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -161,8 +161,6 @@ namespace mapviz_plugins
       points_.push_back(point);
       transformed_points_.push_back(point);
     }
-
-    canvas_->update();
   }
 
   void PathPlugin::PrintError(const std::string& message)
@@ -211,11 +209,7 @@ namespace mapviz_plugins
   bool PathPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
-    connect(ui_.path_color, SIGNAL(colorEdited(const QColor &)),
-            canvas_, SLOT(update()));          
-
     DrawIcon();
-
     return true;
   }
 

--- a/mapviz_plugins/src/robot_image_plugin.cpp
+++ b/mapviz_plugins/src/robot_image_plugin.cpp
@@ -123,8 +123,6 @@ namespace mapviz_plugins
     initialized_ = true;
 
     UpdateShape();
-
-    canvas_->update();
   }
 
   void RobotImagePlugin::WidthChanged(double value)
@@ -132,8 +130,6 @@ namespace mapviz_plugins
     width_ = value;
 
     UpdateShape();
-
-    canvas_->update();
   }
 
   void RobotImagePlugin::HeightChanged(double value)
@@ -141,8 +137,6 @@ namespace mapviz_plugins
     height_ = value;
 
     UpdateShape();
-
-    canvas_->update();
   }
 
   void RobotImagePlugin::UpdateShape()

--- a/mapviz_plugins/src/textured_marker_plugin.cpp
+++ b/mapviz_plugins/src/textured_marker_plugin.cpp
@@ -317,8 +317,6 @@ namespace mapviz_plugins
     {
       markers_[marker.ns].erase(marker.id);
     }
-
-    canvas_->update();
   }
 
   void TexturedMarkerPlugin::MarkerCallback(const marti_visualization_msgs::TexturedMarkerConstPtr marker)

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -142,8 +142,6 @@ namespace mapviz_plugins
     ROS_INFO("Setting target frame to to %s", source_frame_.c_str());
 
     initialized_ = true;
-
-    canvas_->update();
   }
   
   void TfFramePlugin::SetDrawStyle(QString style)
@@ -162,7 +160,6 @@ namespace mapviz_plugins
     }
 
     DrawIcon();
-    canvas_->update();
   }
     
   void TfFramePlugin::PositionToleranceChanged(double value)
@@ -181,8 +178,6 @@ namespace mapviz_plugins
         points_.pop_front();
       }
     }
-
-    canvas_->update();
   }
   
   void TfFramePlugin::TimerCallback(const ros::TimerEvent& event)
@@ -215,9 +210,6 @@ namespace mapviz_plugins
       }
     
       cur_point_ = stamped_point;
-      
-      if (canvas_)
-        canvas_->update();
     }
   }
 
@@ -267,9 +259,6 @@ namespace mapviz_plugins
   bool TfFramePlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
-
-    connect(ui_.color, SIGNAL(colorEdited(const QColor &)),
-            canvas_, SLOT(update()));          
 
     timer_ = node_.createTimer(ros::Duration(0.1), &TfFramePlugin::TimerCallback, this);
 


### PR DESCRIPTION
Addresses Issue #268.

This update adds a timer to the map canvas to repaint at a fixed rate.
The default rate is 50 Hz, but there is a method to change it (not
exposed to the UI at the moment).  50Hz was chosen because it is fast
enough to give smooth animations and we almost always are running
mapviz with at least one plugin triggering updates from a 50Hz topic.

This should be a safe merge because the update() method is still exposed, so existing plugins won't break.  But I think it would be good to have a few other people use it for a day or two before it gets merged in just in case.
