### PR TITLE
Enable QPainter antialiasing

### DIFF
--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -73,6 +73,7 @@ namespace mapviz
     void SetTargetFrame(const std::string& frame);
     void ToggleFixOrientation(bool on);
     void ToggleRotate90(bool on);
+    void ToggleEnableAntialiasing(bool on);
     void ToggleUseLatestTransforms(bool on);
     void UpdateView();
     void ReorderDisplays();
@@ -160,6 +161,7 @@ namespace mapviz
     bool initialized_;
     bool fix_orientation_;
     bool rotate_90_;
+    bool enable_antialiasing_;
 
     QTimer frame_rate_timer_;
 

--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -139,7 +139,7 @@ namespace mapviz
   protected:
     void initializeGL();
     void resizeGL(int w, int h);
-    void paintGL();
+    void paintEvent(QPaintEvent* event);
     void wheelEvent(QWheelEvent* e);
     void mousePressEvent(QMouseEvent* e);
     void mouseReleaseEvent(QMouseEvent* e);
@@ -147,7 +147,7 @@ namespace mapviz
     void leaveEvent(QEvent* e);
 
     void Recenter();
-    void TransformTarget();
+    void TransformTarget(QPainter* painter);
 
     void InitializePixelBuffers();
 
@@ -205,6 +205,7 @@ namespace mapviz
 
     boost::shared_ptr<tf::TransformListener> tf_;
     tf::StampedTransform transform_;
+    QTransform qtransform_;
     std::list<MapvizPluginPtr> plugins_;
     
     std::vector<uint8_t> capture_buffer_;

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -101,6 +101,7 @@ namespace mapviz
     void ToggleCaptureTools(bool on);
     void ToggleFixOrientation(bool on);
     void ToggleRotate90(bool on);
+    void ToggleEnableAntialiasing(bool on);
     void ToggleShowPlugin(QListWidgetItem* item, bool visible);
     void ToggleRecord(bool on);
     void CaptureVideoFrame();

--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -71,6 +71,8 @@ namespace mapviz
     virtual void Shutdown() = 0;
 
     virtual void Draw(double x, double y, double scale) = 0;
+    
+    virtual void Paint(QPainter* painter, double x, double y, double scale) {};
 
     void SetUseLatestTransforms(bool value)
     {
@@ -104,6 +106,16 @@ namespace mapviz
         Transform();
 
         Draw(x, y, scale);
+      }
+    }
+    
+    void PaintPlugin(QPainter* painter, double x, double y, double scale)
+    {
+      if (visible_ && initialized_)
+      {
+        Transform();
+         
+        Paint(painter, x, y, scale);
       }
     }
 

--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -70,8 +70,16 @@ namespace mapviz
 
     virtual void Shutdown() = 0;
 
+    /**
+     * Draws on the Mapviz canvas using OpenGL commands; this will be called
+     * before Paint();
+     */
     virtual void Draw(double x, double y, double scale) = 0;
-    
+
+    /**
+     * Draws on the Mapviz canvas using a QPainter; this is called after Draw().
+     * You only need to implement this if you're actually using a QPainter.
+     */
     virtual void Paint(QPainter* painter, double x, double y, double scale) {};
 
     void SetUseLatestTransforms(bool value)

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -41,7 +41,7 @@ bool compare_plugins(MapvizPluginPtr a, MapvizPluginPtr b)
 }
 
 MapCanvas::MapCanvas(QWidget* parent) :
-  QGLWidget(parent),
+  QGLWidget(QGLFormat(QGL::SampleBuffers), parent),
   has_pixel_buffers_(false),
   pixel_buffer_size_(0),
   pixel_buffer_index_(0),
@@ -49,6 +49,7 @@ MapCanvas::MapCanvas(QWidget* parent) :
   initialized_(false),
   fix_orientation_(false),
   rotate_90_(false),
+  enable_antialiasing_(true),
   mouse_pressed_(false),
   mouse_x_(0),
   mouse_y_(0),
@@ -134,11 +135,23 @@ void MapCanvas::initializeGL()
   }
 
   glClearColor(0.58f, 0.56f, 0.5f, 1);
-  glEnable(GL_POINT_SMOOTH);
-  glEnable(GL_LINE_SMOOTH);
-  glDisable(GL_POLYGON_SMOOTH);
-  glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-  glHint(GL_POINT_SMOOTH_HINT, GL_NICEST);
+  if (enable_antialiasing_)
+  {
+    glEnable(GL_MULTISAMPLE);
+    glEnable(GL_POINT_SMOOTH);
+    glEnable(GL_LINE_SMOOTH);
+    glEnable(GL_POLYGON_SMOOTH);
+    glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
+    glHint(GL_POINT_SMOOTH_HINT, GL_NICEST);
+    glHint(GL_POLYGON_SMOOTH_HINT, GL_NICEST);
+  }
+  else
+  {
+    glDisable(GL_MULTISAMPLE);
+    glDisable(GL_POINT_SMOOTH);
+    glDisable(GL_LINE_SMOOTH);
+    glDisable(GL_POLYGON_SMOOTH);
+  }
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glDepthFunc(GL_NEVER);
@@ -336,6 +349,16 @@ void MapCanvas::ToggleRotate90(bool on)
 {
   rotate_90_ = on;
   update();
+}
+
+void MapCanvas::ToggleEnableAntialiasing(bool on)
+{
+  enable_antialiasing_ = on;
+  QGLFormat format;
+  format.setSwapInterval(1);
+  format.setSampleBuffers(enable_antialiasing_);
+  // After setting the format, initializeGL will automatically be called again, then paintGL.
+  this->setFormat(format);
 }
 
 void MapCanvas::ToggleUseLatestTransforms(bool on)

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -210,6 +210,11 @@ void MapCanvas::paintEvent(QPaintEvent* event)
   }
 
   QPainter p(this);
+  p.setRenderHints(QPainter::Antialiasing |
+                       QPainter::TextAntialiasing |
+                       QPainter::SmoothPixmapTransform |
+                       QPainter::HighQualityAntialiasing,
+                   enable_antialiasing_);
   p.beginNativePainting();
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -207,9 +207,6 @@ void MapCanvas::paintEvent(QPaintEvent* event)
 
   TransformTarget(&p);
 
-  //glPushMatrix();
-  //TransformTarget();
-
   // Draw test pattern
   glLineWidth(3);
   glBegin(GL_LINES);
@@ -228,16 +225,14 @@ void MapCanvas::paintEvent(QPaintEvent* event)
   for (it = plugins_.begin(); it != plugins_.end(); ++it)
   {
     (*it)->DrawPlugin(view_center_x_, view_center_y_, view_scale_);
+    p.endNativePainting();
+    (*it)->PaintPlugin(&p, view_center_x_, view_center_y_, view_scale_);
+    p.beginNativePainting();
   }
 
   glMatrixMode(GL_MODELVIEW);
   glPopMatrix();
   p.endNativePainting();
-
-  for (it = plugins_.begin(); it != plugins_.end(); ++it)
-  {
-    (*it)->PaintPlugin(&p, view_center_x_, view_center_y_, view_scale_);
-  }
 
   glPopMatrix();
 }
@@ -369,6 +364,10 @@ void MapCanvas::RemovePlugin(MapvizPluginPtr plugin)
 void MapCanvas::TransformTarget(QPainter* painter)
 {
   glTranslatef(offset_x_ + drag_x_, offset_y_ + drag_y_, 0);
+  // In order for plugins drawing with a QPainter to be able to use the same coordinates
+  // as plugins using drawing using native GL commands, we have to replicate the
+  // GL transforms using a QTransform.  Note that a QPainter's coordinate system is
+  // flipped on the Y axis relative to OpenGL's.
   qtransform_ = qtransform_.translate(offset_x_ + drag_x_, -(offset_y_ + drag_y_));
 
   view_center_x_ = -offset_x_ - drag_x_;

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -496,6 +496,13 @@ void Mapviz::Open(const std::string& filename)
       ui_.actionRotate_90->setChecked(rotate_90);
     }
 
+    if (swri_yaml_util::FindValue(doc, "enable_antialiasing"))
+    {
+      bool enable_antialiasing = true;
+      doc["enable_antialiasing"] >> enable_antialiasing;
+      ui_.actionEnable_Antialiasing->setChecked(enable_antialiasing);
+    }
+
     if (swri_yaml_util::FindValue(doc, "show_displays"))
     {
       bool show_displays = false;
@@ -672,6 +679,7 @@ void Mapviz::Save(const std::string& filename)
   out << YAML::Key << "target_frame" << YAML::Value << ui_.targetframe->currentText().toStdString();
   out << YAML::Key << "fix_orientation" << YAML::Value << ui_.actionFix_Orientation->isChecked();
   out << YAML::Key << "rotate_90" << YAML::Value << ui_.actionRotate_90->isChecked();
+  out << YAML::Key << "enable_antialiasing" << YAML::Value << ui_.actionEnable_Antialiasing->isChecked();
   out << YAML::Key << "show_displays" << YAML::Value << ui_.actionConfig_Dock->isChecked();
   out << YAML::Key << "show_status_bar" << YAML::Value << ui_.actionShow_Status_Bar->isChecked();
   out << YAML::Key << "show_capture_tools" << YAML::Value << ui_.actionShow_Capture_Tools->isChecked();
@@ -1032,6 +1040,11 @@ void Mapviz::ToggleFixOrientation(bool on)
 void Mapviz::ToggleRotate90(bool on)
 {
   canvas_->ToggleRotate90(on);
+}
+
+void Mapviz::ToggleEnableAntialiasing(bool on)
+{
+  canvas_->ToggleEnableAntialiasing(on);
 }
 
 void Mapviz::ToggleConfigPanel(bool on)

--- a/mapviz/src/mapviz.ui
+++ b/mapviz/src/mapviz.ui
@@ -51,6 +51,7 @@
     </property>
     <addaction name="actionFix_Orientation"/>
     <addaction name="actionRotate_90"/>
+    <addaction name="actionEnable_Antialiasing"/>
     <addaction name="separator"/>
     <addaction name="actionForce_720p"/>
     <addaction name="actionForce_480p"/>
@@ -450,6 +451,20 @@
     <string>Rotate the camera by 90 degrees</string>
    </property>
   </action>
+  <action name="actionEnable_Antialiasing">
+    <property name="checkable">
+      <bool>true</bool>
+    </property>
+    <property name="checked">
+      <bool>true</bool>
+    </property>
+    <property name="text">
+      <string>Enable Antialiasing</string>
+    </property>
+    <property name="statusTip">
+      <string>Enable antialiasing on the GL surface</string>
+    </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -732,6 +747,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionEnable_Antialiasing</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleEnableAntialiasing(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>SelectNewDisplay()</slot>
@@ -740,6 +771,7 @@
   <slot>FixedFrameSelected(QString)</slot>
   <slot>TargetFrameSelected(QString)</slot>
   <slot>ToggleFixOrientation(bool)</slot>
+  <slot>ToggleEnableAntialiasing(bool)</slot>
   <slot>MoveDisplay(QModelIndexList)</slot>
   <slot>OpenConfig()</slot>
   <slot>SaveConfig()</slot>

--- a/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
@@ -71,6 +71,7 @@ namespace mapviz_plugins
     void Shutdown() {}
 
     void Draw(double x, double y, double scale);
+    void Paint(QPainter* painter, double x, double y, double scale);
 
     void Transform();
 


### PR DESCRIPTION
This depends on #303 and #304 and should be merged after both of them.

After turning on QPainter support, there are a few extra flags that have to be set for anti-aliasing to work with it.