### PR TITLE
Ensuring that Mapviz won't subscribe to empty topic names (Jade)

### DIFF
--- a/mapviz_plugins/src/attitude_indicator_plugin.cpp
+++ b/mapviz_plugins/src/attitude_indicator_plugin.cpp
@@ -103,18 +103,22 @@ AttitudeIndicatorPlugin::~AttitudeIndicatorPlugin()
 
  void AttitudeIndicatorPlugin::TopicEdited()
  {
-     if (ui_.topic->text().toStdString() != topic_)
+     std::string topic = ui_.topic->text().trimmed().toStdString();
+     if (topic != topic_)
      {
        initialized_ = true;
        has_message_ = false;
-       topic_ = boost::trim_copy(ui_.topic->text().toStdString());
        PrintWarning("No messages received.");
 
        odometry_sub_.shutdown();
-       odometry_sub_ = node_.subscribe<topic_tools::ShapeShifter>(
-         topic_, 100, &AttitudeIndicatorPlugin::handleMessage, this);
 
-       ROS_INFO("Subscribing to %s", topic_.c_str());
+       if (!topic.empty()) {
+         topic_ = topic;
+         odometry_sub_ = node_.subscribe<topic_tools::ShapeShifter>(
+           topic_, 100, &AttitudeIndicatorPlugin::handleMessage, this);
+
+         ROS_INFO("Subscribing to %s", topic_.c_str());
+       }
      }
  }
  void AttitudeIndicatorPlugin::handleMessage(const topic_tools::ShapeShifter::ConstPtr& msg)

--- a/mapviz_plugins/src/disparity_plugin.cpp
+++ b/mapviz_plugins/src/disparity_plugin.cpp
@@ -181,17 +181,34 @@ namespace mapviz_plugins
 
   void DisparityPlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if(!this->Visible())
+    {
+      PrintWarning("Topic is Hidden");
+      initialized_ = false;
+      has_message_ = false;
+      if (!topic.empty())
+      {
+        topic_ = topic;
+      }
+      disparity_sub_.shutdown();
+      return;
+    }
+    if (topic != topic_)
     {
       initialized_ = false;
       has_message_ = false;
-      topic_ = ui_.topic->text().toStdString();
+      topic_ = topic;
       PrintWarning("No messages received.");
 
       disparity_sub_.shutdown();
-      disparity_sub_ = node_.subscribe(topic_, 1, &DisparityPlugin::disparityCallback, this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      if (!topic.empty())
+      {
+        disparity_sub_ = node_.subscribe(topic_, 1, &DisparityPlugin::disparityCallback, this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -204,34 +204,35 @@ namespace mapviz_plugins
 
   void ImagePlugin::TopicEdited()
   {
-
+    std::string topic = ui_.topic->text().trimmed().toStdString();
     if(!this->Visible())
     {
       PrintWarning("Topic is Hidden");
       initialized_ = false;
       has_message_ = false;
-      topic_ = ui_.topic->text().toStdString();
+      if (!topic.empty())
+      {
+        topic_ = topic;
+      }
       image_sub_.shutdown();
       return;
     }
-    if (ui_.topic->text().toStdString().empty())
-    {
-      PrintWarning("No topic");
-      image_sub_.shutdown();
-      return;
-    }
-    if (ui_.topic->text().toStdString() != topic_)
+    if (topic != topic_)
     {
       initialized_ = false;
       has_message_ = false;
-      topic_ = ui_.topic->text().toStdString();
+      topic_ = topic;
       PrintWarning("No messages received.");
 
       image_sub_.shutdown();
-      image_transport::ImageTransport it(node_);
-      image_sub_ = it.subscribe(topic_, 1, &ImagePlugin::imageCallback, this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      if (!topic_.empty())
+      {
+        image_transport::ImageTransport it(node_);
+        image_sub_ = it.subscribe(topic_, 1, &ImagePlugin::imageCallback, this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -271,21 +271,26 @@ namespace mapviz_plugins
 
   void LaserScanPlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       initialized_ = false;
       scans_.clear();
       has_message_ = false;
-      topic_ = boost::trim_copy(ui_.topic->text().toStdString());
       PrintWarning("No messages received.");
 
       laserscan_sub_.shutdown();
-      laserscan_sub_ = node_.subscribe(topic_,
-          100,
-          &LaserScanPlugin::laserScanCallback,
-          this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      topic_ = topic;
+      if (!topic.empty())
+      {
+        laserscan_sub_ = node_.subscribe(topic_,
+                                         100,
+                                         &LaserScanPlugin::laserScanCallback,
+                                         this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -103,21 +103,25 @@ namespace mapviz_plugins
 
   void MarkerPlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       initialized_ = false;
       markers_.clear();
       has_message_ = false;
-      topic_ = boost::trim_copy(ui_.topic->text().toStdString());
       PrintWarning("No messages received.");
 
       marker_sub_.shutdown();
-      
       connected_ = false;
-      marker_sub_ = node_.subscribe<topic_tools::ShapeShifter>(
-        topic_, 100, &MarkerPlugin::handleMessage, this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      topic_ = topic;
+      if (!topic.empty())
+      {
+        marker_sub_ = node_.subscribe<topic_tools::ShapeShifter>(
+            topic_, 100, &MarkerPlugin::handleMessage, this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 
@@ -589,9 +593,12 @@ namespace mapviz_plugins
   {
     bool new_connected = (marker_sub_.getNumPublishers() > 0);
     if (connected_ && !new_connected) {
-      marker_sub_.shutdown();      
-      marker_sub_ = node_.subscribe<topic_tools::ShapeShifter>(
-        topic_, 100, &MarkerPlugin::handleMessage, this);
+      marker_sub_.shutdown();
+      if (!topic_.empty())
+      {
+        marker_sub_ = node_.subscribe<topic_tools::ShapeShifter>(
+            topic_, 100, &MarkerPlugin::handleMessage, this);
+      }
     }
     connected_ = new_connected;
   }

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -137,18 +137,23 @@ namespace mapviz_plugins
 
   void NavSatPlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       initialized_ = false;
       points_.clear();
       has_message_ = false;
-      topic_ = ui_.topic->text().toStdString();
       PrintWarning("No messages received.");
 
       navsat_sub_.shutdown();
-      navsat_sub_ = node_.subscribe(topic_, 1, &NavSatPlugin::NavSatFixCallback, this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      topic_ = topic;
+      if (!topic.empty())
+      {
+        navsat_sub_ = node_.subscribe(topic_, 1, &NavSatPlugin::NavSatFixCallback, this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -161,18 +161,23 @@ namespace mapviz_plugins
 
   void OdometryPlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       initialized_ = false;
       points_.clear();
       has_message_ = false;
-      topic_ = ui_.topic->text().toStdString();
       PrintWarning("No messages received.");
 
       odometry_sub_.shutdown();
-      odometry_sub_ = node_.subscribe(topic_, 1, &OdometryPlugin::odometryCallback, this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      topic_ = topic;
+      if (!topic.empty())
+      {
+        odometry_sub_ = node_.subscribe(topic_, 1, &OdometryPlugin::odometryCallback, this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -119,19 +119,24 @@ namespace mapviz_plugins
 
   void PathPlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       initialized_ = false;
       points_.clear();
       transformed_points_.clear();
       has_message_ = false;
-      topic_ = ui_.topic->text().toStdString();
       PrintWarning("No messages received.");
 
       path_sub_.shutdown();
-      path_sub_ = node_.subscribe(topic_, 1, &PathPlugin::pathCallback, this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      topic_ = topic;
+      if (!topic.empty())
+      {
+        path_sub_ = node_.subscribe(topic_, 1, &PathPlugin::pathCallback, this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -311,7 +311,8 @@ namespace mapviz_plugins
 
   void PointCloud2Plugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       initialized_ = false;
       {
@@ -319,19 +320,23 @@ namespace mapviz_plugins
         scans_.clear();
       }
       has_message_ = false;
-      topic_ = boost::trim_copy(ui_.topic->text().toStdString());
       PrintWarning("No messages received.");
 
       pc2_sub_.shutdown();
-      pc2_sub_ = node_.subscribe(topic_,
-                                 100,
-                                 &PointCloud2Plugin::PointCloud2Callback,
-                                 this);
-      new_topic_ = true;
-      need_new_list_ = true;
-      max_.clear();
-      min_.clear();
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+
+      topic_ = topic;
+      if (!topic.empty())
+      {
+        pc2_sub_ = node_.subscribe(topic_,
+                                   100,
+                                   &PointCloud2Plugin::PointCloud2Callback,
+                                   this);
+        new_topic_ = true;
+        need_new_list_ = true;
+        max_.clear();
+        min_.clear();
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/route_plugin.cpp
+++ b/mapviz_plugins/src/route_plugin.cpp
@@ -165,31 +165,41 @@ namespace mapviz_plugins
 
   void RoutePlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       src_route_ = sru::Route();
-      topic_ = ui_.topic->text().toStdString();
 
       route_sub_.shutdown();
-      route_sub_ =
-          node_.subscribe(topic_, 1, &RoutePlugin::RouteCallback, this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      topic_ = topic;
+      if (!topic.empty())
+      {
+        route_sub_ =
+            node_.subscribe(topic_, 1, &RoutePlugin::RouteCallback, this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 
   void RoutePlugin::PositionTopicEdited()
   {
-    if (ui_.positiontopic->text().toStdString() != position_topic_)
+    std::string topic = ui_.positiontopic->text().trimmed().toStdString();
+    if (topic != position_topic_)
     {
       src_route_position_.reset();
       
-      position_topic_ = ui_.positiontopic->text().toStdString();
       position_sub_.shutdown();
-      position_sub_ = node_.subscribe(position_topic_, 1,
-                                      &RoutePlugin::PositionCallback, this);
 
-      ROS_INFO("Subscribing to %s", position_topic_.c_str());
+      if (!topic.empty())
+      {
+        position_topic_ = topic;
+        position_sub_ = node_.subscribe(position_topic_, 1,
+                                        &RoutePlugin::PositionCallback, this);
+
+        ROS_INFO("Subscribing to %s", position_topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/string_plugin.cpp
+++ b/mapviz_plugins/src/string_plugin.cpp
@@ -330,17 +330,22 @@ namespace mapviz_plugins
 
   void StringPlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       initialized_ = false;
       has_message_ = false;
-      topic_ = ui_.topic->text().toStdString();
       PrintWarning("No messages received.");
 
       string_sub_.shutdown();
-      string_sub_ = node_.subscribe(topic_, 1, &StringPlugin::stringCallback, this);
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+      topic_ = topic;
+      if (!topic.empty())
+      {
+        string_sub_ = node_.subscribe(topic_, 1, &StringPlugin::stringCallback, this);
+
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 

--- a/mapviz_plugins/src/textured_marker_plugin.cpp
+++ b/mapviz_plugins/src/textured_marker_plugin.cpp
@@ -117,26 +117,30 @@ namespace mapviz_plugins
 
   void TexturedMarkerPlugin::TopicEdited()
   {
-    if (ui_.topic->text().toStdString() != topic_)
+    std::string topic = ui_.topic->text().trimmed().toStdString();
+    if (topic != topic_)
     {
       initialized_ = false;
       markers_.clear();
       has_message_ = false;
-      topic_ = boost::trim_copy(ui_.topic->text().toStdString());
       PrintWarning("No messages received.");
 
       marker_sub_.shutdown();
 
-      if (is_marker_array_)
+      topic_ = topic;
+      if (!topic.empty())
       {
-        marker_sub_ = node_.subscribe(topic_, 1000, &TexturedMarkerPlugin::MarkerArrayCallback, this);
-      }
-      else
-      {
-        marker_sub_ = node_.subscribe(topic_, 1000, &TexturedMarkerPlugin::MarkerCallback, this);
-      }
+        if (is_marker_array_)
+        {
+          marker_sub_ = node_.subscribe(topic_, 1000, &TexturedMarkerPlugin::MarkerArrayCallback, this);
+        }
+        else
+        {
+          marker_sub_ = node_.subscribe(topic_, 1000, &TexturedMarkerPlugin::MarkerCallback, this);
+        }
 
-      ROS_INFO("Subscribing to %s", topic_.c_str());
+        ROS_INFO("Subscribing to %s", topic_.c_str());
+      }
     }
   }
 


### PR DESCRIPTION
I cleaned up and made more consistent the code for handling subscriptions for all topics.
The behavior is now:
- All input is trimmed before processing
- If a topic name is empty, the old subscriber will be shut down and will not subscribe to the empty topic

I also cleaned up and reformatted the code in the Attitude Indicator plugin because it was pretty messy.

Resolves #327