### PR TITLE
Fix for #298; right-click + drag will now zoom

### DIFF
--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -148,6 +148,7 @@ namespace mapviz
 
     void Recenter();
     void TransformTarget();
+    void Zoom(float factor);
 
     void InitializePixelBuffers();
 
@@ -165,9 +166,12 @@ namespace mapviz
 
     QColor bg_color_;
 
+    Qt::MouseButton mouse_button_;
     bool mouse_pressed_;
     int mouse_x_;
     int mouse_y_;
+    // Used when right-click dragging to zoom
+    int mouse_previous_y_;
 
     bool mouse_hovering_;
     int mouse_hover_x_;

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -276,6 +276,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent* e)
 {
   if (mouse_pressed_)
   {
+    int diff;
     switch (mouse_button_)
     {
       case Qt::LeftButton:
@@ -288,7 +289,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent* e)
         }
         break;
       case Qt::RightButton:
-        int diff = e->y() - mouse_previous_y_;
+        diff = e->y() - mouse_previous_y_;
         if (diff != 0)
         {
           Zoom(((float)diff) / 10.0f);


### PR DESCRIPTION
Since rviz uses right-click + drag to zoom in and out, I decided to replicate that behavior for mapviz.  Left or middle-click + drag will still pan the map.