### PR TITLE
added left_offset to robot image plugin config

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/robot_image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/robot_image_plugin.h
@@ -83,13 +83,16 @@ namespace mapviz_plugins
     void FrameEdited();
     void WidthChanged(double value);
     void HeightChanged(double value);
+    void LeftOffsetChanged(double value);
 
   private:
     Ui::robot_image_config ui_;
     QWidget* config_widget_;
 
-    double width_;
-    double height_;
+    double width_; //image width, if vehicle frame is x-forward this corresponds to vehicle length
+    double height_; //image height, corresponds to vehicle width
+    double left_offset_; //distance from left side of image to origin,
+    // if vehicle frame is on rear axle this corresponds to the rear overhang
 
     std::string filename_;
     QImage      image_;

--- a/mapviz_plugins/include/mapviz_plugins/robot_image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/robot_image_plugin.h
@@ -83,16 +83,17 @@ namespace mapviz_plugins
     void FrameEdited();
     void WidthChanged(double value);
     void HeightChanged(double value);
-    void LeftOffsetChanged(double value);
+    void OffsetXChanged(double value);
+    void OffsetYChanged(double value);
 
   private:
     Ui::robot_image_config ui_;
     QWidget* config_widget_;
 
-    double width_; //image width, if vehicle frame is x-forward this corresponds to vehicle length
-    double height_; //image height, corresponds to vehicle width
-    double left_offset_; //distance from left side of image to origin,
-    // if vehicle frame is on rear axle this corresponds to the rear overhang
+    double width_; //image width, if robot frame is x-forward this corresponds to robot length
+    double height_; //image height, corresponds to robot width
+    double offset_x_; //offset of image center from robot frame along x axis
+    double offset_y_; //offset of image center from robot frame along y axis
 
     std::string filename_;
     QImage      image_;

--- a/mapviz_plugins/src/robot_image_plugin.cpp
+++ b/mapviz_plugins/src/robot_image_plugin.cpp
@@ -57,8 +57,9 @@ namespace mapviz_plugins
 {
   RobotImagePlugin::RobotImagePlugin() :
     config_widget_(new QWidget()),
-    width_(1),
-    height_(1),
+    width_(2.0),
+    height_(1.0),
+    left_offset_(1.0),
     texture_loaded_(false),
     transformed_(false)
   {
@@ -81,6 +82,7 @@ namespace mapviz_plugins
     QObject::connect(ui_.frame, SIGNAL(editingFinished()), this, SLOT(FrameEdited()));
     QObject::connect(ui_.width, SIGNAL(valueChanged(double)), this, SLOT(WidthChanged(double)));
     QObject::connect(ui_.height, SIGNAL(valueChanged(double)), this, SLOT(HeightChanged(double)));
+    QObject::connect(ui_.left_offset, SIGNAL(valueChanged(double)), this, SLOT(LeftOffsetChanged(double)));
   }
 
   RobotImagePlugin::~RobotImagePlugin()
@@ -139,12 +141,19 @@ namespace mapviz_plugins
     UpdateShape();
   }
 
+  void RobotImagePlugin::LeftOffsetChanged(double value)
+  {
+    left_offset_ = value;
+
+    UpdateShape();
+  }
+
   void RobotImagePlugin::UpdateShape()
   {
-    top_left_ = tf::Point(-width_ / 2.0, height_ / 2.0, 0);
-    top_right_ = tf::Point(width_ / 2.0, height_ / 2.0, 0);
-    bottom_left_ = tf::Point(-width_ / 2.0, -height_/2.0, 0);
-    bottom_right_ = tf::Point(width_ / 2.0, -height_ / 2.0, 0);
+    top_left_ = tf::Point(-left_offset_, height_ / 2.0, 0);
+    top_right_ = tf::Point(width_ - left_offset_, height_ / 2.0, 0);
+    bottom_left_ = tf::Point(-left_offset_, -height_/2.0, 0);
+    bottom_right_ = tf::Point(width_ - left_offset_, -height_ / 2.0, 0);
   }
 
   void RobotImagePlugin::PrintError(const std::string& message)
@@ -329,6 +338,12 @@ namespace mapviz_plugins
       ui_.height->setValue(height_);
     }
 
+    if (node["left_offset"])
+    {
+      node["left_offset"] >> left_offset_;
+      ui_.left_offset->setValue(left_offset_);
+    }
+
     UpdateShape();
     LoadImage();
     FrameEdited();
@@ -340,6 +355,7 @@ namespace mapviz_plugins
     emitter << YAML::Key << "image" << YAML::Value << ui_.image->text().toStdString();
     emitter << YAML::Key << "width" << YAML::Value << width_;
     emitter << YAML::Key << "height" << YAML::Value << height_;
+    emitter << YAML::Key << "left_offset" << YAML::Value << left_offset_;
   }
 }
 

--- a/mapviz_plugins/ui/robot_image_config.ui
+++ b/mapviz_plugins/ui/robot_image_config.ui
@@ -17,8 +17,53 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="image_label">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Image File:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="image">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QPushButton" name="browse">
+     <property name="maximumSize">
+      <size>
+       <width>55</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>Browse</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="frame_label">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -40,8 +85,30 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="3">
+    <widget class="QPushButton" name="selectframe">
+     <property name="maximumSize">
+      <size>
+       <width>55</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>Select</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
+    <widget class="QLabel" name="width_label">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -73,7 +140,7 @@
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="label_6">
+    <widget class="QLabel" name="height_label">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -105,7 +172,39 @@
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="left_offset_label">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Left Offset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QDoubleSpinBox" name="left_offset">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::PlusMinus</enum>
+     </property>
+     <property name="suffix">
+      <string/>
+     </property>
+     <property name="value">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="status_label">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -117,74 +216,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Image File:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="image">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3">
-    <widget class="QPushButton" name="selectframe">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>Select</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QPushButton" name="browse">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>Browse</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="2">
+   <item row="6" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>

--- a/mapviz_plugins/ui/robot_image_config.ui
+++ b/mapviz_plugins/ui/robot_image_config.ui
@@ -135,7 +135,7 @@
       <string/>
      </property>
      <property name="value">
-      <double>1.000000000000000</double>
+      <double>2.000000000000000</double>
      </property>
     </widget>
    </item>
@@ -172,7 +172,7 @@
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="left_offset_label">
+    <widget class="QLabel" name="offset_x_label">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -180,12 +180,12 @@
       </font>
      </property>
      <property name="text">
-      <string>Left Offset:</string>
+      <string>Offset x:</string>
      </property>
     </widget>
    </item>
    <item row="5" column="1" colspan="2">
-    <widget class="QDoubleSpinBox" name="left_offset">
+    <widget class="QDoubleSpinBox" name="offset_x">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -204,6 +204,38 @@
     </widget>
    </item>
    <item row="6" column="0">
+    <widget class="QLabel" name="offset_y_label">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Offset y:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="2">
+    <widget class="QDoubleSpinBox" name="offset_y">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::PlusMinus</enum>
+     </property>
+     <property name="suffix">
+      <string/>
+     </property>
+     <property name="value">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
     <widget class="QLabel" name="status_label">
      <property name="font">
       <font>
@@ -216,7 +248,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="2">
+   <item row="7" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>


### PR DESCRIPTION
previously the plugin assumed vehicle frame origin to be located
at the vehicle center. This allows the user to specify the distance
from the left of image (rear of vehicle) to the origin.