### PR TITLE
Add option to not scale arrows with zoom level (Jade)

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
@@ -95,8 +95,10 @@ namespace mapviz_plugins
     virtual void DrawIcon();
     virtual void SetDrawStyle(QString style);
     virtual void SetScaledArrows(bool isChecked);
+    virtual void SetArrowSize(int arrowSize);
 
    protected:
+    int arrow_size_;
     DrawStyle draw_style_;
     StampedPoint cur_point_;
     std::list<StampedPoint> points_;

--- a/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
@@ -81,7 +81,7 @@ namespace mapviz_plugins
     {
     }
     virtual void Transform();
-    virtual bool DrawPoints();
+    virtual bool DrawPoints(double scale);
     virtual bool DrawArrows();
     virtual bool DrawArrow(const StampedPoint& point);
     virtual bool DrawLaps();
@@ -94,6 +94,7 @@ namespace mapviz_plugins
    protected Q_SLOTS:
     virtual void DrawIcon();
     virtual void SetDrawStyle(QString style);
+    virtual void SetScaledArrows(bool isChecked);
 
    protected:
     DrawStyle draw_style_;
@@ -106,6 +107,8 @@ namespace mapviz_plugins
     QColor color_;
     bool lap_checked_;
     int buffer_holder_;
+    double scale_;
+    bool scale_arrows_;
 
    private:
     std::vector<std::list<StampedPoint> > laps_;

--- a/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
@@ -94,7 +94,7 @@ namespace mapviz_plugins
    protected Q_SLOTS:
     virtual void DrawIcon();
     virtual void SetDrawStyle(QString style);
-    virtual void SetScaledArrows(bool isChecked);
+    virtual void SetStaticArrowSizes(bool isChecked);
     virtual void SetArrowSize(int arrowSize);
 
    protected:
@@ -110,7 +110,7 @@ namespace mapviz_plugins
     bool lap_checked_;
     int buffer_holder_;
     double scale_;
-    bool scale_arrows_;
+    bool static_arrow_sizes_;
 
    private:
     std::vector<std::list<StampedPoint> > laps_;

--- a/mapviz_plugins/src/navsat_config.ui
+++ b/mapviz_plugins/src/navsat_config.ui
@@ -26,7 +26,7 @@
    <item row="5" column="1" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QCheckBox" name="scale_arrows">
+      <widget class="QCheckBox" name="static_arrow_sizes">
        <property name="text">
         <string/>
        </property>
@@ -34,6 +34,9 @@
      </item>
      <item>
       <widget class="QSlider" name="arrow_size">
+       <property name="minimum">
+        <number>1</number>
+       </property>
        <property name="maximum">
         <number>500</number>
        </property>
@@ -259,7 +262,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Scaled Arrows:</string>
+      <string>Static Arrow Sizes:</string>
      </property>
     </widget>
    </item>

--- a/mapviz_plugins/src/navsat_config.ui
+++ b/mapviz_plugins/src/navsat_config.ui
@@ -23,7 +23,7 @@
    <property name="margin">
     <number>2</number>
    </property>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -36,7 +36,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="2">
+   <item row="8" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -113,7 +113,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -126,7 +126,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="positiontolerance">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -164,7 +164,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -177,7 +177,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="QSpinBox" name="buffersize">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
@@ -224,6 +224,26 @@
        <string>points</string>
       </property>
      </item>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Scaled Arrows:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="scale_arrows">
+     <property name="text">
+      <string/>
+     </property>
     </widget>
    </item>
   </layout>

--- a/mapviz_plugins/src/navsat_config.ui
+++ b/mapviz_plugins/src/navsat_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>197</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,31 @@
    <property name="margin">
     <number>2</number>
    </property>
-   <item row="8" column="0">
+   <item row="5" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="scale_arrows">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="arrow_size">
+       <property name="maximum">
+        <number>500</number>
+       </property>
+       <property name="value">
+        <number>25</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="9" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -36,7 +60,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1" colspan="2">
+   <item row="9" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -239,12 +263,18 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="scale_arrows">
-     <property name="text">
-      <string/>
+   <item row="8" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -75,6 +75,8 @@ namespace mapviz_plugins
                      SLOT(SetDrawStyle(QString)));
     QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
                      this, SLOT(SetScaledArrows(bool)));
+    QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
+                     this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
             SLOT(DrawIcon()));
   }
@@ -289,6 +291,11 @@ namespace mapviz_plugins
       SetScaledArrows(scale_arrows);
     }
 
+    if (node["arrow_size"])
+    {
+      ui_.arrow_size->setValue(node["arrow_size"].as<int>());
+    }
+
     TopicEdited();
   }
 
@@ -309,5 +316,7 @@ namespace mapviz_plugins
     emitter << YAML::Key << "buffer_size" << YAML::Value << buffer_size_;
 
     emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
+
+    emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
   }
 }

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -73,8 +73,8 @@ namespace mapviz_plugins
                      SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
                      SLOT(SetDrawStyle(QString)));
-    QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
-                     this, SLOT(SetScaledArrows(bool)));
+    QObject::connect(ui_.static_arrow_sizes, SIGNAL(clicked(bool)),
+                     this, SLOT(SetStaticArrowSizes(bool)));
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
@@ -284,11 +284,11 @@ namespace mapviz_plugins
       ui_.buffersize->setValue(buffer_size_);
     }
 
-    if (node["scale_arrows"])
+    if (node["static_arrow_sizes"])
     {
-      bool scale_arrows = node["scale_arrows"].as<bool>();
-      ui_.scale_arrows->setChecked(scale_arrows);
-      SetScaledArrows(scale_arrows);
+      bool static_arrow_sizes = node["static_arrow_sizes"].as<bool>();
+      ui_.static_arrow_sizes->setChecked(static_arrow_sizes);
+      SetStaticArrowSizes(static_arrow_sizes);
     }
 
     if (node["arrow_size"])
@@ -315,7 +315,7 @@ namespace mapviz_plugins
 
     emitter << YAML::Key << "buffer_size" << YAML::Value << buffer_size_;
 
-    emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
+    emitter << YAML::Key << "static_arrow_sizes" << YAML::Value << ui_.static_arrow_sizes->isChecked();
 
     emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
   }

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -73,6 +73,8 @@ namespace mapviz_plugins
                      SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
                      SLOT(SetDrawStyle(QString)));
+    QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
+                     this, SLOT(SetScaledArrows(bool)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
             SLOT(DrawIcon()));
   }
@@ -229,7 +231,7 @@ namespace mapviz_plugins
   void NavSatPlugin::Draw(double x, double y, double scale)
   {
     color_ = ui_.color->color();
-    if (DrawPoints())
+    if (DrawPoints(scale))
     {
       PrintInfo("OK");
     }
@@ -280,6 +282,13 @@ namespace mapviz_plugins
       ui_.buffersize->setValue(buffer_size_);
     }
 
+    if (node["scale_arrows"])
+    {
+      bool scale_arrows = node["scale_arrows"].as<bool>();
+      ui_.scale_arrows->setChecked(scale_arrows);
+      SetScaledArrows(scale_arrows);
+    }
+
     TopicEdited();
   }
 
@@ -298,5 +307,7 @@ namespace mapviz_plugins
                YAML::Value << position_tolerance_;
 
     emitter << YAML::Key << "buffer_size" << YAML::Value << buffer_size_;
+
+    emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
   }
 }

--- a/mapviz_plugins/src/odometry_config.ui
+++ b/mapviz_plugins/src/odometry_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>247</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,6 +23,49 @@
    <property name="margin">
     <number>2</number>
    </property>
+   <item row="5" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="scale_arrows">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="arrow_size">
+       <property name="maximum">
+        <number>500</number>
+       </property>
+       <property name="value">
+        <number>25</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="tickPosition">
+        <enum>QSlider::NoTicks</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Scaled Arrows:</string>
+     </property>
+    </widget>
+   </item>
    <item row="8" column="1">
     <widget class="QDoubleSpinBox" name="positiontolerance">
      <property name="sizePolicy">
@@ -113,7 +156,7 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="1" colspan="2">
+   <item row="11" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -195,7 +238,7 @@
      </item>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -270,25 +313,18 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
+   <item row="10" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="text">
-      <string>Scaled Arrows:</string>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
      </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="scale_arrows">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/mapviz_plugins/src/odometry_config.ui
+++ b/mapviz_plugins/src/odometry_config.ui
@@ -17,21 +17,31 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>2</number>
-   </property>
-   <property name="topMargin">
-    <number>2</number>
-   </property>
-   <property name="rightMargin">
-    <number>2</number>
-   </property>
-   <property name="bottomMargin">
-    <number>2</number>
-   </property>
    <property name="verticalSpacing">
     <number>4</number>
    </property>
+   <property name="margin">
+    <number>2</number>
+   </property>
+   <item row="8" column="1">
+    <widget class="QDoubleSpinBox" name="positiontolerance">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::PlusMinus</enum>
+     </property>
+     <property name="suffix">
+      <string/>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="font">
@@ -93,25 +103,6 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <widget class="QDoubleSpinBox" name="positiontolerance">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="buttonSymbols">
-      <enum>QAbstractSpinBox::PlusMinus</enum>
-     </property>
-     <property name="suffix">
-      <string/>
-     </property>
-     <property name="value">
-      <double>1.000000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
     <widget class="QLineEdit" name="topic">
      <property name="font">
@@ -122,7 +113,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1" colspan="2">
+   <item row="10" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -141,7 +132,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -204,7 +195,7 @@
      </item>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -217,14 +208,14 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QCheckBox" name="show_covariance">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_5">
      <property name="font">
       <font>
@@ -237,7 +228,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="QSpinBox" name="buffersize">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
@@ -247,7 +238,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -260,14 +251,14 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="QCheckBox" name="show_laps">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_8">
      <property name="font">
       <font>
@@ -276,6 +267,26 @@
      </property>
      <property name="text">
       <string>Show Laps</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Scaled Arrows:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="scale_arrows">
+     <property name="text">
+      <string/>
      </property>
     </widget>
    </item>

--- a/mapviz_plugins/src/odometry_config.ui
+++ b/mapviz_plugins/src/odometry_config.ui
@@ -29,7 +29,7 @@
       <number>6</number>
      </property>
      <item>
-      <widget class="QCheckBox" name="scale_arrows">
+      <widget class="QCheckBox" name="static_arrow_sizes">
        <property name="text">
         <string/>
        </property>
@@ -37,6 +37,9 @@
      </item>
      <item>
       <widget class="QSlider" name="arrow_size">
+       <property name="minimum">
+        <number>1</number>
+       </property>
        <property name="maximum">
         <number>500</number>
        </property>
@@ -62,7 +65,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Scaled Arrows:</string>
+      <string>Static Arrow Sizes:</string>
      </property>
     </widget>
    </item>

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -83,6 +83,8 @@ namespace mapviz_plugins
                      SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
                      SLOT(SetDrawStyle(QString)));
+    QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
+                     this, SLOT(SetScaledArrows(bool)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
             SLOT(DrawIcon()));
   }
@@ -290,7 +292,7 @@ namespace mapviz_plugins
     {
       DrawCovariance();
     }
-    if (DrawPoints())
+    if (DrawPoints(scale))
     {
       PrintInfo("OK");
     }
@@ -368,17 +370,24 @@ namespace mapviz_plugins
       ui_.buffersize->setValue(buffer_size_);
     }
 
-    if (swri_yaml_util::FindValue(node, "show_covariance"))
+    if (node["show_covariance"])
     {
       bool show_covariance = false;
       node["show_covariance"] >> show_covariance;
       ui_.show_covariance->setChecked(show_covariance);
     }
-    if (swri_yaml_util::FindValue(node, "show_laps"))
+    if (node["show_laps"])
     {
       bool show_laps = false;
       node["show_laps"] >> show_laps;
       ui_.show_laps->setChecked(show_laps);
+    }
+
+    if (node["scale_arrows"])
+    {
+      bool scale_arrows = node["scale_arrows"].as<bool>();
+      ui_.scale_arrows->setChecked(scale_arrows);
+      SetScaledArrows(scale_arrows);
     }
 
     TopicEdited();
@@ -411,5 +420,7 @@ namespace mapviz_plugins
 
     bool show_covariance = ui_.show_covariance->isChecked();
     emitter << YAML::Key << "show_covariance" << YAML::Value << show_covariance;
+
+    emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
   }
 }

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -83,8 +83,8 @@ namespace mapviz_plugins
                      SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
                      SLOT(SetDrawStyle(QString)));
-    QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
-                     this, SLOT(SetScaledArrows(bool)));
+    QObject::connect(ui_.static_arrow_sizes, SIGNAL(clicked(bool)),
+                     this, SLOT(SetStaticArrowSizes(bool)));
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
@@ -385,11 +385,11 @@ namespace mapviz_plugins
       ui_.show_laps->setChecked(show_laps);
     }
 
-    if (node["scale_arrows"])
+    if (node["static_arrow_sizes"])
     {
-      bool scale_arrows = node["scale_arrows"].as<bool>();
-      ui_.scale_arrows->setChecked(scale_arrows);
-      SetScaledArrows(scale_arrows);
+      bool static_arrow_sizes = node["static_arrow_sizes"].as<bool>();
+      ui_.static_arrow_sizes->setChecked(static_arrow_sizes);
+      SetStaticArrowSizes(static_arrow_sizes);
     }
 
     if (node["arrow_size"])
@@ -428,7 +428,7 @@ namespace mapviz_plugins
     bool show_covariance = ui_.show_covariance->isChecked();
     emitter << YAML::Key << "show_covariance" << YAML::Value << show_covariance;
 
-    emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
+    emitter << YAML::Key << "static_arrow_sizes" << YAML::Value << ui_.static_arrow_sizes->isChecked();
 
     emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
   }

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -85,6 +85,8 @@ namespace mapviz_plugins
                      SLOT(SetDrawStyle(QString)));
     QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
                      this, SLOT(SetScaledArrows(bool)));
+    QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
+                     this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
             SLOT(DrawIcon()));
   }
@@ -390,6 +392,11 @@ namespace mapviz_plugins
       SetScaledArrows(scale_arrows);
     }
 
+    if (node["arrow_size"])
+    {
+      ui_.arrow_size->setValue(node["arrow_size"].as<int>());
+    }
+
     TopicEdited();
   }
 
@@ -422,5 +429,7 @@ namespace mapviz_plugins
     emitter << YAML::Key << "show_covariance" << YAML::Value << show_covariance;
 
     emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
+
+    emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
   }
 }

--- a/mapviz_plugins/src/path_config.ui
+++ b/mapviz_plugins/src/path_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>79</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
    <property name="margin">
     <number>2</number>
    </property>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -48,7 +48,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="2" colspan="2">
+   <item row="6" column="2" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -124,6 +124,19 @@
       <string/>
      </property>
     </widget>
+   </item>
+   <item row="5" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -184,15 +184,15 @@ namespace mapviz_plugins
 
   void PathPlugin::Draw(double x, double y, double scale)
   {
-    bool lines, points;
-    lines = points = false;
+    bool lines;
+    bool points;
     color_ = ui_.path_color->color();
     draw_style_ = LINES;
-    lines = DrawPoints();
+    lines = DrawPoints(scale);
     color_ = color_.dark(200);
     draw_style_ = POINTS;
-    points = DrawPoints();
-    if (lines == true && points == true)
+    points = DrawPoints(scale);
+    if (lines && points)
     {
       PrintInfo("OK");
     }

--- a/mapviz_plugins/src/point_drawing_plugin.cpp
+++ b/mapviz_plugins/src/point_drawing_plugin.cpp
@@ -54,7 +54,7 @@ namespace mapviz_plugins
         lap_checked_(false),
         buffer_holder_(false),
         scale_(1.0),
-        scale_arrows_(false),
+        static_arrow_sizes_(false),
         got_begin_(false)
   {
   }
@@ -122,9 +122,9 @@ namespace mapviz_plugins
     DrawIcon();
   }
 
-  void PointDrawingPlugin::SetScaledArrows(bool isChecked)
+  void PointDrawingPlugin::SetStaticArrowSizes(bool isChecked)
   {
-    scale_arrows_ = isChecked;
+    static_arrow_sizes_ = isChecked;
   }
 
   bool PointDrawingPlugin::DrawPoints(double scale)
@@ -283,13 +283,13 @@ namespace mapviz_plugins
                                 point.orientation);
 
       double size = static_cast<double>(arrow_size_);
-      if (scale_arrows_)
+      if (static_arrow_sizes_)
       {
-        size /= 10.0;
+        size *= scale_;
       }
       else
       {
-        size *= scale_;
+        size /= 10.0;
       }
       double arrow_width = size / 5.0;
       double head_length = size * 0.75;

--- a/mapviz_plugins/src/point_drawing_plugin.cpp
+++ b/mapviz_plugins/src/point_drawing_plugin.cpp
@@ -52,9 +52,12 @@ namespace mapviz_plugins
         new_lap_(true),
         lap_checked_(false),
         buffer_holder_(false),
+        scale_(1.0),
+        scale_arrows_(false),
         got_begin_(false)
   {
   }
+
   void PointDrawingPlugin::DrawIcon()
   {
     if (icon_)
@@ -94,6 +97,7 @@ namespace mapviz_plugins
       icon_->SetPixmap(icon);
     }
   }
+
   void PointDrawingPlugin::SetDrawStyle(QString style)
   {
     if (style == "lines")
@@ -112,20 +116,27 @@ namespace mapviz_plugins
     DrawIcon();
   }
 
-  bool PointDrawingPlugin::DrawPoints()
+  void PointDrawingPlugin::SetScaledArrows(bool isChecked)
   {
-    bool transformed = false;
+    ROS_INFO("Scale arrows? %d", isChecked);
+    scale_arrows_ = isChecked;
+  }
+
+  bool PointDrawingPlugin::DrawPoints(double scale)
+  {
+    scale_ = scale;
+    bool transformed = true;
     if (lap_checked_)
     {
       CollectLaps();
 
       if (draw_style_ == ARROWS)
       {
-        transformed = DrawLapsArrows();
+        transformed &= DrawLapsArrows();
       }
       else
       {
-        transformed = DrawLaps();
+        transformed &= DrawLaps();
       }
     }
     else if (buffer_size_ == INT_MAX)
@@ -136,14 +147,16 @@ namespace mapviz_plugins
     }
     if (draw_style_ == ARROWS)
     {
-      transformed = DrawArrows();
+      transformed &= DrawArrows();
     }
     else
     {
-      transformed = DrawLines();
+      transformed &= DrawLines();
     }
+
     return transformed;
   }
+
   void PointDrawingPlugin::CollectLaps()
   {
     if (!got_begin_)
@@ -177,7 +190,7 @@ namespace mapviz_plugins
 
   bool PointDrawingPlugin::DrawLines()
   {
-    bool transformed = false;
+    bool success = cur_point_.transformed;
     glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 1.0);
     if (draw_style_ == LINES)
     {
@@ -193,11 +206,10 @@ namespace mapviz_plugins
     std::list<StampedPoint>::iterator it = points_.begin();
     for (; it != points_.end(); ++it)
     {
+      success &= it->transformed;
       if (it->transformed)
       {
         glVertex2f(it->transformed_point.getX(), it->transformed_point.getY());
-
-        transformed = true;
       }
     }
 
@@ -205,14 +217,13 @@ namespace mapviz_plugins
     {
       glVertex2f(cur_point_.transformed_point.getX(),
                  cur_point_.transformed_point.getY());
-
-      transformed = true;
     }
 
     glEnd();
 
-    return transformed;
+    return success;
   }
+
   bool PointDrawingPlugin::DrawArrow(const StampedPoint& it)
   {
       if (it.transformed)
@@ -239,22 +250,23 @@ namespace mapviz_plugins
 
   bool PointDrawingPlugin::DrawArrows()
   {
-    bool transformed = false;
+    bool success = true;
     glLineWidth(2);
     glBegin(GL_LINES);
     glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 0.5);
     std::list<StampedPoint>::iterator it = points_.begin();
     for (; it != points_.end(); ++it)
     {
-      transformed = DrawArrow(*it);
+      success &= DrawArrow(*it);
     }
 
-    transformed = DrawArrow(cur_point_);
+    success &= DrawArrow(cur_point_);
 
     glEnd();
 
-    return transformed;
+    return success;
   }
+
   bool PointDrawingPlugin::TransformPoint(StampedPoint& point)
   {
     swri_transform_util::Transform transform;
@@ -264,12 +276,24 @@ namespace mapviz_plugins
 
       tf::Transform orientation(tf::Transform(transform.GetOrientation()) *
                                 point.orientation);
-      point.transformed_arrow_point =
-          point.transformed_point + orientation * tf::Point(1.0, 0.0, 0.0);
-      point.transformed_arrow_left =
-          point.transformed_point + orientation * tf::Point(0.75, -0.2, 0.0);
-      point.transformed_arrow_right =
-          point.transformed_point + orientation * tf::Point(0.75, 0.2, 0.0);
+      if (!scale_arrows_)
+      {
+        point.transformed_arrow_point =
+            point.transformed_point + orientation * tf::Point(25.0 * scale_, 0.0, 0.0);
+        point.transformed_arrow_left =
+            point.transformed_point + orientation * tf::Point(18.75 * scale_, -5.0 * scale_, 0.0);
+        point.transformed_arrow_right =
+            point.transformed_point + orientation * tf::Point(18.75 * scale_, 5.0 * scale_, 0.0);
+      }
+      else
+      {
+        point.transformed_arrow_point =
+            point.transformed_point + orientation * tf::Point(1.0, 0.0, 0.0);
+        point.transformed_arrow_left =
+            point.transformed_point + orientation * tf::Point(0.75 , -0.2, 0.0);
+        point.transformed_arrow_right =
+            point.transformed_point + orientation * tf::Point(0.75, 0.2, 0.0);
+      }
 
       if (covariance_checked_)
       {
@@ -318,7 +342,7 @@ namespace mapviz_plugins
 
   bool PointDrawingPlugin::DrawLaps()
   {
-    bool transformed = false;
+    bool transformed = points_.size() != 0;
     glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 0.5);
     glLineWidth(3);
     QColor base_color = color_;
@@ -369,11 +393,11 @@ namespace mapviz_plugins
       std::list<StampedPoint>::iterator it = points_.begin();
       for (; it != points_.end(); ++it)
       {
+        transformed &= it->transformed;
         if (it->transformed)
         {
           glVertex2f(it->transformed_point.getX(),
                      it->transformed_point.getY());
-          transformed = true;
         }
       }
     }
@@ -381,6 +405,7 @@ namespace mapviz_plugins
     glEnd();
     return transformed;
   }
+
   void PointDrawingPlugin::UpdateColor(QColor base_color, int i)
   {
       int hue = color_.hue() + (i + 1) * 10 * M_PI;
@@ -397,7 +422,7 @@ namespace mapviz_plugins
 
   bool PointDrawingPlugin::DrawLapsArrows()
   {
-    bool transformed = false;
+    bool success = laps_.size() != 0 && points_.size() != 0;
     glColor4f(color_.redF(), color_.greenF(), color_.blueF(), 0.5);
     glLineWidth(2);
     QColor base_color = color_;
@@ -410,7 +435,7 @@ namespace mapviz_plugins
         for (; it != laps_[i].end(); ++it)
         {
           glBegin(GL_LINE_STRIP);
-          transformed = DrawArrow(*it);
+          success &= DrawArrow(*it);
           glEnd();
         }
       }
@@ -430,11 +455,11 @@ namespace mapviz_plugins
       for (; it != points_.end(); ++it)
       {
         glBegin(GL_LINE_STRIP);
-        transformed = DrawArrow(*it);
+        success &= DrawArrow(*it);
         glEnd();
       }
     }
 
-    return transformed;
+    return success;
   }
 }

--- a/mapviz_plugins/src/point_drawing_plugin.cpp
+++ b/mapviz_plugins/src/point_drawing_plugin.cpp
@@ -45,7 +45,8 @@
 namespace mapviz_plugins
 {
   PointDrawingPlugin::PointDrawingPlugin()
-      : draw_style_(LINES),
+      : arrow_size_(25),
+        draw_style_(LINES),
         position_tolerance_(0.0),
         buffer_size_(0),
         covariance_checked_(false),
@@ -98,6 +99,11 @@ namespace mapviz_plugins
     }
   }
 
+  void PointDrawingPlugin::SetArrowSize(int arrowSize)
+  {
+    arrow_size_ = arrowSize;
+  }
+
   void PointDrawingPlugin::SetDrawStyle(QString style)
   {
     if (style == "lines")
@@ -118,7 +124,6 @@ namespace mapviz_plugins
 
   void PointDrawingPlugin::SetScaledArrows(bool isChecked)
   {
-    ROS_INFO("Scale arrows? %d", isChecked);
     scale_arrows_ = isChecked;
   }
 
@@ -276,24 +281,25 @@ namespace mapviz_plugins
 
       tf::Transform orientation(tf::Transform(transform.GetOrientation()) *
                                 point.orientation);
-      if (!scale_arrows_)
+
+      double size = static_cast<double>(arrow_size_);
+      if (scale_arrows_)
       {
-        point.transformed_arrow_point =
-            point.transformed_point + orientation * tf::Point(25.0 * scale_, 0.0, 0.0);
-        point.transformed_arrow_left =
-            point.transformed_point + orientation * tf::Point(18.75 * scale_, -5.0 * scale_, 0.0);
-        point.transformed_arrow_right =
-            point.transformed_point + orientation * tf::Point(18.75 * scale_, 5.0 * scale_, 0.0);
+        size /= 10.0;
       }
       else
       {
-        point.transformed_arrow_point =
-            point.transformed_point + orientation * tf::Point(1.0, 0.0, 0.0);
-        point.transformed_arrow_left =
-            point.transformed_point + orientation * tf::Point(0.75 , -0.2, 0.0);
-        point.transformed_arrow_right =
-            point.transformed_point + orientation * tf::Point(0.75, 0.2, 0.0);
+        size *= scale_;
       }
+      double arrow_width = size / 5.0;
+      double head_length = size * 0.75;
+
+      point.transformed_arrow_point =
+          point.transformed_point + orientation * tf::Point(size, 0.0, 0.0);
+      point.transformed_arrow_left =
+          point.transformed_point + orientation * tf::Point(head_length, -arrow_width, 0.0);
+      point.transformed_arrow_right =
+          point.transformed_point + orientation * tf::Point(head_length, arrow_width, 0.0);
 
       if (covariance_checked_)
       {

--- a/mapviz_plugins/src/tf_frame_config.ui
+++ b/mapviz_plugins/src/tf_frame_config.ui
@@ -64,7 +64,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Scaled Arrows:</string>
+      <string>Static Arrow Sizes:</string>
      </property>
     </widget>
    </item>
@@ -247,7 +247,7 @@
    <item row="5" column="1" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QCheckBox" name="scale_arrows">
+      <widget class="QCheckBox" name="static_arrow_sizes">
        <property name="text">
         <string/>
        </property>
@@ -255,6 +255,9 @@
      </item>
      <item>
       <widget class="QSlider" name="arrow_size">
+       <property name="minimum">
+        <number>1</number>
+       </property>
        <property name="maximum">
         <number>500</number>
        </property>

--- a/mapviz_plugins/src/tf_frame_config.ui
+++ b/mapviz_plugins/src/tf_frame_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>197</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -42,7 +42,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -55,7 +55,20 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1" colspan="2">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Scaled Arrows:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -231,25 +244,42 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Scaled Arrows:</string>
-     </property>
-    </widget>
+   <item row="5" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="scale_arrows">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="arrow_size">
+       <property name="maximum">
+        <number>500</number>
+       </property>
+       <property name="value">
+        <number>25</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="scale_arrows">
-     <property name="text">
-      <string/>
+   <item row="8" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/mapviz_plugins/src/tf_frame_config.ui
+++ b/mapviz_plugins/src/tf_frame_config.ui
@@ -23,7 +23,26 @@
    <property name="margin">
     <number>2</number>
    </property>
-   <item row="7" column="0">
+   <item row="3" column="1">
+    <widget class="mapviz::ColorButton" name="color">
+     <property name="maximumSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -36,7 +55,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="2">
+   <item row="8" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -113,7 +132,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -126,7 +145,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="positiontolerance">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -145,26 +164,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="mapviz::ColorButton" name="color">
-     <property name="maximumSize">
-      <size>
-       <width>24</width>
-       <height>24</height>
-      </size>
-     </property>
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -177,7 +177,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="QSpinBox" name="buffersize">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
@@ -229,6 +229,26 @@
        <string>arrows</string>
       </property>
      </item>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Scaled Arrows:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="scale_arrows">
+     <property name="text">
+      <string/>
+     </property>
     </widget>
    </item>
   </layout>

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -78,8 +78,8 @@ namespace mapviz_plugins
                      SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
                      SLOT(SetDrawStyle(QString)));
-    QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
-                     this, SLOT(SetScaledArrows(bool)));
+    QObject::connect(ui_.static_arrow_sizes, SIGNAL(clicked(bool)),
+                     this, SLOT(SetStaticArrowSizes(bool)));
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
@@ -269,11 +269,11 @@ namespace mapviz_plugins
       ui_.buffersize->setValue(buffer_size_);
     }
 
-    if (node["scale_arrows"])
+    if (node["static_arrow_sizes"])
     {
-      bool scale_arrows = node["scale_arrows"].as<bool>();
-      ui_.scale_arrows->setChecked(scale_arrows);
-      SetScaledArrows(scale_arrows);
+      bool static_arrow_sizes = node["static_arrow_sizes"].as<bool>();
+      ui_.static_arrow_sizes->setChecked(static_arrow_sizes);
+      SetStaticArrowSizes(static_arrow_sizes);
     }
 
     if (node["arrow_size"])
@@ -300,7 +300,7 @@ namespace mapviz_plugins
 
     emitter << YAML::Key << "buffer_size" << YAML::Value << buffer_size_;
 
-    emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
+    emitter << YAML::Key << "static_arrow_sizes" << YAML::Value << ui_.static_arrow_sizes->isChecked();
 
     emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
   }

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -80,6 +80,8 @@ namespace mapviz_plugins
                      SLOT(SetDrawStyle(QString)));
     QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
                      this, SLOT(SetScaledArrows(bool)));
+    QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
+                     this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
             SLOT(DrawIcon()));
   }
@@ -274,6 +276,11 @@ namespace mapviz_plugins
       SetScaledArrows(scale_arrows);
     }
 
+    if (node["arrow_size"])
+    {
+      ui_.arrow_size->setValue(node["arrow_size"].as<int>());
+    }
+
     FrameEdited();
   }
 
@@ -294,5 +301,7 @@ namespace mapviz_plugins
     emitter << YAML::Key << "buffer_size" << YAML::Value << buffer_size_;
 
     emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
+
+    emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
   }
 }

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -78,6 +78,8 @@ namespace mapviz_plugins
                      SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
                      SLOT(SetDrawStyle(QString)));
+    QObject::connect(ui_.scale_arrows, SIGNAL(clicked(bool)),
+                     this, SLOT(SetScaledArrows(bool)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
             SLOT(DrawIcon()));
   }
@@ -215,7 +217,7 @@ namespace mapviz_plugins
   void TfFramePlugin::Draw(double x, double y, double scale)
   {
     color_ = ui_.color->color();
-    if (DrawPoints())
+    if (DrawPoints(scale))
     {
       PrintInfo("OK");
     }
@@ -265,6 +267,13 @@ namespace mapviz_plugins
       ui_.buffersize->setValue(buffer_size_);
     }
 
+    if (node["scale_arrows"])
+    {
+      bool scale_arrows = node["scale_arrows"].as<bool>();
+      ui_.scale_arrows->setChecked(scale_arrows);
+      SetScaledArrows(scale_arrows);
+    }
+
     FrameEdited();
   }
 
@@ -283,5 +292,7 @@ namespace mapviz_plugins
                YAML::Value << position_tolerance_;
 
     emitter << YAML::Key << "buffer_size" << YAML::Value << buffer_size_;
+
+    emitter << YAML::Key << "scale_arrows" << YAML::Value << ui_.scale_arrows->isChecked();
   }
 }


### PR DESCRIPTION
This adds a checkbox to all of the plugins that can draw a series of
coordinates as arrows; i. e., the NavSatFix, Odometry, and TF Frame
plugins.  This checkbox will control whether the arrows are drawn at a fixed
size regardless of zoom level or whether they are scaled with the zoom level.

Resolves #414