### PR TITLE
Fixing blending for GL drawing

### DIFF
--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -139,6 +139,9 @@ namespace mapviz
 
   protected:
     void initializeGL();
+    void initGlBlending();
+    void pushGlMatrices();
+    void popGlMatrices();
     void resizeGL(int w, int h);
     void paintEvent(QPaintEvent* event);
     void wheelEvent(QWheelEvent* e);


### PR DESCRIPTION
Fix for #325. The call to QGLWidget::beginNativePainting has a side effect of clearing GL settings related to blending and depth testing, and that was causing alpha transparency to not work right for plugins.  I fixed it by manually re-enabling those settings every time beginNativePainting is called.