### PR TITLE
QPainter support for plugins

### DIFF
--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -139,7 +139,7 @@ namespace mapviz
   protected:
     void initializeGL();
     void resizeGL(int w, int h);
-    void paintGL();
+    void paintEvent(QPaintEvent* event);
     void wheelEvent(QWheelEvent* e);
     void mousePressEvent(QMouseEvent* e);
     void mouseReleaseEvent(QMouseEvent* e);
@@ -147,7 +147,7 @@ namespace mapviz
     void leaveEvent(QEvent* e);
 
     void Recenter();
-    void TransformTarget();
+    void TransformTarget(QPainter* painter);
 
     void InitializePixelBuffers();
 
@@ -205,6 +205,7 @@ namespace mapviz
 
     boost::shared_ptr<tf::TransformListener> tf_;
     tf::StampedTransform transform_;
+    QTransform qtransform_;
     std::list<MapvizPluginPtr> plugins_;
     
     std::vector<uint8_t> capture_buffer_;

--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -71,6 +71,8 @@ namespace mapviz
     virtual void Shutdown() = 0;
 
     virtual void Draw(double x, double y, double scale) = 0;
+    
+    virtual void Paint(QPainter* painter, double x, double y, double scale) {};
 
     void SetUseLatestTransforms(bool value)
     {
@@ -104,6 +106,16 @@ namespace mapviz
         Transform();
 
         Draw(x, y, scale);
+      }
+    }
+    
+    void PaintPlugin(QPainter* painter, double x, double y, double scale)
+    {
+      if (visible_ && initialized_)
+      {
+        Transform();
+         
+        Paint(painter, x, y, scale);
       }
     }
 

--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -70,8 +70,16 @@ namespace mapviz
 
     virtual void Shutdown() = 0;
 
+    /**
+     * Draws on the Mapviz canvas using OpenGL commands; this will be called
+     * before Paint();
+     */
     virtual void Draw(double x, double y, double scale) = 0;
-    
+
+    /**
+     * Draws on the Mapviz canvas using a QPainter; this is called after Draw().
+     * You only need to implement this if you're actually using a QPainter.
+     */
     virtual void Paint(QPainter* painter, double x, double y, double scale) {};
 
     void SetUseLatestTransforms(bool value)

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -207,9 +207,6 @@ void MapCanvas::paintEvent(QPaintEvent* event)
 
   TransformTarget(&p);
 
-  //glPushMatrix();
-  //TransformTarget();
-
   // Draw test pattern
   glLineWidth(3);
   glBegin(GL_LINES);
@@ -228,16 +225,14 @@ void MapCanvas::paintEvent(QPaintEvent* event)
   for (it = plugins_.begin(); it != plugins_.end(); ++it)
   {
     (*it)->DrawPlugin(view_center_x_, view_center_y_, view_scale_);
+    p.endNativePainting();
+    (*it)->PaintPlugin(&p, view_center_x_, view_center_y_, view_scale_);
+    p.beginNativePainting();
   }
 
   glMatrixMode(GL_MODELVIEW);
   glPopMatrix();
   p.endNativePainting();
-
-  for (it = plugins_.begin(); it != plugins_.end(); ++it)
-  {
-    (*it)->PaintPlugin(&p, view_center_x_, view_center_y_, view_scale_);
-  }
 
   glPopMatrix();
 }
@@ -369,6 +364,10 @@ void MapCanvas::RemovePlugin(MapvizPluginPtr plugin)
 void MapCanvas::TransformTarget(QPainter* painter)
 {
   glTranslatef(offset_x_ + drag_x_, offset_y_ + drag_y_, 0);
+  // In order for plugins drawing with a QPainter to be able to use the same coordinates
+  // as plugins using drawing using native GL commands, we have to replicate the
+  // GL transforms using a QTransform.  Note that a QPainter's coordinate system is
+  // flipped on the Y axis relative to OpenGL's.
   qtransform_ = qtransform_.translate(offset_x_ + drag_x_, -(offset_y_ + drag_y_));
 
   view_center_x_ = -offset_x_ - drag_x_;

--- a/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
@@ -71,6 +71,7 @@ namespace mapviz_plugins
     void Shutdown() {}
 
     void Draw(double x, double y, double scale);
+    void Paint(QPainter* painter, double x, double y, double scale);
 
     void Transform();
 


### PR DESCRIPTION
I started work on this a while back, but I finally got around to polishing it up a bit.  The order of plugins is now properly respected; for each individual plugin, GL drawing will still be done before QPainter operations, but QPainter operations will still be done before the next plugin's GL drawing, so the layer ordering looks right.

In a nutshell, this adds a new method that MapvizPlugins can implement, MapvizPlugin::Paint, which allows them to use a Qt QPainter object to draw on Mapviz's canvas with the same coordinate system that they would normally do GL drawing.  This is handy because the QPainter provides a number of useful methods for drawing text, textures, and a variety of shapes using complex pens and brushes that are all a pain to do with native OpenGL commands.  The Paint function has an empty default implementation, so the API has not changed and existing plugins will work without modification.