### PR TITLE
Adding signals for various plugin events (Jade)

### DIFF
--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -84,7 +84,11 @@ namespace mapviz
 
     void SetUseLatestTransforms(bool value)
     {
-      use_latest_transforms_ = value;
+      if (value != use_latest_transforms_)
+      {
+        use_latest_transforms_ = value;
+        Q_EMIT UseLatestTransformsChanged(use_latest_transforms_);
+      }
     }
 
     void SetName(const std::string& name) { name_ = name; }
@@ -99,7 +103,11 @@ namespace mapviz
 
     void SetDrawOrder(int order)
     {
-      draw_order_ = order;
+      if (draw_order_ != order)
+      {
+        draw_order_ = order;
+        Q_EMIT DrawOrderChanged(draw_order_);
+      }
     }
 
     virtual void SetNode(const ros::NodeHandle& node)
@@ -133,6 +141,7 @@ namespace mapviz
       {
         target_frame_ = frame_id;
         Transform();
+        Q_EMIT TargetFrameChanged(target_frame_);
       }
     }
 
@@ -140,7 +149,11 @@ namespace mapviz
 
     void SetVisible(bool visible)
     {
-      visible_ = visible;
+      if (visible_ != visible)
+      {
+        visible_ = visible;
+        Q_EMIT VisibleChanged(visible_);
+      }
     }
 
     bool GetTransform(const ros::Time& stamp, swri_transform_util::Transform& transform, bool use_latest_transforms = true)
@@ -238,6 +251,13 @@ namespace mapviz
     {
       return false;
     }
+
+  Q_SIGNALS:
+    void DrawOrderChanged(int draw_order);
+    void TargetFrameChanged(const std::string& target_frame);
+    void UseLatestTransformsChanged(bool use_latest_transforms);
+    void VisibleChanged(bool visible);
+    
 
   protected:
     bool initialized_;

--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -56,6 +56,8 @@ namespace mapviz
 {
   class MapvizPlugin : public QObject
   {
+    Q_OBJECT;
+
   public:
     virtual ~MapvizPlugin() {}
 


### PR DESCRIPTION
The MapvizPlugin class will now emit signals when any of the following settings change:
- Draw Order
- Target Frame
- Use Latest Transforms
- Visibility

Note that the signals will only be emitted if the setting actually *changes*, not
if it is somehow set to the same value that it was previously.