### PR TITLE
Adding the ability to toggle anti-aliasing

### DIFF
--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -73,6 +73,7 @@ namespace mapviz
     void SetTargetFrame(const std::string& frame);
     void ToggleFixOrientation(bool on);
     void ToggleRotate90(bool on);
+    void ToggleEnableAntialiasing(bool on);
     void ToggleUseLatestTransforms(bool on);
     void UpdateView();
     void ReorderDisplays();
@@ -160,6 +161,7 @@ namespace mapviz
     bool initialized_;
     bool fix_orientation_;
     bool rotate_90_;
+    bool enable_antialiasing_;
 
     QTimer frame_rate_timer_;
 

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -101,6 +101,7 @@ namespace mapviz
     void ToggleCaptureTools(bool on);
     void ToggleFixOrientation(bool on);
     void ToggleRotate90(bool on);
+    void ToggleEnableAntialiasing(bool on);
     void ToggleShowPlugin(QListWidgetItem* item, bool visible);
     void ToggleRecord(bool on);
     void CaptureVideoFrame();

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -496,6 +496,13 @@ void Mapviz::Open(const std::string& filename)
       ui_.actionRotate_90->setChecked(rotate_90);
     }
 
+    if (swri_yaml_util::FindValue(doc, "enable_antialiasing"))
+    {
+      bool enable_antialiasing = true;
+      doc["enable_antialiasing"] >> enable_antialiasing;
+      ui_.actionEnable_Antialiasing->setChecked(enable_antialiasing);
+    }
+
     if (swri_yaml_util::FindValue(doc, "show_displays"))
     {
       bool show_displays = false;
@@ -672,6 +679,7 @@ void Mapviz::Save(const std::string& filename)
   out << YAML::Key << "target_frame" << YAML::Value << ui_.targetframe->currentText().toStdString();
   out << YAML::Key << "fix_orientation" << YAML::Value << ui_.actionFix_Orientation->isChecked();
   out << YAML::Key << "rotate_90" << YAML::Value << ui_.actionRotate_90->isChecked();
+  out << YAML::Key << "enable_antialiasing" << YAML::Value << ui_.actionEnable_Antialiasing->isChecked();
   out << YAML::Key << "show_displays" << YAML::Value << ui_.actionConfig_Dock->isChecked();
   out << YAML::Key << "show_status_bar" << YAML::Value << ui_.actionShow_Status_Bar->isChecked();
   out << YAML::Key << "show_capture_tools" << YAML::Value << ui_.actionShow_Capture_Tools->isChecked();
@@ -1032,6 +1040,11 @@ void Mapviz::ToggleFixOrientation(bool on)
 void Mapviz::ToggleRotate90(bool on)
 {
   canvas_->ToggleRotate90(on);
+}
+
+void Mapviz::ToggleEnableAntialiasing(bool on)
+{
+  canvas_->ToggleEnableAntialiasing(on);
 }
 
 void Mapviz::ToggleConfigPanel(bool on)

--- a/mapviz/src/mapviz.ui
+++ b/mapviz/src/mapviz.ui
@@ -51,6 +51,7 @@
     </property>
     <addaction name="actionFix_Orientation"/>
     <addaction name="actionRotate_90"/>
+    <addaction name="actionEnable_Antialiasing"/>
     <addaction name="separator"/>
     <addaction name="actionForce_720p"/>
     <addaction name="actionForce_480p"/>
@@ -450,6 +451,20 @@
     <string>Rotate the camera by 90 degrees</string>
    </property>
   </action>
+  <action name="actionEnable_Antialiasing">
+    <property name="checkable">
+      <bool>true</bool>
+    </property>
+    <property name="checked">
+      <bool>true</bool>
+    </property>
+    <property name="text">
+      <string>Enable Antialiasing</string>
+    </property>
+    <property name="statusTip">
+      <string>Enable antialiasing on the GL surface</string>
+    </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -732,6 +747,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionEnable_Antialiasing</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleEnableAntialiasing(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>SelectNewDisplay()</slot>
@@ -740,6 +771,7 @@
   <slot>FixedFrameSelected(QString)</slot>
   <slot>TargetFrameSelected(QString)</slot>
   <slot>ToggleFixOrientation(bool)</slot>
+  <slot>ToggleEnableAntialiasing(bool)</slot>
   <slot>MoveDisplay(QModelIndexList)</slot>
   <slot>OpenConfig()</slot>
   <slot>SaveConfig()</slot>


### PR DESCRIPTION
Now there's a checkbox under the "View" menu that will toggle whether
anti-aliasing is applied to the canvas.  In some situations this will
make the display look much prettier at a slight performance cost.