### PR TITLE
Giving tile_map an interface overhaul (Kinetic)

### DIFF
--- a/mapviz/launch/mapviz.launch
+++ b/mapviz/launch/mapviz.launch
@@ -2,7 +2,7 @@
 
   <env name="ROSCONSOLE_FORMAT" value="[${thread}] [${node}/${function}:${line}]: ${message}"/>
 
-  <node pkg="mapviz" type="mapviz" name="$(anon mapviz)"/>
+  <node pkg="mapviz" type="mapviz" name="$(anon mapviz)" required="true"/>
 
   <node pkg="swri_transform_util" type="initialize_origin.py" name="initialize_origin" >
     <param name="local_xy_frame" value="/far_field"/>

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -61,15 +61,18 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 file (GLOB TILE_SRC_FILES 
-   src/image_cache.cpp
-   src/texture_cache.cpp
-   src/tile_map_view.cpp)
+  src/image_cache.cpp
+  src/texture_cache.cpp
+  src/tile_map_view.cpp)
 qt5_wrap_cpp(TILE_SRC_FILES include/tile_map/image_cache.h)
 add_library(${PROJECT_NAME} ${TILE_SRC_FILES})
 target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${QT_QTOPENGL_LIBRARIES} ${GLU_LIBRARY} ${catkin_LIBRARIES})
 
-file (GLOB PLUGIN_SRC_FILES src/tile_map_plugin.cpp)
-file (GLOB PLUGIN_UI_FILES src/*.ui)
+file (GLOB PLUGIN_SRC_FILES
+  src/tile_map_plugin.cpp
+  src/tile_source.cpp)
+file (GLOB PLUGIN_UI_FILES
+  src/tile_map_config.ui)
 qt5_wrap_ui(PLUGIN_SRC_FILES ${PLUGIN_UI_FILES})
 qt5_wrap_cpp(PLUGIN_SRC_FILES include/tile_map/tile_map_plugin.h)
 

--- a/tile_map/include/tile_map/image_cache.h
+++ b/tile_map/include/tile_map/image_cache.h
@@ -99,6 +99,7 @@ namespace tile_map
     void ProcessRequest(QString uri);
     void ProcessReply(QNetworkReply* reply);
     void NetworkError(QNetworkReply::NetworkError error);
+    void Clear();
   
   private:
     QNetworkAccessManager network_manager_;

--- a/tile_map/include/tile_map/texture_cache.h
+++ b/tile_map/include/tile_map/texture_cache.h
@@ -56,6 +56,8 @@ namespace tile_map
 
     TexturePtr GetTexture(size_t url_hash, const std::string& url, bool& failed);
     void AddTexture(const TexturePtr& texture);
+
+    void Clear();
     
   private:
     QCache<size_t, TexturePtr> cache_;

--- a/tile_map/include/tile_map/tile_map_plugin.h
+++ b/tile_map/include/tile_map/tile_map_plugin.h
@@ -32,6 +32,7 @@
 
 // C++ standard libraries
 #include <string>
+#include <map>
 
 // Boost libraries
 #include <boost/filesystem.hpp>
@@ -51,6 +52,8 @@
 
 namespace tile_map
 {
+  class TileSource;
+
   class TileMapPlugin : public mapviz::MapvizPlugin
   {
     Q_OBJECT
@@ -77,9 +80,16 @@ namespace tile_map
     void PrintWarning(const std::string& message);
 
   protected Q_SLOTS:
-    void SelectSource(QString style);
+    void DeleteTileSource();
+    void SelectSource(QString source_name);
+    void SaveCustomSource();
+    void ResetTileCache();
 
   private:
+    void selectTileSource(const TileSource& tile_source);
+    void startCustomEditing();
+    void stopCustomEditing();
+
     Ui::tile_map_config ui_;
     QWidget* config_widget_;
 
@@ -89,6 +99,18 @@ namespace tile_map
     bool transformed_;
     
     TileMapView tile_map_;
+    std::map<QString, TileSource> tile_sources_;
+
+    static std::string BASE_URL_KEY;
+    static std::string COORD_ORDER_KEY;
+    static std::string CUSTOM_SOURCES_KEY;
+    static std::string MAX_ZOOM_KEY;
+    static std::string NAME_KEY;
+    static std::string SOURCE_KEY;
+    static std::string SUFFIX_KEY;
+    static QString STAMEN_TERRAIN_NAME;
+    static QString STAMEN_TONER_NAME;
+    static QString STAMEN_WATERCOLOR_NAME;
   };
 }
 

--- a/tile_map/include/tile_map/tile_map_view.h
+++ b/tile_map/include/tile_map/tile_map_view.h
@@ -36,10 +36,14 @@
 
 #include <tile_map/texture_cache.h>
 
+#include <tile_map/tile_source.h>
+
 #include <swri_transform_util/transform.h>
 
 namespace tile_map
 {
+  class TileSource;
+
   struct Tile
   {
   public:
@@ -59,13 +63,11 @@ namespace tile_map
   {
   public:
     TileMapView();
-    
-    void SetBaseUrl(const std::string& url);
-    
-    void SetMaxLevel(int32_t level);
-    
-    void SetExtension(const std::string& extension);
-    
+
+    void ResetCache();
+
+    void SetTileSource(const TileSource& tile_source);
+
     void SetTransform(const swri_transform_util::Transform& transform);
     
     void SetView(
@@ -78,13 +80,9 @@ namespace tile_map
     void Draw();
     
   private:
-    std::string base_url_;
-    
-    std::string extension_;
-    
+    TileSource tile_source_;
+
     swri_transform_util::Transform transform_;
-    
-    int32_t max_level_;
     
     int32_t level_;
     

--- a/tile_map/include/tile_map/tile_source.h
+++ b/tile_map/include/tile_map/tile_source.h
@@ -1,0 +1,109 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef TILE_MAP_TILE_SOURCE_H
+#define TILE_MAP_TILE_SOURCE_H
+
+#include <QString>
+
+namespace tile_map
+{
+  /**
+   * Represents a network source for map tiles; contains information about how to
+   * connect to the source and how to retrieve tiles from it.
+   *
+   * Currently this implementation is fairly WMTS-centric, but there's no reason
+   * this couldn't be made a bit more generate for supporting other service formats
+   * in the future.
+   */
+  class TileSource
+  {
+  public:
+    enum COORD_ORDER
+    {
+      // The order of the listing here should match the order listed
+      // in the combo box in tile_map_config.ui
+      ZXY,
+      ZYX,
+      XYZ,
+      XZY,
+      YXZ,
+      YZX
+    };
+
+    TileSource();
+
+    TileSource(const QString& name,
+               const QString& base_url,
+               COORD_ORDER coord_order,
+               bool is_custom,
+               int32_t max_zoom,
+               const QString& suffix
+               );
+
+    TileSource(const TileSource& tile_source);
+
+    const QString& GetBaseUrl() const;
+
+    void SetBaseUrl(const QString& base_url);
+
+    COORD_ORDER GetCoordOrder() const;
+
+    void SetCoordOrder(COORD_ORDER coord_order);
+
+    bool IsCustom() const;
+
+    void SetCustom(bool is_custom);
+
+    int32_t GetMaxZoom() const;
+
+    void SetMaxZoom(int32_t max_zoom);
+
+    const QString& GetName() const;
+
+    void SetName(const QString& name);
+
+    const QString& GetSuffix() const;
+
+    void SetSuffix(const QString& suffix);
+
+    std::string GenerateTileUrl(int32_t level, int64_t x, int64_t y) const;
+
+  private:
+    QString base_url_;
+    COORD_ORDER coord_order_;
+    bool is_custom_;
+    int32_t max_zoom_;
+    QString name_;
+    QString suffix_;
+  };
+}
+
+#endif //TILE_MAP_TILE_SOURCE_H

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -104,6 +104,12 @@ namespace tile_map
     delete cache_thread_;
   }
 
+  void ImageCache::Clear()
+  {
+    cache_.clear();
+    network_manager_.cache()->clear();
+  }
+
   ImagePtr ImageCache::GetImage(size_t uri_hash, const std::string& uri, int32_t priority)
   {
     ImagePtr image;
@@ -160,11 +166,15 @@ namespace tile_map
     request.setUrl(QUrl(uri));
     request.setRawHeader("User-Agent", "mapviz-1.0");
     request.setAttribute(
-    QNetworkRequest::CacheLoadControlAttribute,
-    QNetworkRequest::PreferCache);
+        QNetworkRequest::CacheLoadControlAttribute,
+        QNetworkRequest::PreferCache);
+    request.setAttribute(
+        QNetworkRequest::HttpPipeliningAllowedAttribute,
+        true);
         
     QNetworkReply *reply = network_manager_.get(request);
-    connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(NetworkError(QNetworkReply::NetworkError)));
+    connect(reply, SIGNAL(error(QNetworkReply::NetworkError)),
+            this, SLOT(NetworkError(QNetworkReply::NetworkError)));
   } 
   
   void ImageCache::ProcessReply(QNetworkReply* reply)

--- a/tile_map/src/texture_cache.cpp
+++ b/tile_map/src/texture_cache.cpp
@@ -159,4 +159,10 @@ namespace tile_map
       cache_.insert(texture->url_hash, texture_ptr);
     }
   }
+
+  void TextureCache::Clear()
+  {
+    image_cache_->Clear();
+    cache_.clear();
+  }
 }

--- a/tile_map/src/tile_map_config.ui
+++ b/tile_map/src/tile_map_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>395</width>
-    <height>300</height>
+    <width>294</width>
+    <height>178</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,6 +24,149 @@
     <number>2</number>
    </property>
    <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Base URL:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Source:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="QComboBox" name="coord_order_combo_box">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>z/x/y</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>z/y/x</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>x/y/z</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>x/z/y</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>y/x/z</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>y/z/x</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Coord order:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Max Zoom:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Suffix:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="suffix_text">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>50</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>.jpg</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="3">
+    <widget class="QComboBox" name="source_combo">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>27</height>
+      </size>
+     </property>
+     <property name="editable">
+      <bool>false</bool>
+     </property>
+     <item>
+      <property name="text">
+       <string>Stamen (terrain)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Stamen (watercolor)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Stamen (toner)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Custom...</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="3">
+    <widget class="QLineEdit" name="base_url_text">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>http://tile.stamen.com/terrain/</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -36,7 +179,36 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="3">
+   <item row="5" column="1">
+    <widget class="QSpinBox" name="max_zoom_spin_box">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>50</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="value">
+      <number>15</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="3">
+    <widget class="QPushButton" name="reset_cache_button">
+     <property name="text">
+      <string>Reset Cache</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1" colspan="3">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -55,49 +227,24 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
+   <item row="5" column="2">
+    <widget class="QPushButton" name="save_button">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
      <property name="text">
-      <string>Source:</string>
+      <string>Save...</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="3">
-    <widget class="QComboBox" name="source_combo">
-     <property name="editable">
-      <bool>true</bool>
+   <item row="5" column="3">
+    <widget class="QPushButton" name="delete_button">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
-     <item>
-      <property name="text">
-       <string>MapQuest (satellite)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>MapQuest (roads)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Stamen (watercolor)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Stamen (terrain)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Stamen (toner)</string>
-      </property>
-     </item>
+     <property name="text">
+      <string>Delete</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/tile_map/src/tile_map_plugin.cpp
+++ b/tile_map/src/tile_map_plugin.cpp
@@ -28,9 +28,12 @@
 // *****************************************************************************
 
 #include <tile_map/tile_map_plugin.h>
+#include <tile_map/tile_source.h>
 
 // QT libraries
 #include <QGLWidget>
+#include <QInputDialog>
+#include <QMessageBox>
 #include <QPalette>
 
 // ROS libraries
@@ -46,11 +49,41 @@ PLUGINLIB_DECLARE_CLASS(mapviz_plugins, tile_map, tile_map::TileMapPlugin, mapvi
 
 namespace tile_map
 {
+  std::string TileMapPlugin::BASE_URL_KEY = "base_url";
+  std::string TileMapPlugin::COORD_ORDER_KEY = "coord_order";
+  std::string TileMapPlugin::CUSTOM_SOURCES_KEY = "custom_sources";
+  std::string TileMapPlugin::MAX_ZOOM_KEY = "max_zoom";
+  std::string TileMapPlugin::NAME_KEY = "name";
+  std::string TileMapPlugin::SOURCE_KEY = "source";
+  std::string TileMapPlugin::SUFFIX_KEY = "suffix";
+  QString TileMapPlugin::STAMEN_TERRAIN_NAME = "Stamen (terrain)";
+  QString TileMapPlugin::STAMEN_TONER_NAME = "Stamen (toner)";
+  QString TileMapPlugin::STAMEN_WATERCOLOR_NAME = "Stamen (watercolor)";
+
   TileMapPlugin::TileMapPlugin() :
     config_widget_(new QWidget()),
     transformed_(false)
   {
     ui_.setupUi(config_widget_);
+
+    tile_sources_[STAMEN_TERRAIN_NAME] = TileSource(STAMEN_TERRAIN_NAME,
+                                                    "http://tile.stamen.com/terrain/",
+                                                    TileSource::ZXY,
+                                                    false,
+                                                    15,
+                                                    ".png");
+    tile_sources_[STAMEN_TONER_NAME] = TileSource(STAMEN_TONER_NAME,
+                                                  "http://tile.stamen.com/toner/",
+                                                  TileSource::ZXY,
+                                                  false,
+                                                  19,
+                                                  ".png");
+    tile_sources_[STAMEN_WATERCOLOR_NAME] = TileSource(STAMEN_WATERCOLOR_NAME,
+                                                       "http://tile.stamen.com/watercolor/",
+                                                       TileSource::ZXY,
+                                                       false,
+                                                       19,
+                                                       ".jpg");
 
     QPalette p(config_widget_->palette());
     p.setColor(QPalette::Background, Qt::white);
@@ -61,57 +94,109 @@ namespace tile_map
     ui_.status->setPalette(p2);
 
     source_frame_ = swri_transform_util::_wgs84_frame;
-    
+
+    QObject::connect(ui_.delete_button, SIGNAL(clicked()), this, SLOT(DeleteTileSource()));
     QObject::connect(ui_.source_combo, SIGNAL(activated(QString)), this, SLOT(SelectSource(QString)));
+    QObject::connect(ui_.save_button, SIGNAL(clicked()), this, SLOT(SaveCustomSource()));
+    QObject::connect(ui_.reset_cache_button, SIGNAL(clicked()), this, SLOT(ResetTileCache()));
   }
 
   TileMapPlugin::~TileMapPlugin()
   {
   }
 
+  void TileMapPlugin::DeleteTileSource()
+  {
+    int source_index = ui_.source_combo->currentIndex();
+    QString current_name = ui_.source_combo->currentText();
+
+    QMessageBox mbox;
+    mbox.setText("Are you sure you want to delete the source \"" + current_name + "\"?");
+    mbox.setIcon(QMessageBox::Warning);
+    mbox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+    mbox.setDefaultButton(QMessageBox::Cancel);
+    int ret = mbox.exec();
+
+    if (ret == QMessageBox::Ok)
+    {
+      ui_.source_combo->removeItem(source_index);
+      tile_sources_.erase(current_name);
+      ui_.source_combo->setCurrentIndex(0);
+      SelectSource(ui_.source_combo->currentText());
+    }
+  }
+
   void TileMapPlugin::SelectSource(QString source)
   {
-    if (source == "MapQuest (satellite)")
+    if (source == STAMEN_TERRAIN_NAME ||
+        source == STAMEN_WATERCOLOR_NAME ||
+        source == STAMEN_TONER_NAME)
     {
-      tile_map_.SetBaseUrl("http://otile1.mqcdn.com/tiles/1.0.0/sat/");
-      tile_map_.SetExtension(".jpg");
-      tile_map_.SetMaxLevel(18);
-    }
-    else if (source == "MapQuest (roads)")
-    {
-      tile_map_.SetBaseUrl("http://otile1.mqcdn.com/tiles/1.0.0/map/");
-      tile_map_.SetExtension(".jpg");
-      tile_map_.SetMaxLevel(19);
-    }
-    else if (source == "Stamen (watercolor)")
-    {
-      tile_map_.SetBaseUrl("http://tile.stamen.com/watercolor/");
-      tile_map_.SetExtension(".jpg");
-      tile_map_.SetMaxLevel(19);
-      
-    }
-    else if (source == "Stamen (terrain)")
-    {
-      tile_map_.SetBaseUrl("http://tile.stamen.com/terrain/");
-      tile_map_.SetExtension(".jpg");
-      tile_map_.SetMaxLevel(15);
-    }
-    else if (source == "Stamen (toner)")
-    {
-      tile_map_.SetBaseUrl("http://tile.stamen.com/toner/");
-      tile_map_.SetExtension(".png");
-      tile_map_.SetMaxLevel(19);
+      stopCustomEditing();
     }
     else
     {
-      tile_map_.SetBaseUrl(source.toStdString());
-      tile_map_.SetExtension(".jpg");
-      tile_map_.SetMaxLevel(19);
+      startCustomEditing();
     }
 
-    initialized_ = true;
+    if (tile_sources_.find(source) != tile_sources_.end())
+    {
+      selectTileSource(tile_sources_[source]);
+      initialized_ = true;
+    }
+    else
+    {
+      ui_.delete_button->setEnabled(false);
+    }
+  }
 
-    canvas_->update();
+  void TileMapPlugin::SaveCustomSource()
+  {
+    // If the user is editing a custom source, we want to fill in the default
+    // name for it with its current name.
+    // Otherwise, they're creating a new custom source, in which case we
+    // should leave the default blank.
+    QString current_source = ui_.source_combo->currentText();
+    QString default_name = "";
+    if (tile_sources_.find(current_source) != tile_sources_.end())
+    {
+      if (tile_sources_[current_source].IsCustom())
+      {
+        default_name = current_source;
+      }
+    }
+    bool ok;
+    QString name = QInputDialog::getText(config_widget_,
+                                         tr("Save New Tile Source"),
+                                         tr("Tile Source Name:"),
+                                         QLineEdit::Normal,
+                                         default_name,
+                                         &ok);
+    name = name.trimmed();
+    if (ok && !name.isEmpty())
+    {
+      TileSource source(name,
+                        ui_.base_url_text->text(),
+                        static_cast<TileSource::COORD_ORDER>(ui_.coord_order_combo_box->currentIndex()),
+                        true,
+                        ui_.max_zoom_spin_box->value(),
+                        ui_.suffix_text->text());
+      int existing_index = ui_.source_combo->findText(name);
+      if (existing_index != -1)
+      {
+        ui_.source_combo->removeItem(existing_index);
+      }
+      tile_sources_[name] = source;
+      ui_.source_combo->addItem(name);
+      int new_index = ui_.source_combo->findText(name);
+      ui_.source_combo->setCurrentIndex(new_index);
+      SelectSource(name);
+    }
+  }
+
+  void TileMapPlugin::ResetTileCache()
+  {
+    tile_map_.ResetCache();
   }
 
   void TileMapPlugin::PrintError(const std::string& message)
@@ -161,18 +246,16 @@ namespace tile_map
   {
     canvas_ = canvas;
 
-    SelectSource("MapQuest (satellite)");
+    SelectSource(STAMEN_TERRAIN_NAME);
 
     return true;
   }
 
   void TileMapPlugin::Draw(double x, double y, double scale)
   {
-    //ROS_ERROR("Draw(%lf, %lf, %lf)", x, y, scale);
     swri_transform_util::Transform to_wgs84;
     if (tf_manager_.GetTransform(source_frame_, target_frame_, to_wgs84))
     {
-      //ROS_ERROR("%s -> %s", target_frame_.c_str(), source_frame_.c_str());
       tf::Vector3 center(x, y, 0);
       center = to_wgs84 * center;
       tile_map_.SetView(center.y(), center.x(), scale, canvas_->width(), canvas_->height());
@@ -196,29 +279,30 @@ namespace tile_map
 
   void TileMapPlugin::LoadConfig(const YAML::Node& node, const std::string& path)
   {
-    if (swri_yaml_util::FindValue(node, "custom_sources"))
+    if (swri_yaml_util::FindValue(node, CUSTOM_SOURCES_KEY))
     {
-      const YAML::Node& sources = node["custom_sources"];
-      for (uint32_t i = 0; i < sources.size(); i++)
+      const YAML::Node& sources = node[CUSTOM_SOURCES_KEY];
+      YAML::Node::const_iterator source_iter;
+      for (source_iter = sources.begin(); source_iter != sources.end(); source_iter++)
       {
-        std::string url;
-        sources[i] >> url;
-        ui_.source_combo->addItem(QString::fromStdString(url));
+        TileSource source(QString::fromStdString(((*source_iter)[NAME_KEY]).as<std::string>()),
+                          QString::fromStdString((*source_iter)[BASE_URL_KEY].as<std::string>()),
+                          static_cast<TileSource::COORD_ORDER>((*source_iter)[COORD_ORDER_KEY].as<int32_t>()),
+                          true,
+                          (*source_iter)[MAX_ZOOM_KEY].as<int>(),
+                          QString::fromStdString((*source_iter)[SUFFIX_KEY].as<std::string>())
+                          );
+        tile_sources_[source.GetName()] = source;
+        ui_.source_combo->addItem(source.GetName());
       }
     }
     
-    if (swri_yaml_util::FindValue(node, "source"))
+    if (node[SOURCE_KEY])
     {
-      std::string source;
-      node["source"] >> source;
-      
+      std::string source = node[SOURCE_KEY].as<std::string>();
+
       int index = ui_.source_combo->findText(QString::fromStdString(source), Qt::MatchExactly);
-      if (index < 0)
-      {
-        ui_.source_combo->addItem(QString::fromStdString(source));
-        index = ui_.source_combo->findText(QString::fromStdString(source), Qt::MatchExactly);
-      }
-      
+
       if (index >= 0)
       {
         ui_.source_combo->setCurrentIndex(index);
@@ -230,17 +314,54 @@ namespace tile_map
 
   void TileMapPlugin::SaveConfig(YAML::Emitter& emitter, const std::string& path)
   {
-    if (ui_.source_combo->count() > 5)
+    emitter << YAML::Key << CUSTOM_SOURCES_KEY << YAML::Value << YAML::BeginSeq;
+
+    std::map<QString, TileSource>::iterator iter;
+    for (iter = tile_sources_.begin(); iter != tile_sources_.end(); iter++)
     {
-      emitter << YAML::Key << "custom_sources" << YAML::Value << YAML::BeginSeq;
-      for (int32_t i = 5; i < ui_.source_combo->count(); i++)
+      if (iter->second.IsCustom())
       {
-        emitter << YAML::Value << ui_.source_combo->itemText(i).toStdString();
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << BASE_URL_KEY << YAML::Value << iter->second.GetBaseUrl().toStdString();
+        emitter << YAML::Key << COORD_ORDER_KEY << YAML::Value << (int) iter->second.GetCoordOrder();
+        emitter << YAML::Key << MAX_ZOOM_KEY << YAML::Value << iter->second.GetMaxZoom();
+        emitter << YAML::Key << NAME_KEY << YAML::Value << iter->second.GetName().toStdString();
+        emitter << YAML::Key << SUFFIX_KEY << YAML::Value << iter->second.GetSuffix().toStdString();
+        emitter << YAML::EndMap;
       }
-      emitter << YAML::EndSeq;
     }
-  
-    emitter << YAML::Key << "source" << YAML::Value << boost::trim_copy(ui_.source_combo->currentText().toStdString());
+    emitter << YAML::EndSeq;
+
+    emitter << YAML::Key << SOURCE_KEY << YAML::Value << boost::trim_copy(ui_.source_combo->currentText().toStdString());
+  }
+
+  void TileMapPlugin::selectTileSource(const TileSource& tile_source)
+  {
+    tile_map_.SetTileSource(tile_source);
+    ui_.base_url_text->setText(tile_source.GetBaseUrl());
+    ui_.suffix_text->setText(tile_source.GetSuffix());
+    ui_.coord_order_combo_box->setCurrentIndex((int) tile_source.GetCoordOrder());
+    ui_.max_zoom_spin_box->setValue(tile_source.GetMaxZoom());
+  }
+
+  void TileMapPlugin::startCustomEditing()
+  {
+    ui_.base_url_text->setEnabled(true);
+    ui_.suffix_text->setEnabled(true);
+    ui_.coord_order_combo_box->setEnabled(true);
+    ui_.delete_button->setEnabled(true);
+    ui_.max_zoom_spin_box->setEnabled(true);
+    ui_.save_button->setEnabled(true);
+  }
+
+  void TileMapPlugin::stopCustomEditing()
+  {
+    ui_.base_url_text->setEnabled(false);
+    ui_.suffix_text->setEnabled(false);
+    ui_.coord_order_combo_box->setEnabled(false);
+    ui_.delete_button->setEnabled(false);
+    ui_.max_zoom_spin_box->setEnabled(false);
+    ui_.save_button->setEnabled(false);
   }
 }
 

--- a/tile_map/src/tile_source.cpp
+++ b/tile_map/src/tile_source.cpp
@@ -1,0 +1,217 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+
+#include <tile_map/tile_source.h>
+#include <sstream>
+#include <boost/lexical_cast.hpp>
+
+namespace tile_map
+{
+  /**
+   * Default constructor.
+   *
+   * Not actually used in the code, this is only necessary so that this class can
+   * be used by STL data structures.
+   */
+  TileSource::TileSource() :
+      coord_order_(ZYX),
+      is_custom_(false),
+      max_zoom_(-1)
+  {
+  }
+
+  /**
+   * Creates a new tile source from a set of known parameters.
+   *
+   * @param[in] name A user-friendly display name
+   * @param[in] base_url The base HTTP URL of the data source; e. g.:
+   *   "http://tile.stamen.com/terrain/"
+   * @param[in] coord_order The order in which coordinates should be appended
+   *   to the URL
+   * @param is_custom If this is a custom (i. e. not one of the default)
+   *   tile source; custom sources are saved and loaded from our settings
+   * @param[in] max_zoom The maximum zoom level
+   * @param[in] suffix A suffix that should be appended to the URL; i. e. ".jpg"
+   */
+  TileSource::TileSource(const QString& name,
+                         const QString& base_url,
+                         COORD_ORDER coord_order,
+                         bool is_custom,
+                         int32_t max_zoom,
+                         const QString& suffix) :
+      base_url_(base_url),
+      coord_order_(coord_order),
+      is_custom_(is_custom),
+      max_zoom_(max_zoom),
+      name_(name),
+      suffix_(suffix)
+  {
+  }
+
+  /**
+   * Copy constructor
+   */
+  TileSource::TileSource(const TileSource& tile_source) :
+      base_url_(tile_source.base_url_),
+      coord_order_(tile_source.coord_order_),
+      is_custom_(tile_source.is_custom_),
+      max_zoom_(tile_source.max_zoom_),
+      name_(tile_source.name_),
+      suffix_(tile_source.suffix_)
+  {
+  }
+
+  const QString& TileSource::GetBaseUrl() const
+  {
+    return base_url_;
+  }
+
+  void TileSource::SetBaseUrl(const QString& base_url)
+  {
+    base_url_ = base_url;
+  }
+
+  TileSource::COORD_ORDER TileSource::GetCoordOrder() const
+  {
+    return coord_order_;
+  }
+
+  void TileSource::SetCoordOrder(TileSource::COORD_ORDER coord_order)
+  {
+    coord_order_ = coord_order;
+  }
+
+  bool TileSource::IsCustom() const
+  {
+    return is_custom_;
+  }
+
+  void TileSource::SetCustom(bool is_custom)
+  {
+    is_custom_ = is_custom;
+  }
+
+  int32_t TileSource::GetMaxZoom() const
+  {
+    return max_zoom_;
+  }
+
+  void TileSource::SetMaxZoom(int32_t max_zoom)
+  {
+    max_zoom_ = max_zoom;
+  }
+
+  const QString& TileSource::GetName() const
+  {
+    return name_;
+  }
+
+  void TileSource::SetName(const QString& name)
+  {
+    name_ = name;
+  }
+
+  const QString& TileSource::GetSuffix() const
+  {
+    return suffix_;
+  }
+
+  void TileSource::SetSuffix(const QString& suffix)
+  {
+    suffix_ = suffix;
+  }
+
+  /**
+   * Given a zoom level and x and y coordinates appropriate for the tile source's
+   * projection, this will generate a URL that points to an image tile for that
+   * location.
+   *
+   * @param[in] level The zoom level
+   * @param[in] x The X coordinate of the tile
+   * @param[in] y The Y coordinate of the tile
+   * @return A URL that references that tile
+   */
+  std::string TileSource::GenerateTileUrl(int32_t level, int64_t x, int64_t y) const
+  {
+    std::stringstream url;
+    url << base_url_.toStdString();
+
+    switch (coord_order_)
+    {
+      case TileSource::XYZ:
+      case TileSource::XZY:
+        url << boost::lexical_cast<std::string>(x);
+        break;
+      case TileSource::YXZ:
+      case TileSource::YZX:
+        url << boost::lexical_cast<std::string>(y);
+        break;
+      case TileSource::ZXY:
+      case TileSource::ZYX:
+        url << boost::lexical_cast<std::string>(level);
+        break;
+    }
+    url << "/";
+    switch (coord_order_)
+    {
+      case TileSource::ZXY:
+      case TileSource::YXZ:
+        url << boost::lexical_cast<std::string>(x);
+        break;
+      case TileSource::ZYX:
+      case TileSource::XYZ:
+        url << boost::lexical_cast<std::string>(y);
+        break;
+      case TileSource::XZY:
+      case TileSource::YZX:
+        url << boost::lexical_cast<std::string>(level);
+        break;
+    }
+    url << "/";
+    switch (coord_order_)
+    {
+      case TileSource::YZX:
+      case TileSource::ZYX:
+        url << boost::lexical_cast<std::string>(x);
+        break;
+      case TileSource::ZXY:
+      case TileSource::XZY:
+        url << boost::lexical_cast<std::string>(y);
+        break;
+      case TileSource::YXZ:
+      case TileSource::XYZ:
+        url << boost::lexical_cast<std::string>(level);
+        break;
+    }
+    url << suffix_.toStdString();
+
+    return url.str();
+  }
+}


### PR DESCRIPTION
MapQuest has turned off their public API for map tiles, so this plugin needed some work.  I have:
- Removed the MapQuest sources
- Made the interface for adding new sources more powerful
- Overhauled how sources are saved and loaded under the hood
- Added a button to reset the current tile cache

Resolves #402

Conflicts:
	tile_map/CMakeLists.txt