### PR TITLE
Fixing #317; weird plugin transformation glitches

### DIFF
--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -230,6 +230,15 @@ namespace mapviz
 
     void SetIcon(IconWidget* icon) { icon_ = icon; }
 
+    /**
+     * Override this to return "true" if you want QPainter support for your
+     * plugin.
+     */
+    virtual bool SupportsPainting()
+    {
+      return false;
+    }
+
   protected:
     bool initialized_;
     bool visible_;

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -244,6 +244,8 @@ void MapCanvas::paintEvent(QPaintEvent* event)
   std::list<MapvizPluginPtr>::iterator it;
   for (it = plugins_.begin(); it != plugins_.end(); ++it)
   {
+    (*it)->DrawPlugin(view_center_x_, view_center_y_, view_scale_);
+    
     if ((*it)->SupportsPainting())
     {
       glMatrixMode(GL_MODELVIEW);
@@ -256,7 +258,6 @@ void MapCanvas::paintEvent(QPaintEvent* event)
       UpdateView();
       TransformTarget(&p);
     }
-    (*it)->DrawPlugin(view_center_x_, view_center_y_, view_scale_);
   }
 
   glMatrixMode(GL_MODELVIEW);

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -244,20 +244,33 @@ void MapCanvas::paintEvent(QPaintEvent* event)
   std::list<MapvizPluginPtr>::iterator it;
   for (it = plugins_.begin(); it != plugins_.end(); ++it)
   {
+    // Before we let a plugin do any drawing, push all matrices and attributes.
+    // This helps to ensure that plugins can't accidentally mess something up
+    // for the next plugin.
+    glMatrixMode(GL_TEXTURE);
+    glPushMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glPushAttrib(GL_ALL_ATTRIB_BITS);
+
     (*it)->DrawPlugin(view_center_x_, view_center_y_, view_scale_);
-    
+
     if ((*it)->SupportsPainting())
     {
-      glMatrixMode(GL_MODELVIEW);
-      glPushMatrix();
       p.endNativePainting();
       (*it)->PaintPlugin(&p, view_center_x_, view_center_y_, view_scale_);
       p.beginNativePainting();
-      glPopMatrix();
-
-      UpdateView();
-      TransformTarget(&p);
     }
+
+    glPopAttrib();
+    glMatrixMode(GL_MODELVIEW);
+    glPopMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_TEXTURE);
+    glPopMatrix();
   }
 
   glMatrixMode(GL_MODELVIEW);

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -258,7 +258,6 @@ void MapCanvas::paintEvent(QPaintEvent* event)
     }
     (*it)->DrawPlugin(view_center_x_, view_center_y_, view_scale_);
   }
-  ROS_INFO("Done drawing plugins");
 
   glMatrixMode(GL_MODELVIEW);
   glPopMatrix();

--- a/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
@@ -80,6 +80,10 @@ namespace mapviz_plugins
 
     QWidget* GetConfigWidget(QWidget* parent);
 
+    bool SupportsPainting() {
+      return true;
+    }
+
   protected:
     void PrintError(const std::string& message);
     void PrintInfo(const std::string& message);

--- a/mapviz_plugins/include/mapviz_plugins/string_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/string_plugin.h
@@ -87,6 +87,11 @@ namespace mapviz_plugins
 
     QWidget* GetConfigWidget(QWidget* parent);
 
+    bool SupportsPainting()
+    {
+      return true;
+    }
+
   protected:
     void PaintText(QPainter* painter);
     void PrintError(const std::string& message);

--- a/mapviz_plugins/src/disparity_plugin.cpp
+++ b/mapviz_plugins/src/disparity_plugin.cpp
@@ -412,6 +412,7 @@ namespace mapviz_plugins
       y_pos = canvas_->height() - height - y_offset;
     }
 
+    glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     glLoadIdentity();
     glOrtho(0, canvas_->width(), canvas_->height(), 0, -0.5f, 0.5f);

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -379,6 +379,7 @@ namespace mapviz_plugins
       y_pos = canvas_->height() - height - y_offset;
     }
 
+    glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     glLoadIdentity();
     glOrtho(0, canvas_->width(), canvas_->height(), 0, -0.5f, 0.5f);


### PR DESCRIPTION
First, the model view matrix needs to be saved and restored around QPainter operations because Qt clears several GL variables.  Also, the image plugin needed to explicitly call glMatrixMode(GL_PROJECTION); it does a few operations on the projection matrix and was just assuming that was the current matrix mode.  Also, I added a function that plugins need to override if they want to do QPainter operations; this will eliminate unnecessary overhead for plugins that do not.