### PR TITLE
Adding a way for plugin config widgets to resize (Indigo)

### DIFF
--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -257,6 +257,7 @@ namespace mapviz
 
   Q_SIGNALS:
     void DrawOrderChanged(int draw_order);
+    void SizeChanged();
     void TargetFrameChanged(const std::string& target_frame);
     void UseLatestTransformsChanged(bool use_latest_transforms);
     void VisibleChanged(bool visible);

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -56,12 +56,14 @@
 #include <QMessageBox>
 #include <QProcessEnvironment>
 #include <QFileInfo>
+#include <QListWidgetItem>
 
 #include <swri_math_util/constants.h>
 #include <swri_transform_util/frames.h>
 #include <swri_yaml_util/yaml_util.h>
 
 #include <mapviz/config_item.h>
+#include <QtGui/QtGui>
 
 namespace mapviz
 {
@@ -1058,6 +1060,7 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
   connect(config_item, SIGNAL(UpdateSizeHint()), this, SLOT(UpdateSizeHints()));
   connect(config_item, SIGNAL(ToggledDraw(QListWidgetItem*, bool)), this, SLOT(ToggleShowPlugin(QListWidgetItem*, bool)));
   connect(plugin.get(), SIGNAL(VisibleChanged(bool)), config_item, SLOT(ToggleDraw(bool)));
+  connect(plugin.get(), SIGNAL(SizeChanged()), this, SLOT(UpdateSizeHints()));
 
   if (draw_order == 0)
   {
@@ -1295,10 +1298,16 @@ void Mapviz::Screenshot()
 
 void Mapviz::UpdateSizeHints()
 {
-  ROS_INFO("Updating size hints");
   for (int i = 0; i < ui_.configs->count(); i++)
   {
-    ui_.configs->item(i)->setSizeHint(ui_.configs->itemWidget(ui_.configs->item(i))->sizeHint());
+    QListWidgetItem* item = ui_.configs->item(i);
+    ConfigItem* widget = static_cast<ConfigItem*>(ui_.configs->itemWidget(item));
+    if (widget) {
+      // Make sure the ConfigItem in the QListWidgetItem we're getting really
+      // exists; if this method is called before it's been initialized, it would
+      // cause a crash.
+      item->setSizeHint(widget->sizeHint());
+    }
   }
 }
 

--- a/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.h
@@ -123,6 +123,7 @@ namespace mapviz_plugins
       double PointFeature(const uint8_t*, const Field_info&);
       void PointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr& scan);
       QColor CalculateColor(const StampedPoint& point);
+      void UpdateMinMaxWidgets();
 
       Ui::PointCloud2_config ui_;
       QWidget* config_widget_;

--- a/mapviz_plugins/src/pointcloud2_config.ui
+++ b/mapviz_plugins/src/pointcloud2_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>425</height>
+    <width>306</width>
+    <height>341</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,22 +17,13 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>2</number>
-   </property>
-   <property name="topMargin">
-    <number>2</number>
-   </property>
-   <property name="rightMargin">
-    <number>2</number>
-   </property>
-   <property name="bottomMargin">
-    <number>2</number>
-   </property>
    <property name="verticalSpacing">
     <number>4</number>
    </property>
-   <item row="15" column="0">
+   <property name="margin">
+    <number>2</number>
+   </property>
+   <item row="14" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -45,7 +36,7 @@
      </property>
     </widget>
    </item>
-   <item row="15" column="2" colspan="3">
+   <item row="14" column="1" colspan="3">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -64,7 +55,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="4">
+   <item row="2" column="3">
     <widget class="QPushButton" name="selecttopic">
      <property name="maximumSize">
       <size>
@@ -86,7 +77,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="1">
     <widget class="QLineEdit" name="topic">
      <property name="font">
       <font>
@@ -109,56 +100,7 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="minValueLabel">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Min Value:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="2">
-    <widget class="QDoubleSpinBox" name="minValue">
-     <property name="minimum">
-      <double>-999999999.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>999999999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="maxValueLabel">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Max Value:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="2">
-    <widget class="QDoubleSpinBox" name="maxValue">
-     <property name="minimum">
-      <double>-999999999.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>999999999.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>100.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
+   <item row="3" column="1">
     <widget class="QSpinBox" name="bufferSize">
      <property name="maximum">
       <number>99999999</number>
@@ -168,7 +110,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
+   <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="alpha">
      <property name="maximum">
       <double>1.000000000000000</double>
@@ -194,7 +136,20 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="12" column="1">
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="1">
     <widget class="QComboBox" name="color_transformer"/>
    </item>
    <item row="4" column="0">
@@ -210,7 +165,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="4" column="1">
     <widget class="QSpinBox" name="pointSize">
      <property name="suffix">
       <string> pixel</string>
@@ -250,7 +205,7 @@
     </widget>
    </item>
    <item row="7" column="0">
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="color_label">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -262,11 +217,8 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="2" rowspan="4">
+   <item row="7" column="1" rowspan="4">
     <layout class="QVBoxLayout" name="verticalLayout_2">
-     <property name="spacing">
-      <number>15</number>
-     </property>
      <item>
       <widget class="QCheckBox" name="use_rainbow">
        <property name="font">
@@ -293,85 +245,160 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="spacing">
-        <number>9</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="minColorLabel">
-         <property name="font">
-          <font>
-           <family>Sans Serif</family>
-           <pointsize>8</pointsize>
-           <italic>false</italic>
-          </font>
-         </property>
-         <property name="text">
-          <string>Min:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="mapviz::ColorButton" name="min_color">
-         <property name="maximumSize">
-          <size>
-           <width>24</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="maxColorLabel">
-         <property name="font">
-          <font>
-           <family>Sans Serif</family>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>Max:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="mapviz::ColorButton" name="max_color">
-         <property name="maximumSize">
-          <size>
-           <width>24</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
+      <widget class="QWidget" name="min_max_color_widget" native="true">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="margin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="minColorLabel">
+          <property name="font">
+           <font>
+            <family>Sans Serif</family>
+            <pointsize>8</pointsize>
+            <italic>false</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Min:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="mapviz::ColorButton" name="min_color">
+          <property name="maximumSize">
+           <size>
+            <width>24</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="maxColorLabel">
+          <property name="font">
+           <font>
+            <family>Sans Serif</family>
+            <pointsize>8</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string>Max:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="mapviz::ColorButton" name="max_color">
+          <property name="maximumSize">
+           <size>
+            <width>24</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>4</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
      </item>
     </layout>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QWidget" name="min_max_value_widget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,1">
+      <property name="verticalSpacing">
+       <number>4</number>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="minValueLabel">
+        <property name="minimumSize">
+         <size>
+          <width>99</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <family>Sans Serif</family>
+          <pointsize>8</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>Min Value:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="maxValueLabel">
+        <property name="font">
+         <font>
+          <family>Sans Serif</family>
+          <pointsize>8</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>Max Value:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QDoubleSpinBox" name="minValue">
+        <property name="minimum">
+         <double>-999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QDoubleSpinBox" name="maxValue">
+        <property name="minimum">
+         <double>-999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>999999999.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>100.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -635,52 +635,19 @@ namespace mapviz_plugins
 
   void PointCloud2Plugin::UseRainbowChanged(int check_state)
   {
-    if (check_state == Qt::Checked)
-    {
-      ui_.max_color->setVisible(false);
-      ui_.min_color->setVisible(false);
-      ui_.maxColorLabel->setVisible(false);
-      ui_.minColorLabel->setVisible(false);
-    }
-    else
-    {
-      ui_.max_color->setVisible(true);
-      ui_.min_color->setVisible(true);
-      ui_.maxColorLabel->setVisible(true);
-      ui_.minColorLabel->setVisible(true);
-    }
+    UpdateMinMaxWidgets();
+
     UpdateColors();
   }
 
   void PointCloud2Plugin::UseAutomaxminChanged(int check_state)
   {
-    if (check_state == Qt::Checked)
-    {
-      ui_.max_color->setVisible(true);
-      ui_.min_color->setVisible(true);
-      ui_.maxColorLabel->setVisible(true);
-      ui_.minColorLabel->setVisible(true);
-      ui_.minValueLabel->setVisible(false);
-      ui_.maxValueLabel->setVisible(false);
-      ui_.minValue->setVisible(false);
-      ui_.maxValue->setVisible(false);
-
+    if (check_state == need_minmax_) {
       need_minmax_ = true;
-
     }
-    else
-    {
-      ui_.max_color->setVisible(true);
-      ui_.min_color->setVisible(true);
-      ui_.maxColorLabel->setVisible(true);
-      ui_.minColorLabel->setVisible(true);
-      ui_.minValueLabel->setVisible(true);
-      ui_.maxValueLabel->setVisible(true);
-      ui_.minValue->setVisible(true);
-      ui_.maxValue->setVisible(true);
 
-      need_minmax_ = false;
-    }
+    UpdateMinMaxWidgets();
+
     UpdateColors();
   }
 
@@ -811,33 +778,39 @@ namespace mapviz_plugins
   void PointCloud2Plugin::ColorTransformerChanged(int index)
   {
     ROS_DEBUG("Color transformer changed to %d", index);
-    switch (index)
-    {
-      case COLOR_FLAT:
-        ui_.min_color->setVisible(true);
-        ui_.max_color->setVisible(false);
-        ui_.maxColorLabel->setVisible(false);
-        ui_.minColorLabel->setVisible(false);
-        ui_.minValueLabel->setVisible(false);
-        ui_.maxValueLabel->setVisible(false);
-        ui_.minValue->setVisible(false);
-        ui_.maxValue->setVisible(false);
-        ui_.use_rainbow->setVisible(true);
-        ui_.use_automaxmin->setVisible(true);
-        break;
-      default:
-        ui_.min_color->setVisible(!ui_.use_rainbow->isChecked());
-        ui_.max_color->setVisible(!ui_.use_rainbow->isChecked());
-        ui_.maxColorLabel->setVisible(!ui_.use_rainbow->isChecked());
-        ui_.minColorLabel->setVisible(!ui_.use_rainbow->isChecked());
-        ui_.minValueLabel->setVisible(true);
-        ui_.maxValueLabel->setVisible(true);
-        ui_.minValue->setVisible(true);
-        ui_.maxValue->setVisible(true);
-        ui_.use_rainbow->setVisible(true);
-        ui_.use_automaxmin->setVisible(true);
-    }
+    UpdateMinMaxWidgets();
     UpdateColors();
+  }
+
+  void PointCloud2Plugin::UpdateMinMaxWidgets()
+  {
+    bool color_is_flat = ui_.color_transformer->currentIndex() == COLOR_FLAT;
+
+    if (color_is_flat) 
+    {
+      ui_.maxColorLabel->hide();
+      ui_.max_color->hide();
+      ui_.minColorLabel->hide();
+      ui_.min_max_color_widget->show();
+      ui_.min_max_value_widget->hide();
+      ui_.use_automaxmin->hide();
+      ui_.use_rainbow->hide();
+    }
+    else
+    {
+      ui_.maxColorLabel->show();
+      ui_.max_color->show();
+      ui_.minColorLabel->show();
+      ui_.min_max_color_widget->setVisible(!ui_.use_rainbow->isChecked());
+      ui_.min_max_value_widget->setVisible(!ui_.use_automaxmin->isChecked());
+      ui_.use_automaxmin->show();
+      ui_.use_rainbow->show();
+    }
+
+    config_widget_->updateGeometry();
+    config_widget_->adjustSize();
+
+    Q_EMIT SizeChanged();
   }
 
   /**


### PR DESCRIPTION
- Adding an event plugins can emit to indicate their geometry has changed
- Modifying the PCL2 plugin to use it as an example

Fixes #393 

Here's an example of what the PCL2 plugin looks like after my fix.  Compare it to the screenshot in the original issue.
![mapviz-393-fix](https://cloud.githubusercontent.com/assets/12546134/16622933/88805bfa-4361-11e6-9118-81fb10c60f58.png)
