### PR TITLE
Compiler warnings kinetic

### DIFF
--- a/mapviz/src/select_topic_dialog.cpp
+++ b/mapviz/src/select_topic_dialog.cpp
@@ -196,7 +196,7 @@ std::vector<ros::master::TopicInfo> SelectTopicDialog::selectedTopics() const
 
   std::vector<ros::master::TopicInfo> selection;
   selection.resize(qt_selection.size());
-  for (size_t i = 0; i < qt_selection.size(); i++) {
+  for (int i = 0; i < qt_selection.size(); i++) {
     if (!qt_selection[i].isValid()) {
       continue;
     }

--- a/mapviz_plugins/src/point_drawing_plugin.cpp
+++ b/mapviz_plugins/src/point_drawing_plugin.cpp
@@ -300,7 +300,7 @@ namespace mapviz_plugins
     transformed = transformed | TransformPoint(cur_point_);
     if (laps_.size() > 0)
     {
-      for (int i = 0; i < laps_.size(); i++)
+      for (size_t i = 0; i < laps_.size(); i++)
       {
         std::list<StampedPoint>::iterator lap_it = laps_[i].begin();
         for (; lap_it != laps_[i].end(); ++lap_it)
@@ -324,7 +324,7 @@ namespace mapviz_plugins
     QColor base_color = color_;
     if (laps_.size() != 0)
     {
-      for (int i = 0; i < laps_.size(); i++)
+      for (size_t i = 0; i < laps_.size(); i++)
       {
         UpdateColor(base_color,i);
         if (draw_style_ == LINES)
@@ -403,7 +403,7 @@ namespace mapviz_plugins
     QColor base_color = color_;
     if (laps_.size() != 0)
     {
-      for (int i = 0; i < laps_.size(); i++)
+      for (size_t i = 0; i < laps_.size(); i++)
       {
         UpdateColor(base_color,i);
         std::list<StampedPoint>::iterator it = laps_[i].begin();


### PR DESCRIPTION
Fix compiler warnings in mapviz and mapviz plugins. This fixes #410.