### PR TITLE
Delete markers that have expired and remove error message. (Kinetic)

### DIFF
--- a/mapviz_plugins/CMakeLists.txt
+++ b/mapviz_plugins/CMakeLists.txt
@@ -155,6 +155,7 @@ target_link_libraries(${PROJECT_NAME}
     ${QT_LIBRARIES}
     ${QT_QTOPENGL_LIBRARIES}
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-std=c++11 -D__STDC_FORMAT_MACROS")
 
 add_dependencies(${PROJECT_NAME} marti_visualization_msgs_generate_messages_cpp)
 

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -424,7 +424,7 @@ namespace mapviz_plugins
     for (nsIter = markers_.begin(); nsIter != markers_.end(); ++nsIter)
     {
       std::map<int, MarkerData>::iterator markerIter;
-      for (markerIter = nsIter->second.begin(); markerIter != nsIter->second.end(); ++markerIter)
+      for (markerIter = nsIter->second.begin(); markerIter != nsIter->second.end();)
       {
         MarkerData& marker = markerIter->second;
 
@@ -631,12 +631,13 @@ namespace mapviz_plugins
 
             PrintInfo("OK");
           }
+
+          ++markerIter;
         }
         else
         {
           PrintInfo("OK");
-          ROS_ERROR("Not displaying expired marker[%s:%d]: %lf < %lf (now)",
-                    topic_.c_str(), markerIter->first, marker.expire_time.toSec(), now.toSec());
+          markerIter = nsIter->second.erase(markerIter);
         }
       }
     }


### PR DESCRIPTION
Delete markers that have expired and remove error message. 