### PR TITLE
Fix icon colors for point drawing plugins (Jade)

### DIFF
--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -237,13 +237,14 @@ namespace mapviz
 
     virtual QWidget* GetConfigWidget(QWidget* parent) { return NULL; }
 
-    virtual void DrawIcon() {}
-
     virtual void PrintError(const std::string& message) = 0;
     virtual void PrintInfo(const std::string& message) = 0;
     virtual void PrintWarning(const std::string& message) = 0;
 
     void SetIcon(IconWidget* icon) { icon_ = icon; }
+
+  public Q_SLOTS:
+    virtual void DrawIcon() {}
 
     /**
      * Override this to return "true" if you want QPainter support for your

--- a/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
@@ -93,6 +93,7 @@ namespace mapviz_plugins
 
    protected Q_SLOTS:
     virtual void DrawIcon();
+    virtual void SetColor(const QColor& color);
     virtual void SetDrawStyle(QString style);
     virtual void SetStaticArrowSizes(bool isChecked);
     virtual void SetArrowSize(int arrowSize);

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -78,7 +78,7 @@ namespace mapviz_plugins
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
-            SLOT(DrawIcon()));
+            SLOT(SetColor(const QColor&)));
   }
 
   NavSatPlugin::~NavSatPlugin()
@@ -226,13 +226,12 @@ namespace mapviz_plugins
   bool NavSatPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
-    DrawIcon();
+    SetColor(ui_.color->color());
     return true;
   }
 
   void NavSatPlugin::Draw(double x, double y, double scale)
   {
-    color_ = ui_.color->color();
     if (DrawPoints(scale))
     {
       PrintInfo("OK");
@@ -252,7 +251,8 @@ namespace mapviz_plugins
     {
       std::string color;
       node["color"] >> color;
-      ui_.color->setColor(QColor(color.c_str()));
+      SetColor(QColor(color.c_str()));
+      ui_.color->setColor(color_);
     }
 
     if (node["draw_style"])

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -88,7 +88,7 @@ namespace mapviz_plugins
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
-            SLOT(DrawIcon()));
+            SLOT(SetColor(const QColor&)));
   }
 
   OdometryPlugin::~OdometryPlugin()
@@ -280,16 +280,13 @@ namespace mapviz_plugins
   bool OdometryPlugin::Initialize(QGLWidget* canvas)
   {
     canvas_ = canvas;
-    color_ = ui_.color->color();
-    DrawIcon();
+    SetColor(ui_.color->color());
 
     return true;
   }
 
   void OdometryPlugin::Draw(double x, double y, double scale)
   {
-    color_ = ui_.color->color();
-
     if (ui_.show_covariance->isChecked())
     {
       DrawCovariance();
@@ -335,7 +332,8 @@ namespace mapviz_plugins
     {
       std::string color;
       node["color"] >> color;
-      ui_.color->setColor(QColor(color.c_str()));
+      SetColor(QColor(color.c_str()));
+      ui_.color->setColor(color_);
     }
 
     if (node["draw_style"])

--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -69,7 +69,7 @@ namespace mapviz_plugins
     connect(ui_.selecttopic, SIGNAL(clicked()), this, SLOT(SelectTopic()));
     connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
     connect(ui_.path_color, SIGNAL(colorEdited(const QColor&)), this,
-            SLOT(DrawIcon()));
+            SLOT(SetColor(const QColor&)));
   }
 
   PathPlugin::~PathPlugin()
@@ -186,12 +186,13 @@ namespace mapviz_plugins
   {
     bool lines;
     bool points;
-    color_ = ui_.path_color->color();
+    QColor old_color = ui_.path_color->color();
     draw_style_ = LINES;
     lines = DrawPoints(scale);
     color_ = color_.dark(200);
     draw_style_ = POINTS;
     points = DrawPoints(scale);
+    color_ = old_color;
     if (lines && points)
     {
       PrintInfo("OK");
@@ -212,7 +213,8 @@ namespace mapviz_plugins
     {
       std::string color;
       node["color"] >> color;
-      ui_.path_color->setColor(QColor(color.c_str()));
+      SetColor(QColor(color.c_str()));
+      ui_.path_color->setColor(color_);
     }
   }
 

--- a/mapviz_plugins/src/point_drawing_plugin.cpp
+++ b/mapviz_plugins/src/point_drawing_plugin.cpp
@@ -272,6 +272,15 @@ namespace mapviz_plugins
     return success;
   }
 
+  void PointDrawingPlugin::SetColor(const QColor& color)
+  {
+    if (color != color_)
+    {
+      color_ = color;
+      DrawIcon();
+    }
+  }
+
   bool PointDrawingPlugin::TransformPoint(StampedPoint& point)
   {
     swri_transform_util::Transform transform;

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -83,7 +83,7 @@ namespace mapviz_plugins
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
-            SLOT(DrawIcon()));
+            SLOT(SetColor(const QColor&)));
   }
 
   TfFramePlugin::~TfFramePlugin()
@@ -211,14 +211,13 @@ namespace mapviz_plugins
     timer_ = node_.createTimer(ros::Duration(0.1),
                                &TfFramePlugin::TimerCallback, this);
 
-    DrawIcon();
+    SetColor(ui_.color->color());
 
     return true;
   }
 
   void TfFramePlugin::Draw(double x, double y, double scale)
   {
-    color_ = ui_.color->color();
     if (DrawPoints(scale))
     {
       PrintInfo("OK");
@@ -237,7 +236,8 @@ namespace mapviz_plugins
     {
       std::string color;
       node["color"] >> color;
-      ui_.color->setColor(QColor(color.c_str()));
+      SetColor(QColor(color.c_str()));
+      ui_.color->setColor(color_);
     }
 
     if (node["draw_style"])


### PR DESCRIPTION
This was probably broken back when all of these were refactored to have a
single base class.  It looks like the member variable that holds the color
used to draw the icon was never actually being updated.

Fixes #426