### PR TITLE
Enabling anti-aliasing for QPainter drawing

### DIFF
--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -212,6 +212,11 @@ void MapCanvas::paintEvent(QPaintEvent* event)
   }
 
   QPainter p(this);
+  p.setRenderHints(QPainter::Antialiasing |
+                       QPainter::TextAntialiasing |
+                       QPainter::SmoothPixmapTransform |
+                       QPainter::HighQualityAntialiasing,
+                   enable_antialiasing_);
   p.beginNativePainting();
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();


### PR DESCRIPTION
This sets a few extra flags that are necessary for anti-aliasing to work with a QPainter.