### PR TITLE
Add a GUI for controlling the Image Transport (Kinetic)

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(mapviz)
 
 find_package(catkin REQUIRED COMPONENTS
+  image_transport
   marti_common_msgs
   message_generation
   rosapi

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -44,6 +44,7 @@
 // QT libraries
 #include <QtGui/QtGui>
 #include <QDialog>
+#include <QMenu>
 #include <QTimer>
 #include <QString>
 #include <QShowEvent>
@@ -105,6 +106,8 @@ namespace mapviz
     void ToggleEnableAntialiasing(bool on);
     void ToggleShowPlugin(QListWidgetItem* item, bool visible);
     void ToggleRecord(bool on);
+    void SetImageTransport(QAction* transport_action);
+    void UpdateImageTransportMenu();
     void CaptureVideoFrame();
     void StopRecord();
     void Screenshot();
@@ -116,8 +119,13 @@ namespace mapviz
     void Hover(double x, double y, double scale);
     void Recenter();
 
+  Q_SIGNALS:
+    void ImageTransportChanged();
+
   protected:
     Ui::mapviz ui_;
+
+    QMenu* image_transport_menu_;
 
     QTimer frame_timer_;
     QTimer spin_timer_;
@@ -182,6 +190,7 @@ namespace mapviz
 
     static const QString ROS_WORKSPACE_VAR;
     static const QString MAPVIZ_CONFIG_FILE;
+    static const std::string IMAGE_TRANSPORT_PARAM;
   };
 }
 

--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -260,7 +260,7 @@ namespace mapviz
     void TargetFrameChanged(const std::string& target_frame);
     void UseLatestTransformsChanged(bool use_latest_transforms);
     void VisibleChanged(bool visible);
-    
+
 
   protected:
     bool initialized_;

--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -17,26 +17,26 @@
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>
 
+  <build_depend>libqt5-opengl-dev</build_depend>
   <depend>glut</depend>
+  <depend>image_transport</depend>
   <depend>libglew-dev</depend>
   <depend>libopencv-dev</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-opengl</depend>
-  <build_depend>libqt5-opengl-dev</build_depend>
   <depend>libqt5-widgets</depend>
   <depend>libxmu-dev</depend>
   <depend>marti_common_msgs</depend>
   <depend>pluginlib</depend>
-  <depend>qt4-qmake</depend>
   <depend>rosapi</depend>
   <depend>roscpp</depend>
   <depend>rqt_gui_cpp</depend>
   <depend>rqt_gui</depend>
   <depend>std_srvs</depend>
-  <depend>tf</depend>
   <depend>swri_transform_util</depend>
   <depend>swri_yaml_util</depend>
+  <depend>tf</depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -65,10 +65,13 @@
 #include <mapviz/config_item.h>
 #include <QtGui/QtGui>
 
+#include <image_transport/image_transport.h>
+
 namespace mapviz
 {
 const QString Mapviz::ROS_WORKSPACE_VAR = "ROS_WORKSPACE";
 const QString Mapviz::MAPVIZ_CONFIG_FILE = "/.mapviz_config";
+const std::string Mapviz::IMAGE_TRANSPORT_PARAM = "image_transport";
 
 Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::WindowFlags flags) :
     QMainWindow(parent, flags),
@@ -167,6 +170,11 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
   connect(stop_button_, SIGNAL(clicked()), this, SLOT(StopRecord()));
   connect(screenshot_button_, SIGNAL(clicked()), this, SLOT(Screenshot()));
 
+  image_transport_menu_ = new QMenu("Default Image Transport", ui_.menu_View);
+  ui_.menu_View->addMenu(image_transport_menu_);
+
+  connect(image_transport_menu_, SIGNAL(aboutToShow()), this, SLOT(UpdateImageTransportMenu()));
+
   ui_.bg_color->setColor(background_);
   canvas_->SetBackground(background_);
 }
@@ -201,7 +209,23 @@ void Mapviz::Initialize()
       connect(&spin_timer_, SIGNAL(timeout()), this, SLOT(SpinOnce()));
     }
 
-    node_ = new ros::NodeHandle("mapviz");
+    node_ = new ros::NodeHandle("~");
+
+    // Create a sub-menu that lists all available Image Transports
+    image_transport::ImageTransport it(*node_);
+    std::vector<std::string> transports = it.getLoadableTransports();
+    QActionGroup* group = new QActionGroup(image_transport_menu_);
+    for (std::vector<std::string>::iterator iter = transports.begin(); iter != transports.end(); iter++)
+    {
+      QString transport = QString::fromStdString(*iter).replace(
+          QString::fromStdString(IMAGE_TRANSPORT_PARAM) + "/", "");
+      QAction* action = image_transport_menu_->addAction(transport);
+      action->setCheckable(true);
+      group->addAction(action);
+    }
+
+    connect(group, SIGNAL(triggered(QAction*)), this, SLOT(SetImageTransport(QAction*)));
+
     tf_ = boost::make_shared<tf::TransformListener>();
     tf_manager_.Initialize(tf_);
 
@@ -604,6 +628,14 @@ void Mapviz::Open(const std::string& filename)
       }
     }
 
+    if (swri_yaml_util::FindValue(doc, IMAGE_TRANSPORT_PARAM))
+    {
+      std::string image_transport;
+      doc[IMAGE_TRANSPORT_PARAM] >> image_transport;
+
+      node_->setParam(IMAGE_TRANSPORT_PARAM, image_transport);
+    }
+
     bool use_latest_transforms = true;
     if (swri_yaml_util::FindValue(doc, "use_latest_transforms"))
     {
@@ -706,6 +738,11 @@ void Mapviz::Save(const std::string& filename)
   out << YAML::Key << "offset_y" << YAML::Value << canvas_->OffsetY();
   out << YAML::Key << "use_latest_transforms" << YAML::Value << ui_.uselatesttransforms->isChecked();
   out << YAML::Key << "background" << YAML::Value << background_.name().toStdString();
+  std::string image_transport;
+  if (node_->getParam(IMAGE_TRANSPORT_PARAM, image_transport))
+  {
+    out << YAML::Key << IMAGE_TRANSPORT_PARAM << YAML::Value << image_transport;
+  }
 
   if (force_720p_)
   {
@@ -1074,6 +1111,16 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
   connect(plugin.get(), SIGNAL(VisibleChanged(bool)), config_item, SLOT(ToggleDraw(bool)));
   connect(plugin.get(), SIGNAL(SizeChanged()), this, SLOT(UpdateSizeHints()));
 
+  if (real_type == "mapviz_plugins/image")
+  {
+    // This is a little kludgey because we're relying on hard-coding a
+    // plugin type here... feel free to suggest a better way.
+    // If the default image transport has changed, we want to notify all of our
+    // image plugins of it so that they will resubscribe appropriately.
+    connect(this, SIGNAL(ImageTransportChanged()),
+            plugin.get(), SLOT(Resubscribe()));
+  }
+
   if (draw_order == 0)
   {
     ui_.configs->addItem(item);
@@ -1242,6 +1289,34 @@ void Mapviz::ToggleRecord(bool on)
     rec_button_->setToolTip("Continue recording video of display canvas");
     record_timer_.stop();
   }
+}
+
+void Mapviz::SetImageTransport(QAction* transport_action)
+{
+  std::string transport = transport_action->text().toStdString();
+  ROS_INFO("Setting %s to %s", IMAGE_TRANSPORT_PARAM.c_str(), transport.c_str());
+  node_->setParam(IMAGE_TRANSPORT_PARAM, transport);
+
+  Q_EMIT(ImageTransportChanged());
+}
+
+void Mapviz::UpdateImageTransportMenu()
+{
+  QList<QAction*> actions = image_transport_menu_->actions();
+
+  std::string current_transport;
+  node_->param<std::string>(IMAGE_TRANSPORT_PARAM, current_transport, "raw");
+  Q_FOREACH(QAction* action, actions)
+  {
+    if (action->text() == QString::fromStdString(current_transport))
+    {
+      action->setChecked(true);
+      return;
+    }
+  }
+
+  ROS_WARN("%s param was set to an unrecognized value: %s",
+           IMAGE_TRANSPORT_PARAM.c_str(), current_transport.c_str());
 }
 
 void Mapviz::CaptureVideoFrame()

--- a/mapviz/src/mapviz.ui
+++ b/mapviz/src/mapviz.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>732</width>
+    <width>600</width>
     <height>600</height>
    </rect>
   </property>
@@ -30,7 +30,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>732</width>
+     <width>600</width>
      <height>27</height>
     </rect>
    </property>
@@ -60,6 +60,7 @@
     <addaction name="actionConfig_Dock"/>
     <addaction name="actionShow_Status_Bar"/>
     <addaction name="actionShow_Capture_Tools"/>
+    <addaction name="separator"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menu_View"/>
@@ -452,18 +453,23 @@
    </property>
   </action>
   <action name="actionEnable_Antialiasing">
-    <property name="checkable">
-      <bool>true</bool>
-    </property>
-    <property name="checked">
-      <bool>true</bool>
-    </property>
-    <property name="text">
-      <string>Enable Antialiasing</string>
-    </property>
-    <property name="statusTip">
-      <string>Enable antialiasing on the GL surface</string>
-    </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Antialiasing</string>
+   </property>
+   <property name="statusTip">
+    <string>Enable antialiasing on the GL surface</string>
+   </property>
+  </action>
+  <action name="actionImage_Transport">
+   <property name="text">
+    <string>Image Transport</string>
+   </property>
   </action>
  </widget>
  <customwidgets>

--- a/mapviz_plugins/include/mapviz_plugins/image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/image_plugin.h
@@ -83,6 +83,9 @@ namespace mapviz_plugins
 
     void Draw(double x, double y, double scale);
 
+    void CreateLocalNode();
+    virtual void SetNode(const ros::NodeHandle& node);
+
     void Transform() {}
 
     void LoadConfig(const YAML::Node& node, const std::string& path);
@@ -95,6 +98,9 @@ namespace mapviz_plugins
     void PrintInfo(const std::string& message);
     void PrintWarning(const std::string& message);
 
+  public Q_SLOTS:
+    void Resubscribe();
+
   protected Q_SLOTS:
     void SelectTopic();
     void TopicEdited();
@@ -105,6 +111,7 @@ namespace mapviz_plugins
     void SetWidth(int width);
     void SetHeight(int height);
     void SetSubscription(bool visible);
+    void SetTransport(const QString& transport);
 
   private:
     Ui::image_config ui_;
@@ -117,12 +124,15 @@ namespace mapviz_plugins
     int offset_y_;
     int width_;
     int height_;
+    QString transport_;
 
+    bool force_resubscribe_;
     bool has_image_;
 
     int last_width_;
     int last_height_;
 
+    ros::NodeHandle local_node_;
     image_transport::Subscriber image_sub_;
     bool has_message_;
 

--- a/mapviz_plugins/src/image_config.ui
+++ b/mapviz_plugins/src/image_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>334</width>
+    <height>262</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,16 +23,32 @@
    <property name="margin">
     <number>2</number>
    </property>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="7" column="1">
+    <widget class="QSpinBox" name="height">
+     <property name="maximum">
+      <number>2000</number>
+     </property>
+     <property name="value">
+      <number>240</number>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1" colspan="2">
+    <widget class="QLabel" name="status">
      <property name="font">
       <font>
        <family>Sans Serif</family>
        <pointsize>8</pointsize>
       </font>
      </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="text">
-      <string>Status:</string>
+      <string>No topic</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -58,13 +74,29 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="topic">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="font">
       <font>
        <family>Sans Serif</family>
        <pointsize>8</pointsize>
       </font>
+     </property>
+     <property name="text">
+      <string>Anchor:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Width:</string>
      </property>
     </widget>
    </item>
@@ -78,6 +110,60 @@
      </property>
      <property name="text">
       <string>Topic:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QComboBox" name="transport_combo_box">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>25</height>
+      </size>
+     </property>
+     <item>
+      <property name="text">
+       <string>default</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Offset X:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Units:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Status:</string>
      </property>
     </widget>
    </item>
@@ -142,91 +228,6 @@
      </item>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Anchor:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Offset X:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QSpinBox" name="offsetx">
-     <property name="maximum">
-      <number>2000</number>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1" colspan="2">
-    <widget class="QLabel" name="status">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>No topic</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Offset Y:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QSpinBox" name="offsety">
-     <property name="maximum">
-      <number>2000</number>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Width:</string>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="1">
     <widget class="QSpinBox" name="width">
      <property name="maximum">
@@ -234,6 +235,16 @@
      </property>
      <property name="value">
       <number>320</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="topic">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
      </property>
     </widget>
    </item>
@@ -250,18 +261,8 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <widget class="QSpinBox" name="height">
-     <property name="maximum">
-      <number>2000</number>
-     </property>
-     <property name="value">
-      <number>240</number>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_8">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_5">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -269,7 +270,14 @@
       </font>
      </property>
      <property name="text">
-      <string>Units:</string>
+      <string>Offset Y:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QSpinBox" name="offsetx">
+     <property name="maximum">
+      <number>2000</number>
      </property>
     </widget>
    </item>
@@ -298,6 +306,39 @@
       </property>
      </item>
     </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Transport:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QSpinBox" name="offsety">
+     <property name="maximum">
+      <number>2000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This will add a sub-menu under the "View" menu that will:
- List all available image transports
- Indicate which one is currently the default
- Allow the user to choose which one will be used for new ImageTransport subscriptions
- Save and restore this setting to Mapviz's config file
- Cause any `image` plugins using the default transport to resubscribe

In addition, the image plugin now has a menu that can be used to change the
transport for that specific plugin so that it is different from the default.

Fixes #430