### PR TITLE
Fix for #336; Qt event handler exceptions shouldn't crash Mapviz (Jade)

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -63,6 +63,7 @@ file (GLOB HEADER_FILES
   include/mapviz/config_item.h
   include/mapviz/map_canvas.h
   include/mapviz/mapviz.h
+  include/mapviz/mapviz_application.h
   include/mapviz/mapviz_plugin.h
   include/mapviz/rqt_mapviz.h
   include/mapviz/select_frame_dialog.h
@@ -73,6 +74,7 @@ file (GLOB SRC_FILES
   src/mapviz.cpp
   src/color_button.cpp
   src/config_item.cpp
+  src/mapviz_application.cpp
   src/map_canvas.cpp
   src/rqt_mapviz.cpp
   src/select_frame_dialog.cpp

--- a/mapviz/include/mapviz/mapviz_application.h
+++ b/mapviz/include/mapviz/mapviz_application.h
@@ -27,20 +27,26 @@
 //
 // *****************************************************************************
 
-#include "mapviz/mapviz.h"
-#include "mapviz/mapviz_application.h"
+#ifndef MAPVIZ_MAPVIZ_APPLICATION_H
+#define MAPVIZ_MAPVIZ_APPLICATION_H
 
-int main(int argc, char **argv)
+#include <QApplication>
+#include <QEvent>
+
+namespace mapviz
 {
-  // Initialize QT
-  mapviz::MapvizApplication app(argc, argv);
-
-  // Initialize glut (for displaying text)
-  glutInit(&argc, argv);
-
-  // Start mapviz
-  mapviz::Mapviz mapviz(true, argc, argv);
-  mapviz.show();
-
-  return app.exec();
+  /**
+   * This class exists solely so that we can override QApplication::notify and
+   * log exceptions in the event loop as errors rather than letting them
+   * crash the entire program.
+   */
+  class MapvizApplication : public QApplication
+  {
+  public:
+    MapvizApplication(int &argc, char** argv);
+  private:
+    bool notify(QObject* receiver, QEvent* event);
+  };
 }
+
+#endif

--- a/mapviz/src/mapviz_application.cpp
+++ b/mapviz/src/mapviz_application.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2014, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -17,30 +17,40 @@
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
 //
 // *****************************************************************************
 
-#include "mapviz/mapviz.h"
 #include "mapviz/mapviz_application.h"
 
-int main(int argc, char **argv)
+#include <ros/ros.h>
+
+namespace mapviz
 {
-  // Initialize QT
-  mapviz::MapvizApplication app(argc, argv);
+  MapvizApplication::MapvizApplication(int& argc, char** argv) :
+    QApplication(argc, argv)
+  {
+  }
 
-  // Initialize glut (for displaying text)
-  glutInit(&argc, argv);
+  bool MapvizApplication::notify(QObject* receiver, QEvent* event)
+  {
+    try {
+      return QApplication::notify(receiver, event);
+    }
+    catch (const ros::Exception& e) {
+      ROS_ERROR("Unhandled ros::Exception in Qt event loop: %s", e.what());
+    }
+    catch (const std::exception& e) {
+      ROS_ERROR("Unhandled std::exception in Qt event loop: %s", e.what());
+    }
 
-  // Start mapviz
-  mapviz::Mapviz mapviz(true, argc, argv);
-  mapviz.show();
-
-  return app.exec();
+    return false;
+  }
 }


### PR DESCRIPTION
Jade version of #337.