### PR TITLE
Fix compiler warning in mapviz widgets.h

### DIFF
--- a/mapviz/include/mapviz/widgets.h
+++ b/mapviz/include/mapviz/widgets.h
@@ -52,7 +52,7 @@ namespace mapviz
     
     void UpdateIndices()
     {
-      for (size_t i = 0; i < count(); i++)
+      for (int i = 0; i < count(); i++)
       {
         item(i)->setData(Qt::UserRole, QVariant((float)i));
       }


### PR DESCRIPTION
QListWidget::count() returns an int, so comparing it to a size_t causes a sign-compare warning.