### PR TITLE
Removing extraneous calls to MapCanvas::update()

### DIFF
--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -253,8 +253,6 @@ void MapCanvas::paintEvent(QPaintEvent* event)
   glMatrixMode(GL_MODELVIEW);
   glPopMatrix();
   p.endNativePainting();
-
-  glPopMatrix();
 }
 
 void MapCanvas::wheelEvent(QWheelEvent* e)
@@ -315,7 +313,6 @@ void MapCanvas::mouseMoveEvent(QMouseEvent* e)
         {
           drag_x_ = -((mouse_x_ - e->x()) * view_scale_);
           drag_y_ = ((mouse_y_ - e->y()) * view_scale_);
-          update();
         }
         break;
       case Qt::RightButton:
@@ -361,7 +358,6 @@ void MapCanvas::SetFixedFrame(const std::string& frame)
   {
     (*it)->SetTargetFrame(frame);
   }
-  update();
 }
 
 void MapCanvas::SetTargetFrame(const std::string& frame)
@@ -372,19 +368,16 @@ void MapCanvas::SetTargetFrame(const std::string& frame)
   drag_y_ = 0;
 
   target_frame_ = frame;
-  update();
 }
 
 void MapCanvas::ToggleFixOrientation(bool on)
 {
   fix_orientation_ = on;
-  update();
 }
 
 void MapCanvas::ToggleRotate90(bool on)
 {
   rotate_90_ = on;
-  update();
 }
 
 void MapCanvas::ToggleEnableAntialiasing(bool on)
@@ -404,8 +397,6 @@ void MapCanvas::ToggleUseLatestTransforms(bool on)
   {
     (*it)->SetUseLatestTransforms(on);
   }
-
-  update();
 }
 
 void MapCanvas::AddPlugin(MapvizPluginPtr plugin, int order)
@@ -417,7 +408,6 @@ void MapCanvas::RemovePlugin(MapvizPluginPtr plugin)
 {
   plugin->Shutdown();
   plugins_.remove(plugin);
-  update();
 }
 
 void MapCanvas::TransformTarget(QPainter* painter)
@@ -516,8 +506,6 @@ void MapCanvas::UpdateView()
 
     qtransform_ = QTransform::fromTranslate(width() / 2.0, height() / 2.0).
         scale(1.0 / view_scale_, 1.0 / view_scale_);
-
-    update();
   }
 }
 


### PR DESCRIPTION
Now that update() is being called automatically at a rate of 50 Hz, the explicit calls in many locations are unnecessary.  It was also possible for it to be called in some of these locations from a non-main thread, which is invalid and could cause crashes.

Also, there was an extra call to glPopMatrix() that did not have a matching glPushMatrix().  It didn't seem to be hurting anything, but I removed it.