### PR TITLE
Adding support for Bing Maps (Kinetic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Textured markers follow the same general approach as traditional markers, but ca
  * Topic: The textured marker topic
 
 ### Tile Map
-Projects a geo-referenced multi-resolution image tile map into the scene.  Data is automatically streamed from [OpenMapQuest](http://open.mapquest.com/) (satellite and roads) or [Stamen Design] (http://maps.stamen.com/) (terrain, watercolor, and toner).  Custom or local map servers can also be specified.  Map data is cached to disk which enables some limited use completely offline.
+Projects a geo-referenced multi-resolution image tile map into the scene.  Map tiles can be obtained from [Bing Maps](https://www.bing.com/mapspreview) or any [WMTS Tile Service](http://www.opengeospatial.org/standards/wmts).  Pre-defined services that access [Stamen Design](http://maps.stamen.com/) (terrain, watercolor, and toner) are provided.  Custom or local WMTS map servers can also be specified.  Map data is cached to disk which enables some limited use completely offline.
 
 <img src="https://github.com/swri-robotics/mapviz/wiki/satellite.png" width="200" height="200" />
 <img src="https://github.com/swri-robotics/mapviz/wiki/roads.png" width="200" height="200" />
@@ -255,7 +255,10 @@ Projects a geo-referenced multi-resolution image tile map into the scene.  Data 
 <img src="https://github.com/swri-robotics/mapviz/wiki/toner.png" width="200" height="200" />
 
 **Parameters**
- * Source: The source of the tile data.
+ * Source: The name of source of the tile data.
+ * Base URL: A template URL used to obtain map tiles.  When obtaining map tiles, parameters labeled `{level}`, `{x}`, and `{y}` in the URL will be replaced with appropriate values.  For example, `http://tile.stamen.com/terrain/{level}/{x}/{y}.png` is appropriate for retrieving terrain tiles from Stamen Design.
+ * API Key: When the `Bing Maps (terrain)` source is selected, you must enter a Bing Maps access key here and click the `Save` button in order for tiles to be available.  You can get a Bing Maps Key from the [Microsoft Developer Network](https://msdn.microsoft.com/en-us/library/ff428642.aspx).
+ * Max Zoom: The maximum zoom level that will be used when requesting tiles.
 
 ### TF Frame
 

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -38,7 +38,11 @@ add_definitions(
 )
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
 
+find_package(PkgConfig REQUIRED)
+
 find_package(GLU REQUIRED)
+
+pkg_check_modules(JSONCPP REQUIRED jsoncpp)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -55,7 +59,7 @@ catkin_package(
 # Fix conflict between Boost signals used by tf and QT signals used by mapviz
 add_definitions(-DQT_NO_KEYWORDS)
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${JSONCPP_INCLUDE_DIRS})
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -63,14 +67,20 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 file (GLOB TILE_SRC_FILES 
   src/image_cache.cpp
   src/texture_cache.cpp
+  src/bing_source.cpp
+  src/tile_source.cpp
+  src/wmts_source.cpp
   src/tile_map_view.cpp)
-qt5_wrap_cpp(TILE_SRC_FILES include/tile_map/image_cache.h)
+qt5_wrap_cpp(TILE_SRC_FILES 
+  include/tile_map/image_cache.h
+  include/tile_map/tile_source.h
+  include/tile_map/wmts_source.h
+  include/tile_map/bing_source.h)
 add_library(${PROJECT_NAME} ${TILE_SRC_FILES})
-target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${QT_QTOPENGL_LIBRARIES} ${GLU_LIBRARY} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${QT_QTOPENGL_LIBRARIES} ${GLU_LIBRARY} ${JSONCPP_LIBRARIES} ${catkin_LIBRARIES})
 
 file (GLOB PLUGIN_SRC_FILES
-  src/tile_map_plugin.cpp
-  src/tile_source.cpp)
+  src/tile_map_plugin.cpp)
 file (GLOB PLUGIN_UI_FILES
   src/tile_map_config.ui)
 qt5_wrap_ui(PLUGIN_SRC_FILES ${PLUGIN_UI_FILES})

--- a/tile_map/include/tile_map/bing_source.h
+++ b/tile_map/include/tile_map/bing_source.h
@@ -1,0 +1,141 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef TILE_MAP_BING_SOURCE_H
+#define TILE_MAP_BING_SOURCE_H
+
+#include "tile_source.h"
+
+#include <boost/functional/hash.hpp>
+#include <boost/random.hpp>
+
+#include <vector>
+
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QString>
+
+namespace tile_map
+{
+  class BingSource : public TileSource
+  {
+    Q_OBJECT
+  public:
+    /**
+     * Initializes a Bing map source with a given name.
+     *
+     * Note that currently, only a single, hard-coded Bing map source is supported.
+     * There's only one Bing Maps, after all.
+     * In the future, though, it would probably make sense to extend its
+     * functionality to allow pulling different tile sets from Bing.
+     * @param name The name the source will appear as in the combo box.
+     */
+    explicit BingSource(const QString& name);
+
+    /**
+     * Generates a unique hash that identifies the tile as the given coordinates.
+     *
+     * Note that Bing Maps tiles could potentially be pulled from one of many
+     * different servers, depending on the subdomain list given to us after we
+     * authenticate with our API Key.  That means the exact URL to any given tile
+     * should not be used as part of the hash, because there are many valid URLs
+     * for a tile.
+     * @param level The zoom level
+     * @param x The X coordinate
+     * @param y The Y coordinate
+     * @return A hash that uniquely identifies this tile
+     */
+    virtual size_t GenerateTileHash(int32_t level, int64_t x, int64_t y);
+
+    /**
+     * Generates a URL that will retrieve a tile for the given coordinates.
+     *
+     * Since Bing can give us a list of subdomains to pull tiles from, the
+     * exact subdomain for a tile is chosen at random every time this function
+     * is called.  That means you are not guaranteed to get the same URL for a
+     * tile every time you call this function.
+     * @param level The zoom level
+     * @param x The X coordinate
+     * @param y The Y coordinate
+     * @return A URL that points to this tile
+     */
+    virtual QString GenerateTileUrl(int32_t level, int64_t x, int64_t y);
+
+    virtual QString GetType() const;
+
+    QString GetApiKey() const;
+
+    /**
+     * Bing requires an API key in order to access its tiles.  The key provided
+     * will determine the URL we use to retrieve map tiles, so setting the API
+     * key will also cause this object to make a network request to the Bing Map
+     * server to get the appropriate URL.
+     *
+     * More information about getting an API key:
+     * https://msdn.microsoft.com/en-us/library/ff428642.aspx
+     * @param api_key A valid Bing Maps key
+     */
+    void SetApiKey(const QString& api_key);
+
+    static const QString BING_TYPE;
+
+  protected Q_SLOTS:
+    void ReplyFinished(QNetworkReply* reply);
+
+  protected:
+    /**
+     * Bing Maps identifies tiles using a quadkey that is generated from the zoom
+     * level and x and y coordinates.  Details on how the quadkey is generated can
+     * be found here:
+     * https://msdn.microsoft.com/en-us/library/bb259689.aspx
+     *
+     * @param level The zoom level
+     * @param x The X coordinate
+     * @param y The Y coordinate
+     * @return The quadkey that represents the tile at the requested location
+     */
+    QString GenerateQuadKey(int32_t level, int64_t x, int64_t y) const;
+
+    QString api_key_;
+    boost::hash<std::string> hash_;
+    QNetworkAccessManager network_manager_;
+    boost::random::mt19937 rng_;
+    std::vector<QString> subdomains_;
+    QString tile_url_;
+
+    static const std::string BING_IMAGE_URL_KEY;
+    static const std::string BING_IMAGE_URL_SUBDOMAIN_KEY;
+    static const std::string BING_RESOURCE_SET_KEY;
+    static const std::string BING_RESOURCE_KEY;
+    static const std::string BING_STATUS_CODE_KEY;
+  };
+}
+
+#endif //TILE_MAP_BING_SOURCE_H

--- a/tile_map/include/tile_map/image_cache.h
+++ b/tile_map/include/tile_map/image_cache.h
@@ -32,8 +32,7 @@
 
 #include <string>
 
-#include <boost/functional/hash.hpp>
-
+#include <boost/cstdint.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <QCache>
@@ -51,10 +50,10 @@ namespace tile_map
   class Image
   {
   public:
-    Image(const std::string& uri, size_t uri_hash, uint64_t priority = 0);
+    Image(const QString& uri, size_t uri_hash, uint64_t priority = 0);
     ~Image();
-    
-    std::string Uri() const { return uri_; }
+
+    QString Uri() const { return uri_; }
     size_t UriHash() const { return uri_hash_; }
   
     boost::shared_ptr<QImage> GetImage() { return image_; }
@@ -72,7 +71,7 @@ namespace tile_map
     void SetLoading(bool loading) { loading_ = loading; }
 
   private:
-    std::string uri_;
+    QString uri_;
     
     size_t uri_hash_;
     
@@ -93,7 +92,7 @@ namespace tile_map
     explicit ImageCache(const QString& cache_dir, size_t size = 4096);
     ~ImageCache();
     
-    ImagePtr GetImage(size_t uri_hash, const std::string& uri, int32_t priority = 0);
+    ImagePtr GetImage(size_t uri_hash, const QString& uri, int32_t priority = 0);
   
   public Q_SLOTS:
     void ProcessRequest(QString uri);
@@ -105,10 +104,10 @@ namespace tile_map
     QNetworkAccessManager network_manager_;
     
     QString cache_dir_;
-  
-    boost::hash<std::string> hash_function_;
+
     QCache<size_t, ImagePtr> cache_;
     QMap<size_t, ImagePtr> unprocessed_;
+    QMap<QString, size_t> uri_to_hash_map_;
     
     QMutex cache_mutex_;
     QMutex unprocessed_mutex_;

--- a/tile_map/include/tile_map/texture_cache.h
+++ b/tile_map/include/tile_map/texture_cache.h
@@ -54,7 +54,7 @@ namespace tile_map
   public:
     explicit TextureCache(ImageCachePtr image_cache, size_t size = 512);
 
-    TexturePtr GetTexture(size_t url_hash, const std::string& url, bool& failed);
+    TexturePtr GetTexture(size_t url_hash, const QString& url, bool& failed);
     void AddTexture(const TexturePtr& texture);
 
     void Clear();

--- a/tile_map/include/tile_map/tile_map_plugin.h
+++ b/tile_map/include/tile_map/tile_map_plugin.h
@@ -36,6 +36,7 @@
 
 // Boost libraries
 #include <boost/filesystem.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <mapviz/mapviz_plugin.h>
 
@@ -74,19 +75,18 @@ namespace tile_map
 
     QWidget* GetConfigWidget(QWidget* parent);
 
-  protected:
+  protected Q_SLOTS:
     void PrintError(const std::string& message);
     void PrintInfo(const std::string& message);
     void PrintWarning(const std::string& message);
 
-  protected Q_SLOTS:
     void DeleteTileSource();
-    void SelectSource(QString source_name);
+    void SelectSource(const QString& source_name);
     void SaveCustomSource();
     void ResetTileCache();
 
   private:
-    void selectTileSource(const TileSource& tile_source);
+    void selectTileSource(const boost::shared_ptr<TileSource>& tile_source);
     void startCustomEditing();
     void stopCustomEditing();
 
@@ -99,15 +99,22 @@ namespace tile_map
     bool transformed_;
     
     TileMapView tile_map_;
-    std::map<QString, TileSource> tile_sources_;
+    std::map<QString, boost::shared_ptr<TileSource> > tile_sources_;
+
+    double last_center_x_;
+    double last_center_y_;
+    double last_scale_;
+    int32_t last_height_;
+    int32_t last_width_;
 
     static std::string BASE_URL_KEY;
-    static std::string COORD_ORDER_KEY;
+    static std::string BING_API_KEY;
     static std::string CUSTOM_SOURCES_KEY;
     static std::string MAX_ZOOM_KEY;
     static std::string NAME_KEY;
     static std::string SOURCE_KEY;
-    static std::string SUFFIX_KEY;
+    static std::string TYPE_KEY;
+    static QString BING_NAME;
     static QString STAMEN_TERRAIN_NAME;
     static QString STAMEN_TONER_NAME;
     static QString STAMEN_WATERCOLOR_NAME;

--- a/tile_map/include/tile_map/tile_map_view.h
+++ b/tile_map/include/tile_map/tile_map_view.h
@@ -32,11 +32,10 @@
 
 #include <string>
 
-#include <boost/functional/hash.hpp>
-
-#include <tile_map/texture_cache.h>
+#include <boost/shared_ptr.hpp>
 
 #include <tile_map/tile_source.h>
+#include <tile_map/texture_cache.h>
 
 #include <swri_transform_util/transform.h>
 
@@ -47,7 +46,7 @@ namespace tile_map
   struct Tile
   {
   public:
-    std::string url;
+    QString url;
     size_t url_hash;
     int32_t level;
     int32_t subdiv_count;
@@ -66,7 +65,7 @@ namespace tile_map
 
     void ResetCache();
 
-    void SetTileSource(const TileSource& tile_source);
+    void SetTileSource(const boost::shared_ptr<TileSource>& tile_source);
 
     void SetTransform(const swri_transform_util::Transform& transform);
     
@@ -80,7 +79,7 @@ namespace tile_map
     void Draw();
     
   private:
-    TileSource tile_source_;
+    boost::shared_ptr<TileSource> tile_source_;
 
     swri_transform_util::Transform transform_;
     
@@ -96,8 +95,7 @@ namespace tile_map
     
     std::vector<Tile> tiles_;
     std::vector<Tile> precache_;
-    
-    boost::hash<std::string> hash_function_;
+
     TextureCachePtr tile_cache_;
     
     void ToLatLon(int32_t level, double x, double y, double& latitude, double& longitude);

--- a/tile_map/include/tile_map/wmts_source.h
+++ b/tile_map/include/tile_map/wmts_source.h
@@ -28,57 +28,59 @@
 //
 // *****************************************************************************
 
-#include <tile_map/tile_source.h>
+#ifndef TILE_MAP_WMTS_SOURCE_H
+#define TILE_MAP_WMTS_SOURCE_H
+
+#include "tile_source.h"
+
+#include <boost/functional/hash.hpp>
 
 namespace tile_map
 {
-  const QString& TileSource::GetBaseUrl() const
+  class WmtsSource : public TileSource
   {
-    return base_url_;
-  }
+  Q_OBJECT
+  public:
+    /**
+     * Creates a new tile source from a set of known parameters.
+     *
+     * @param[in] name A user-friendly display name
+     * @param[in] base_url The base HTTP URL of the data source; e. g.:
+     *   "http://tile.stamen.com/terrain/"
+     * @param[in] is_custom If this is a custom (i. e. not one of the default)
+     *   tile source; custom sources are saved and loaded from our settings
+     * @param[in] max_zoom The maximum zoom level
+     */
+    explicit WmtsSource(const QString& name,
+               const QString& base_url,
+               bool is_custom,
+               int32_t max_zoom);
 
-  void TileSource::SetBaseUrl(const QString& base_url)
-  {
-    base_url_ = base_url;
-  }
+    virtual size_t GenerateTileHash(int32_t level, int64_t x, int64_t y);
 
-  bool TileSource::IsCustom() const
-  {
-    return is_custom_;
-  }
+    /**
+     * Given a zoom level and x and y coordinates appropriate for the tile source's
+     * projection, this will generate a URL that points to an image tile for that
+     * location.
+     *
+     * This expects the URL to have three strings in it, "{level}", "{x}", and "{y}",
+     * which will be replaced with the passed values.  See tile_map_plugin.cpp for
+     * example URLs.
+     *
+     * @param[in] level The zoom level
+     * @param[in] x The X coordinate of the tile
+     * @param[in] y The Y coordinate of the tile
+     * @return A URL that references that tile
+     */
+    virtual QString GenerateTileUrl(int32_t level, int64_t x, int64_t y);
 
-  void TileSource::SetCustom(bool is_custom)
-  {
-    is_custom_ = is_custom;
-  }
+    virtual QString GetType() const;
 
-  int32_t TileSource::GetMaxZoom() const
-  {
-    return max_zoom_;
-  }
+    static const QString WMTS_TYPE;
 
-  void TileSource::SetMaxZoom(int32_t max_zoom)
-  {
-    max_zoom_ = max_zoom;
-  }
-
-  int32_t TileSource::GetMinZoom() const
-  {
-    return min_zoom_;
-  }
-
-  void TileSource::SetMinZoom(int32_t min_zoom)
-  {
-    min_zoom_ = min_zoom;
-  }
-
-  const QString& TileSource::GetName() const
-  {
-    return name_;
-  }
-
-  void TileSource::SetName(const QString& name)
-  {
-    name_ = name;
-  }
+  private:
+    boost::hash<std::string> hash_;
+  };
 }
+
+#endif //TILE_MAP_WMTS_SOURCE_H

--- a/tile_map/package.xml
+++ b/tile_map/package.xml
@@ -15,11 +15,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>libjsoncpp-dev</build_depend>
+  <build_depend>libqt5-opengl-dev</build_depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-network</depend>
   <depend>libqt5-opengl</depend>
-  <build_depend>libqt5-opengl-dev</build_depend>
   <depend>libqt5-widgets</depend>
   <depend>mapviz</depend>
   <depend>pluginlib</depend>
@@ -28,6 +29,7 @@
   <depend>swri_transform_util</depend>
   <depend>swri_yaml_util</depend>
   <depend>tf</depend>
+  <exec_depend>libjsoncpp</exec_depend>
 
   <export>
     <mapviz plugin="${prefix}/mapviz_plugins.xml" />

--- a/tile_map/src/bing_source.cpp
+++ b/tile_map/src/bing_source.cpp
@@ -1,0 +1,185 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+
+#include <tile_map/bing_source.h>
+#include <boost/lexical_cast.hpp>
+#include <boost/random.hpp>
+
+#include <QRegExp>
+#include <QString>
+
+#include <json/json.h>
+
+namespace tile_map
+{
+  const QString BingSource::BING_TYPE = "bing";
+  const std::string BingSource::BING_IMAGE_URL_KEY = "imageUrl";
+  const std::string BingSource::BING_IMAGE_URL_SUBDOMAIN_KEY = "imageUrlSubdomains";
+  const std::string BingSource::BING_RESOURCE_SET_KEY = "resourceSets";
+  const std::string BingSource::BING_RESOURCE_KEY = "resources";
+  const std::string BingSource::BING_STATUS_CODE_KEY = "statusCode";
+
+  BingSource::BingSource(const QString& name) :
+    network_manager_(this)
+  {
+    name_ = name;
+    is_custom_ = false;
+    max_zoom_ = 19;
+    base_url_ = "https://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial?uriScheme=https&include=ImageryProviders&key={api_key}";
+    tile_url_ = "";
+    min_zoom_ = 2;
+
+    QObject::connect(&network_manager_, SIGNAL(finished(QNetworkReply*)),
+                     this, SLOT(ReplyFinished(QNetworkReply*)));
+  }
+
+  size_t BingSource::GenerateTileHash(int32_t level, int64_t x, int64_t y)
+  {
+    size_t hash = hash_((base_url_ + api_key_ + GenerateQuadKey(level, x, y)).toStdString());
+    return hash;
+  }
+
+  QString BingSource::GenerateTileUrl(int32_t level, int64_t x, int64_t y)
+  {
+    QString url = tile_url_;
+    if (!subdomains_.empty())
+    {
+      boost::random::uniform_int_distribution<> random(0, (int) subdomains_.size() - 1);
+      url.replace(QString::fromStdString("{subdomain}"), subdomains_[random(rng_)]);
+    }
+    url.replace(QString::fromStdString("{quadkey}"), GenerateQuadKey(level, x, y));
+    return url;
+  }
+
+  QString BingSource::GetType() const
+  {
+    return BING_TYPE;
+  }
+
+  QString BingSource::GetApiKey() const
+  {
+    return api_key_;
+  }
+
+  void BingSource::SetApiKey(const QString& api_key)
+  {
+    api_key_ = api_key.trimmed();
+    if (!api_key_.isEmpty())
+    {
+      QString url(base_url_);
+      url.replace(QString::fromStdString("{api_key}"), api_key_);
+      // Changing the API key will result in the tile URL changing; go ahead
+      // and blank it out so we don't make requests using the old one.
+      tile_url_= "";
+      subdomains_.clear();
+      network_manager_.get(QNetworkRequest(QUrl(url)));
+    }
+  }
+
+  QString BingSource::GenerateQuadKey(int32_t level, int64_t x, int64_t y) const
+  {
+    QString quadkey;
+    for (int32_t i = level; i > 0; i--)
+    {
+      int32_t bitmask = 1 << (i-1);
+      int32_t digit = 0;
+      if ((x & bitmask) != 0)
+      {
+        digit |= 1;
+      }
+      if ((y & bitmask) != 0)
+      {
+        digit |= 2;
+      }
+      quadkey.append(QString::number(digit));
+    }
+
+    return quadkey;
+  }
+
+  void BingSource::ReplyFinished(QNetworkReply* reply)
+  {
+    QString reply_string(reply->readAll());
+    Json::Reader reader;
+    Json::Value root;
+    reader.parse(reply_string.toStdString(), root);
+
+    int status = root[BING_STATUS_CODE_KEY].asInt();
+    if (status != 200)
+    {
+      Q_EMIT ErrorMessage("Bing authorization error: " + boost::lexical_cast<std::string>(status));
+    }
+    else
+    {
+      if (!root[BING_RESOURCE_SET_KEY].isArray() ||
+          root[BING_RESOURCE_SET_KEY].size() == 0)
+      {
+        Q_EMIT ErrorMessage("No Bing resource sets found.");
+        return;
+      }
+      Json::Value firstResourceSet = root[BING_RESOURCE_SET_KEY][0];
+
+      if (!firstResourceSet[BING_RESOURCE_KEY].isArray() ||
+          firstResourceSet[BING_RESOURCE_KEY].size() == 0)
+      {
+        Q_EMIT ErrorMessage("No Bing resources found.");
+        return;
+      }
+
+      Json::Value first_resource = firstResourceSet[BING_RESOURCE_KEY][0];
+
+      std::string image_url = first_resource[BING_IMAGE_URL_KEY].asString();
+
+      if (image_url.empty())
+      {
+        Q_EMIT ErrorMessage("No Bing image URL found.");
+        return;
+      }
+
+      tile_url_ = QString::fromStdString(image_url);
+      SetMaxZoom(19);
+
+
+      if (!first_resource[BING_IMAGE_URL_SUBDOMAIN_KEY].isArray() ||
+          first_resource[BING_IMAGE_URL_SUBDOMAIN_KEY].size() == 0)
+      {
+        Q_EMIT ErrorMessage("No image URL subdomains; maybe that's ok sometimes?");
+      }
+
+      for (int i = 0; i < first_resource[BING_IMAGE_URL_SUBDOMAIN_KEY].size(); i++)
+      {
+        Json::Value subdomain = first_resource[BING_IMAGE_URL_SUBDOMAIN_KEY][i];
+        subdomains_.push_back(QString::fromStdString(subdomain.asString()));
+      }
+
+      Q_EMIT InfoMessage("API Key Set.");
+    }
+  }
+}

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -47,7 +47,7 @@ namespace tile_map
     return left->Priority() > right->Priority();
   }
 
-  Image::Image(const std::string& uri, size_t uri_hash, uint64_t priority) :
+  Image::Image(const QString& uri, size_t uri_hash, uint64_t priority) :
     uri_(uri),
     uri_hash_(uri_hash),
     loading_(false),
@@ -110,7 +110,7 @@ namespace tile_map
     network_manager_.cache()->clear();
   }
 
-  ImagePtr ImageCache::GetImage(size_t uri_hash, const std::string& uri, int32_t priority)
+  ImagePtr ImageCache::GetImage(size_t uri_hash, const QString& uri, int32_t priority)
   {
     ImagePtr image;
     
@@ -124,7 +124,7 @@ namespace tile_map
       image = *image_ptr;
       if (!cache_.insert(uri_hash, image_ptr))
       {
-        ROS_ERROR("FAILED TO CREATE HANDLE: %s", uri.c_str());
+        ROS_ERROR("FAILED TO CREATE HANDLE: %s", uri.toStdString().c_str());
         image_ptr = 0;
       }
     }
@@ -147,11 +147,12 @@ namespace tile_map
         {
           image->SetPriority(tick_++);
           unprocessed_[uri_hash] = image;
+          uri_to_hash_map_[uri] = uri_hash;
         }
       }
       else
       {
-        ROS_ERROR("To many failures for image: %s", uri.c_str());
+        ROS_ERROR("To many failures for image: %s", uri.toStdString().c_str());
       }
     }
 
@@ -179,12 +180,12 @@ namespace tile_map
   
   void ImageCache::ProcessReply(QNetworkReply* reply)
   {
-    std::string url = reply->url().toString().toStdString();
-    size_t hash = hash_function_(url);
+    QString url = reply->url().toString();
     
     ImagePtr image;
     unprocessed_mutex_.lock();
-    
+
+    size_t hash = uri_to_hash_map_[url];
     image = unprocessed_[hash];
     if (image)
     {
@@ -194,19 +195,20 @@ namespace tile_map
         image->InitializeImage();
         if (!image->GetImage()->loadFromData(data))
         {
-          ROS_ERROR("FAILED TO CREATE IMAGE FROM REPLY: %s", url.c_str());
+          ROS_ERROR("FAILED TO CREATE IMAGE FROM REPLY: %s", url.toStdString().c_str());
           image->ClearImage();
           image->AddFailure();
         }
       }
       else
       {
-        ROS_ERROR("============ AN ERROR OCCURRED ==============: %s", url.c_str());
+        ROS_ERROR("============ AN ERROR OCCURRED ==============: %s", url.toStdString().c_str());
         image->AddFailure();
       }
     }
     
     unprocessed_.remove(hash);
+    uri_to_hash_map_.remove(url);
     if (image)
     {
       image->SetLoading(false);
@@ -217,8 +219,6 @@ namespace tile_map
     unprocessed_mutex_.unlock();
     
     reply->deleteLater();
-    
-    
     
     // Condition variable?
   }
@@ -253,7 +253,7 @@ namespace tile_map
           image->SetLoading(true);
           images.pop_front();
         
-          Q_EMIT RequestImage(QString::fromStdString(image->Uri()));
+          Q_EMIT RequestImage(image->Uri());
         
           p->pending_++;
           count++;
@@ -272,6 +272,7 @@ namespace tile_map
         ImagePtr image = images.back();
         images.pop_back();
         p->unprocessed_.remove(image->UriHash());
+        p->uri_to_hash_map_.remove(image->Uri());
       }
       p->unprocessed_mutex_.unlock();
     

--- a/tile_map/src/texture_cache.cpp
+++ b/tile_map/src/texture_cache.cpp
@@ -69,7 +69,7 @@ namespace tile_map
   
   }
 
-  TexturePtr TextureCache::GetTexture(size_t url_hash, const std::string& url, bool& failed)
+  TexturePtr TextureCache::GetTexture(size_t url_hash, const QString& url, bool& failed)
   {
     TexturePtr texture;
 

--- a/tile_map/src/tile_map_config.ui
+++ b/tile_map/src/tile_map_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>294</width>
-    <height>178</height>
+    <width>305</width>
+    <height>141</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,7 +24,13 @@
     <number>2</number>
    </property>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="url_label">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
      <property name="text">
       <string>Base URL:</string>
      </property>
@@ -43,83 +49,42 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="3">
-    <widget class="QComboBox" name="coord_order_combo_box">
-     <property name="enabled">
-      <bool>false</bool>
+   <item row="7" column="1" colspan="3">
+    <widget class="QLabel" name="status">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
      </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="styleSheet">
+      <string notr="true"/>
      </property>
-     <item>
-      <property name="text">
-       <string>z/x/y</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>z/y/x</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>x/y/z</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>x/z/y</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>y/x/z</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>y/z/x</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Coord order:</string>
+      <string>Unconfigured</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_6">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
      <property name="text">
       <string>Max Zoom:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="5" column="3">
+    <widget class="QPushButton" name="reset_cache_button">
      <property name="text">
-      <string>Suffix:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="suffix_text">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>50</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>.jpg</string>
+      <string>Reset Cache</string>
      </property>
     </widget>
    </item>
@@ -151,7 +116,12 @@
      </item>
      <item>
       <property name="text">
-       <string>Custom...</string>
+       <string>Bing Maps (terrain)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Custom WMTS Source...</string>
       </property>
      </item>
     </widget>
@@ -166,7 +136,27 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="4" column="3">
+    <widget class="QPushButton" name="delete_button">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Delete</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QPushButton" name="save_button">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Save...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -179,7 +169,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="4" column="1">
     <widget class="QSpinBox" name="max_zoom_spin_box">
      <property name="enabled">
       <bool>false</bool>
@@ -198,52 +188,6 @@
      </property>
      <property name="value">
       <number>15</number>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="3">
-    <widget class="QPushButton" name="reset_cache_button">
-     <property name="text">
-      <string>Reset Cache</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1" colspan="3">
-    <widget class="QLabel" name="status">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>Unconfigured</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QPushButton" name="save_button">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Save...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="3">
-    <widget class="QPushButton" name="delete_button">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Delete</string>
      </property>
     </widget>
    </item>

--- a/tile_map/src/wmts_source.cpp
+++ b/tile_map/src/wmts_source.cpp
@@ -28,57 +28,43 @@
 //
 // *****************************************************************************
 
-#include <tile_map/tile_source.h>
+#include <tile_map/wmts_source.h>
+
+#include <boost/functional/hash.hpp>
 
 namespace tile_map
 {
-  const QString& TileSource::GetBaseUrl() const
-  {
-    return base_url_;
-  }
+  const QString WmtsSource::WMTS_TYPE = "wmts";
 
-  void TileSource::SetBaseUrl(const QString& base_url)
-  {
-    base_url_ = base_url;
-  }
-
-  bool TileSource::IsCustom() const
-  {
-    return is_custom_;
-  }
-
-  void TileSource::SetCustom(bool is_custom)
-  {
-    is_custom_ = is_custom;
-  }
-
-  int32_t TileSource::GetMaxZoom() const
-  {
-    return max_zoom_;
-  }
-
-  void TileSource::SetMaxZoom(int32_t max_zoom)
-  {
-    max_zoom_ = max_zoom;
-  }
-
-  int32_t TileSource::GetMinZoom() const
-  {
-    return min_zoom_;
-  }
-
-  void TileSource::SetMinZoom(int32_t min_zoom)
-  {
-    min_zoom_ = min_zoom;
-  }
-
-  const QString& TileSource::GetName() const
-  {
-    return name_;
-  }
-
-  void TileSource::SetName(const QString& name)
+  WmtsSource::WmtsSource(const QString& name,
+                         const QString& base_url,
+                         bool is_custom,
+                         int32_t max_zoom)
   {
     name_ = name;
+    base_url_ = base_url;
+    is_custom_ = is_custom;
+    max_zoom_ = max_zoom;
+    min_zoom_ = 1;
+  }
+
+  QString WmtsSource::GetType() const
+  {
+    return WMTS_TYPE;
+  }
+
+  size_t WmtsSource::GenerateTileHash(int32_t level, int64_t x, int64_t y)
+  {
+    return hash_(GenerateTileUrl(level, x, y).toStdString());
+  }
+
+  QString WmtsSource::GenerateTileUrl(int32_t level, int64_t x, int64_t y)
+  {
+    QString url(base_url_);
+    url.replace(QString::fromStdString("{level}"), QString::number(level));
+    url.replace(QString::fromStdString("{x}"), QString::number(x));
+    url.replace(QString::fromStdString("{y}"), QString::number(y));
+
+    return url;
   }
 }


### PR DESCRIPTION
This makes a number of changes in the `tile_map` plugin in order to support
different types of tile servers, including Bing Maps.  Notable changes include:
- TileSource is now an abstract class
- WMTS server-specific behavior has been moved into a new WmtsSource class
- BingSource provides support for obtaining tiles from Bing Maps
- The UI for specifying server URLs has changed
  - Prefix and coordinate order are no longer separate fields
  - In URLs for WMTS sources, the variables {level}, {x}, and {y} will be substituted with appropriate values when tiles are requested
- Rather than generating hashes for image tiles based on their URLs, hashes are now generated by the TileSource implementations in order to support sources that can pull tiles from multiple servers
- Idle performance has been improved by removing redundant recalculations of the map view
- Added a dependency on libjsoncpp

Resolves #227

Conflicts:
	tile_map/CMakeLists.txt
	tile_map/package.xml