### PR TITLE
fixing a variable name

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/disparity_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/disparity_plugin.h
@@ -103,7 +103,7 @@ namespace mapviz_plugins
     void SetOffsetY(int offset);
     void SetWidth(int width);
     void SetHeight(int height);
-    void SetSubscription(bool hidden);
+    void SetSubscription(bool visible);
 
   private:
     Ui::disparity_config ui_;

--- a/mapviz_plugins/include/mapviz_plugins/image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/image_plugin.h
@@ -104,7 +104,7 @@ namespace mapviz_plugins
     void SetOffsetY(int offset);
     void SetWidth(int width);
     void SetHeight(int height);
-    void SetSubscription(bool hidden);
+    void SetSubscription(bool visible);
 
   private:
     Ui::image_config ui_;

--- a/mapviz_plugins/src/disparity_plugin.cpp
+++ b/mapviz_plugins/src/disparity_plugin.cpp
@@ -167,18 +167,18 @@ namespace mapviz_plugins
       units_ = PERCENT;
     }
   }
-  void DisparityPlugin::SetSubscription(bool hidden)
+  void DisparityPlugin::SetSubscription(bool visible)
   {
     if(topic_.empty())
     {
       return;
     }
-    else if(!hidden)
+    else if(!visible)
     {
       disparity_sub_.shutdown();
       ROS_INFO("Dropped subscription to %s", topic_.c_str());
     }
-    else if(hidden)
+    else
     {
         disparity_sub_ = node_.subscribe(topic_, 1, &DisparityPlugin::disparityCallback, this);
 

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -166,13 +166,13 @@ namespace mapviz_plugins
       units_ = PERCENT;
     }
   }
-  void ImagePlugin::SetSubscription(bool hidden)
+  void ImagePlugin::SetSubscription(bool visible)
   {
     if(topic_.empty())
     {
       return;
     }
-    else if(!hidden)
+    else if(!visible)
     {
       image_sub_.shutdown();
       ROS_INFO("Dropped subscription to %s", topic_.c_str());


### PR DESCRIPTION
Changed a variable named 'hidden' inside  of a function within the disparity and image plugins to 'visible' to prevent any confusion.