### PR TITLE
Fix for #265; message source frames don't update (Indigo)

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
@@ -101,20 +101,21 @@ namespace mapviz_plugins
     private:
       struct StampedPoint
       {
-          tf::Point point;
-          tf::Point transformed_point;
-          QColor color;
-          float range;
-          float intensity;
+        tf::Point point;
+        tf::Point transformed_point;
+        QColor color;
+        float range;
+        float intensity;
       };
 
       struct Scan
       {
-          ros::Time stamp;
-          QColor color;
-          std::vector<StampedPoint> points;
-          bool transformed;
-          bool has_intensity;
+        ros::Time stamp;
+        QColor color;
+        std::vector<StampedPoint> points;
+        std::string source_frame_;
+        bool transformed;
+        bool has_intensity;
       };
 
       void laserScanCallback(const sensor_msgs::LaserScanConstPtr& scan);

--- a/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/marker_plugin.h
@@ -117,6 +117,7 @@ namespace mapviz_plugins
       float scale_y;
       float scale_z;
 
+      std::string source_frame_;
       swri_transform_util::Transform local_transform;
       
       bool transformed;

--- a/mapviz_plugins/include/mapviz_plugins/odometry_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/odometry_plugin.h
@@ -67,6 +67,7 @@ namespace mapviz_plugins
       tf::Point transformed_arrow_point;
       tf::Point transformed_arrow_left;
       tf::Point transformed_arrow_right;
+      std::string source_frame;
       bool transformed;
       ros::Time stamp;
 

--- a/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.h
@@ -114,6 +114,7 @@ namespace mapviz_plugins
         ros::Time stamp;
         QColor color;
         std::vector<StampedPoint> points;
+        std::string source_frame;
         bool transformed;
         std::map<std::string, Field_info> new_features;
       };

--- a/mapviz_plugins/include/mapviz_plugins/textured_marker_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/textured_marker_plugin.h
@@ -116,6 +116,8 @@ namespace mapviz_plugins
       
       std::vector<tf::Vector3> quad_;
       std::vector<tf::Vector3> transformed_quad_;
+
+      std::string source_frame_;
       
       bool transformed;
     };

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -323,10 +323,10 @@ namespace mapviz_plugins
   {
     if (!has_message_)
     {
-      source_frame_ = msg->header.frame_id;
       initialized_ = true;
       has_message_ = true;
     }
+    source_frame_ = msg->header.frame_id;
 
     Scan scan;
     scan.stamp = msg->header.stamp;

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -137,10 +137,10 @@ namespace mapviz_plugins
   {
     if (!has_message_)
     {
-      source_frame_ = marker.header.frame_id;
       initialized_ = true;
       has_message_ = true;
     }
+    source_frame_ = marker.header.frame_id;
 
     if (marker.action == visualization_msgs::Marker::ADD)
     {

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -180,10 +180,10 @@ namespace mapviz_plugins
   {
     if (!has_message_)
     {
-      source_frame_ = odometry->header.frame_id;
       initialized_ = true;
       has_message_ = true;
     }
+    source_frame_ = odometry->header.frame_id;
 
     StampedPoint stamped_point;
     stamped_point.stamp = odometry->header.stamp;

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -183,10 +183,15 @@ namespace mapviz_plugins
       initialized_ = true;
       has_message_ = true;
     }
-    source_frame_ = odometry->header.frame_id;
+
+    // Note that unlike some plugins, this one does not store nor rely on the
+    // source_frame_ member variable.  This one can potentially store many
+    // messages with different source frames, so we need to store and transform
+    // them individually.
 
     StampedPoint stamped_point;
     stamped_point.stamp = odometry->header.stamp;
+    stamped_point.source_frame = odometry->header.frame_id;
 
     stamped_point.point = tf::Point(
         odometry->pose.pose.position.x,
@@ -460,7 +465,7 @@ namespace mapviz_plugins
   bool OdometryPlugin::TransformPoint(StampedPoint& point)
   {
     swri_transform_util::Transform transform;
-    if (GetTransform(point.stamp, transform))
+    if (GetTransform(point.source_frame, point.stamp, transform))
     {
       point.transformed_point = transform * point.point;
 
@@ -499,7 +504,7 @@ namespace mapviz_plugins
 
     if (!points_.empty() && !transformed)
     {
-      PrintError("No transform between " + source_frame_ + " and " + target_frame_);
+      PrintError("No transform between " + cur_point_.source_frame + " and " + target_frame_);
     }
   }
 

--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -140,10 +140,10 @@ namespace mapviz_plugins
     ROS_INFO("Got path message");
     if (!has_message_)
     {
-      source_frame_ = path->header.frame_id;
       initialized_ = true;
       has_message_ = true;
     }
+    source_frame_ = path->header.frame_id;
 
     transformed_ = false;
 

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -357,10 +357,10 @@ namespace mapviz_plugins
   {
     if (!has_message_)
     {
-      source_frame_ = msg->header.frame_id;
       initialized_ = true;
       has_message_ = true;
     }
+    source_frame_ = msg->header.frame_id;
 
     Scan scan;
     scan.stamp = msg->header.stamp;

--- a/mapviz_plugins/src/route_plugin.cpp
+++ b/mapviz_plugins/src/route_plugin.cpp
@@ -243,11 +243,11 @@ namespace mapviz_plugins
     {
       source_frame_ = "/wgs84";
     }
-    unsigned long route_size = route->route_points.size();
+    size_t route_size = route->route_points.size();
 
     points_.clear();
 
-    for (unsigned long i = 0; i < route_size; i++)
+    for (size_t i = 0; i < route_size; i++)
     {
       StampedPoint stamped_point;
       stamped_point.stamp = route->header.stamp;

--- a/mapviz_plugins/src/route_plugin.cpp
+++ b/mapviz_plugins/src/route_plugin.cpp
@@ -232,16 +232,16 @@ namespace mapviz_plugins
   {
     if (!has_message_)
     {
-      if (!route->header.frame_id.empty())
-      {
-        source_frame_ = route->header.frame_id;
-      }
-      else
-      {
-        source_frame_ = "/wgs84";
-      }
       initialized_ = true;
       has_message_ = true;
+    }
+    if (!route->header.frame_id.empty())
+    {
+      source_frame_ = route->header.frame_id;
+    }
+    else
+    {
+      source_frame_ = "/wgs84";
     }
     int route_size = route->route_points.size();
 

--- a/mapviz_plugins/src/route_plugin.cpp
+++ b/mapviz_plugins/src/route_plugin.cpp
@@ -243,11 +243,11 @@ namespace mapviz_plugins
     {
       source_frame_ = "/wgs84";
     }
-    int route_size = route->route_points.size();
+    unsigned long route_size = route->route_points.size();
 
     points_.clear();
 
-    for (int i = 0; i < route_size; i++)
+    for (unsigned long i = 0; i < route_size; i++)
     {
       StampedPoint stamped_point;
       stamped_point.stamp = route->header.stamp;

--- a/mapviz_plugins/src/textured_marker_plugin.cpp
+++ b/mapviz_plugins/src/textured_marker_plugin.cpp
@@ -149,10 +149,10 @@ namespace mapviz_plugins
   {
     if (!has_message_)
     {
-      source_frame_ = marker.header.frame_id;
       initialized_ = true;
       has_message_ = true;
     }
+    source_frame_ = marker.header.frame_id;
 
     if (marker.action == marti_visualization_msgs::TexturedMarker::ADD)
     {

--- a/mapviz_plugins/src/textured_marker_plugin.cpp
+++ b/mapviz_plugins/src/textured_marker_plugin.cpp
@@ -152,7 +152,11 @@ namespace mapviz_plugins
       initialized_ = true;
       has_message_ = true;
     }
-    source_frame_ = marker.header.frame_id;
+
+    // Note that unlike some plugins, this one does not store nor rely on the
+    // source_frame_ member variable.  This one can potentially store many
+    // messages with different source frames, so we need to store and transform
+    // them individually.
 
     if (marker.action == marti_visualization_msgs::TexturedMarker::ADD)
     {
@@ -161,12 +165,13 @@ namespace mapviz_plugins
 
       markerData.transformed = true;
       markerData.alpha_ = marker.alpha;
+      markerData.source_frame_ = marker.header.frame_id;
 
       swri_transform_util::Transform transform;
-      if (!GetTransform(marker.header.stamp, transform))
+      if (!GetTransform(markerData.source_frame_, marker.header.stamp, transform))
       {
         markerData.transformed = false;
-        PrintError("No transform between " + source_frame_ + " and " + target_frame_);
+        PrintError("No transform between " + markerData.source_frame_ + " and " + target_frame_);
       }
 
       // Handle lifetime parameter
@@ -464,7 +469,7 @@ namespace mapviz_plugins
       for (markerIter = nsIter->second.begin(); markerIter != nsIter->second.end(); ++markerIter)
       {
         swri_transform_util::Transform transform;
-        if (GetTransform(markerIter->second.stamp, transform))
+        if (GetTransform(markerIter->second.source_frame_, markerIter->second.stamp, transform))
         {
           markerIter->second.transformed_quad_.clear();
           for (size_t i = 0; i < markerIter->second.quad_.size(); i++)


### PR DESCRIPTION
Several plugins were storing the source frames of messages received when
they first received a message but never updating them, so subsequent
messages in different frames would be rendered incorrectly.