### PR TITLE
Making the Image plugin use image_transport

### DIFF
--- a/mapviz_plugins/CMakeLists.txt
+++ b/mapviz_plugins/CMakeLists.txt
@@ -1,24 +1,28 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mapviz_plugins)
 
-find_package(catkin REQUIRED COMPONENTS 
-  roscpp 
-  pluginlib 
-  tf 
-  std_msgs 
-  nav_msgs
-  sensor_msgs
-  stereo_msgs
-  visualization_msgs
-  gps_common
-  marti_visualization_msgs
-  mapviz
-  multires_image
+set(DEPENDENCIES
   cv_bridge
-  swri_transform_util
-  swri_math_util
+  gps_common
+  image_transport
+  mapviz
+  marti_visualization_msgs
+  multires_image
+  nav_msgs
+  pluginlib 
+  roscpp 
+  sensor_msgs
+  std_msgs 
+  stereo_msgs
   swri_image_util
-  swri_yaml_util)
+  swri_math_util
+  swri_transform_util
+  swri_yaml_util
+  tf 
+  visualization_msgs
+)
+
+find_package(catkin REQUIRED COMPONENTS ${DEPENDENCIES})
 
 find_package(Qt4 COMPONENTS QtCore QtGui QtOpenGL REQUIRED)
 set(QT_USE_QTOPENGL TRUE)
@@ -30,24 +34,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   DEPENDS Qt4
-  CATKIN_DEPENDS 
-    roscpp 
-    pluginlib 
-    tf 
-    std_msgs 
-    nav_msgs
-    sensor_msgs
-    stereo_msgs
-    visualization_msgs
-    gps_common
-    marti_visualization_msgs
-    mapviz
-    multires_image
-    cv_bridge
-    swri_transform_util
-    swri_math_util
-    swri_image_util
-    swri_yaml_util
+  CATKIN_DEPENDS ${DEPENDENCIES}
 )
 
 # Fix conflict between Boost signals used by tf and QT signals used by mapviz

--- a/mapviz_plugins/include/mapviz_plugins/image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/image_plugin.h
@@ -48,6 +48,7 @@
 #include <sensor_msgs/Image.h>
 #include <opencv/highgui.h>
 #include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.h>
 
 #include <mapviz/map_canvas.h>
 
@@ -121,7 +122,7 @@ namespace mapviz_plugins
     int last_width_;
     int last_height_;
 
-    ros::Subscriber image_sub_;
+    image_transport::Subscriber image_sub_;
     bool has_message_;
 
     sensor_msgs::Image image_;
@@ -129,7 +130,7 @@ namespace mapviz_plugins
     cv_bridge::CvImagePtr cv_image_;
     cv::Mat scaled_image_;
 
-    void imageCallback(const sensor_msgs::ImageConstPtr image);
+    void imageCallback(const sensor_msgs::ImageConstPtr& image);
 
     void ScaleImage(int width, int height);
     void DrawIplImage(cv::Mat *image);

--- a/mapviz_plugins/package.xml
+++ b/mapviz_plugins/package.xml
@@ -19,6 +19,7 @@
   <build_depend>libqt4-opengl-dev</build_depend>
   <depend>cv_bridge</depend>
   <depend>gps_common</depend>
+  <depend>image_transport</depend>
   <depend>mapviz</depend>
   <depend>marti_visualization_msgs</depend>
   <depend>multires_image</depend>

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -195,13 +195,14 @@ namespace mapviz_plugins
       PrintWarning("No messages received.");
 
       image_sub_.shutdown();
-      image_sub_ = node_.subscribe(topic_, 1, &ImagePlugin::imageCallback, this);
+      image_transport::ImageTransport it(node_);
+      image_sub_ = it.subscribe(topic_, 1, &ImagePlugin::imageCallback, this);
 
       ROS_INFO("Subscribing to %s", topic_.c_str());
     }
   }
 
-  void ImagePlugin::imageCallback(const sensor_msgs::ImageConstPtr image)
+  void ImagePlugin::imageCallback(const sensor_msgs::ImageConstPtr& image)
   {
     if (!has_message_)
     {


### PR DESCRIPTION
The image_transport package provides support for transparently
subscribing and publishing to topics using low-bandwidth compressed
formats; if the publisher supports it, this will cause the Image
plugin to consume far less bandwidth than before.

I also condensed all of the dependencies in the CMakeLists.txt file in
order to reduce redundant lines.