### PR TITLE
Fix for #319

### DIFF
--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -304,13 +304,8 @@ void MapCanvas::mousePressEvent(QMouseEvent* e)
 
 QPointF MapCanvas::MapGlCoordToFixedFrame(const QPointF& point)
 {
-  double center_x = -offset_x_ - drag_x_;
-  double center_y = -offset_y_ - drag_y_;
-  double x = center_x + (point.x() - width() / 2.0) * view_scale_;
-  double y = center_y + (height() / 2.0  - point.y()) * view_scale_;
-  tf::Point tfPoint(x, y, 0);
-  tfPoint = transform_ * tfPoint;
-  return QPointF(tfPoint.x(), tfPoint.y());
+  bool invertible = true;
+  return qtransform_.inverted(&invertible).map(point);
 }
 
 void MapCanvas::mouseReleaseEvent(QMouseEvent* e)


### PR DESCRIPTION
Previously, the MapCanvas::MapGlCoordToFixedFrame function relied on
the transform_ member variable being set, but it is not set if the
target frame is <none>.  Instead it will now use the qtransform_
variable, which is always initialized for the purpose of QPainters.