### PR TITLE
Add a GUI for controlling the Image Transport (Jade)

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(mapviz)
 
 find_package(catkin REQUIRED COMPONENTS
+  image_transport
   marti_common_msgs
   message_generation
   rosapi

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -44,6 +44,7 @@
 // QT libraries
 #include <QtGui/QtGui>
 #include <QDialog>
+#include <QMenu>
 #include <QTimer>
 #include <QString>
 #include <QShowEvent>
@@ -105,6 +106,8 @@ namespace mapviz
     void ToggleEnableAntialiasing(bool on);
     void ToggleShowPlugin(QListWidgetItem* item, bool visible);
     void ToggleRecord(bool on);
+    void SetImageTransport(QAction* transport_action);
+    void UpdateImageTransportMenu();
     void CaptureVideoFrame();
     void StopRecord();
     void Screenshot();
@@ -116,8 +119,13 @@ namespace mapviz
     void Hover(double x, double y, double scale);
     void Recenter();
 
+  Q_SIGNALS:
+    void ImageTransportChanged();
+
   protected:
     Ui::mapviz ui_;
+
+    QMenu* image_transport_menu_;
 
     QTimer frame_timer_;
     QTimer spin_timer_;
@@ -182,6 +190,7 @@ namespace mapviz
 
     static const QString ROS_WORKSPACE_VAR;
     static const QString MAPVIZ_CONFIG_FILE;
+    static const std::string IMAGE_TRANSPORT_PARAM;
   };
 }
 

--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -260,7 +260,7 @@ namespace mapviz
     void TargetFrameChanged(const std::string& target_frame);
     void UseLatestTransformsChanged(bool use_latest_transforms);
     void VisibleChanged(bool visible);
-    
+
 
   protected:
     bool initialized_;

--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>message_runtime</exec_depend>
 
   <depend>glut</depend>
+  <depend>image_transport</depend>
   <exec_depend>libqt4</exec_depend>
   <build_depend>libqt4-dev</build_depend>
   <exec_depend>libqt4-opengl</exec_depend>

--- a/mapviz/src/mapviz.ui
+++ b/mapviz/src/mapviz.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>732</width>
+    <width>600</width>
     <height>600</height>
    </rect>
   </property>
@@ -30,7 +30,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>732</width>
+     <width>600</width>
      <height>27</height>
     </rect>
    </property>
@@ -60,6 +60,7 @@
     <addaction name="actionConfig_Dock"/>
     <addaction name="actionShow_Status_Bar"/>
     <addaction name="actionShow_Capture_Tools"/>
+    <addaction name="separator"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menu_View"/>
@@ -452,18 +453,23 @@
    </property>
   </action>
   <action name="actionEnable_Antialiasing">
-    <property name="checkable">
-      <bool>true</bool>
-    </property>
-    <property name="checked">
-      <bool>true</bool>
-    </property>
-    <property name="text">
-      <string>Enable Antialiasing</string>
-    </property>
-    <property name="statusTip">
-      <string>Enable antialiasing on the GL surface</string>
-    </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Antialiasing</string>
+   </property>
+   <property name="statusTip">
+    <string>Enable antialiasing on the GL surface</string>
+   </property>
+  </action>
+  <action name="actionImage_Transport">
+   <property name="text">
+    <string>Image Transport</string>
+   </property>
   </action>
  </widget>
  <customwidgets>

--- a/mapviz_plugins/include/mapviz_plugins/image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/image_plugin.h
@@ -83,6 +83,9 @@ namespace mapviz_plugins
 
     void Draw(double x, double y, double scale);
 
+    void CreateLocalNode();
+    virtual void SetNode(const ros::NodeHandle& node);
+
     void Transform() {}
 
     void LoadConfig(const YAML::Node& node, const std::string& path);
@@ -95,6 +98,9 @@ namespace mapviz_plugins
     void PrintInfo(const std::string& message);
     void PrintWarning(const std::string& message);
 
+  public Q_SLOTS:
+    void Resubscribe();
+
   protected Q_SLOTS:
     void SelectTopic();
     void TopicEdited();
@@ -105,6 +111,7 @@ namespace mapviz_plugins
     void SetWidth(int width);
     void SetHeight(int height);
     void SetSubscription(bool visible);
+    void SetTransport(const QString& transport);
 
   private:
     Ui::image_config ui_;
@@ -117,12 +124,15 @@ namespace mapviz_plugins
     int offset_y_;
     int width_;
     int height_;
+    QString transport_;
 
+    bool force_resubscribe_;
     bool has_image_;
 
     int last_width_;
     int last_height_;
 
+    ros::NodeHandle local_node_;
     image_transport::Subscriber image_sub_;
     bool has_message_;
 

--- a/mapviz_plugins/src/image_config.ui
+++ b/mapviz_plugins/src/image_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>334</width>
+    <height>262</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,16 +23,32 @@
    <property name="margin">
     <number>2</number>
    </property>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="7" column="1">
+    <widget class="QSpinBox" name="height">
+     <property name="maximum">
+      <number>2000</number>
+     </property>
+     <property name="value">
+      <number>240</number>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1" colspan="2">
+    <widget class="QLabel" name="status">
      <property name="font">
       <font>
        <family>Sans Serif</family>
        <pointsize>8</pointsize>
       </font>
      </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="text">
-      <string>Status:</string>
+      <string>No topic</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -58,13 +74,29 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="topic">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="font">
       <font>
        <family>Sans Serif</family>
        <pointsize>8</pointsize>
       </font>
+     </property>
+     <property name="text">
+      <string>Anchor:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Width:</string>
      </property>
     </widget>
    </item>
@@ -78,6 +110,60 @@
      </property>
      <property name="text">
       <string>Topic:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QComboBox" name="transport_combo_box">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>25</height>
+      </size>
+     </property>
+     <item>
+      <property name="text">
+       <string>default</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Offset X:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Units:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Status:</string>
      </property>
     </widget>
    </item>
@@ -142,91 +228,6 @@
      </item>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Anchor:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Offset X:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QSpinBox" name="offsetx">
-     <property name="maximum">
-      <number>2000</number>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1" colspan="2">
-    <widget class="QLabel" name="status">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>No topic</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Offset Y:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QSpinBox" name="offsety">
-     <property name="maximum">
-      <number>2000</number>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Width:</string>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="1">
     <widget class="QSpinBox" name="width">
      <property name="maximum">
@@ -234,6 +235,16 @@
      </property>
      <property name="value">
       <number>320</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="topic">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
      </property>
     </widget>
    </item>
@@ -250,18 +261,8 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <widget class="QSpinBox" name="height">
-     <property name="maximum">
-      <number>2000</number>
-     </property>
-     <property name="value">
-      <number>240</number>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_8">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_5">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -269,7 +270,14 @@
       </font>
      </property>
      <property name="text">
-      <string>Units:</string>
+      <string>Offset Y:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QSpinBox" name="offsetx">
+     <property name="maximum">
+      <number>2000</number>
      </property>
     </widget>
    </item>
@@ -298,6 +306,39 @@
       </property>
      </item>
     </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Transport:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QSpinBox" name="offsety">
+     <property name="maximum">
+      <number>2000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This will add a sub-menu under the "View" menu that will:
- List all available image transports
- Indicate which one is currently the default
- Allow the user to choose which one will be used for new ImageTransport subscriptions
- Save and restore this setting to Mapviz's config file
- Cause any `image` plugins using the default transport to resubscribe

In addition, the image plugin now has a menu that can be used to change the
transport for that specific plugin so that it is different from the default.

Fixes #430