### PR TITLE
Add basic profiling to mapviz (indigo)

### DIFF
--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -73,6 +73,8 @@
 #include <mapviz/mapviz_plugin.h>
 #include <mapviz/map_canvas.h>
 
+#include "stopwatch.h"
+
 namespace mapviz
 {
   class Mapviz : public QMainWindow
@@ -118,6 +120,7 @@ namespace mapviz
     void SetCaptureDirectory();
     void Hover(double x, double y, double scale);
     void Recenter();
+    void HandleProfileTimer();
 
   Q_SIGNALS:
     void ImageTransportChanged();
@@ -131,6 +134,7 @@ namespace mapviz
     QTimer spin_timer_;
     QTimer save_timer_;
     QTimer record_timer_;
+    QTimer profile_timer_;
 
     QLabel* xy_pos_label_;
     QLabel* lat_lon_pos_label_;
@@ -167,6 +171,8 @@ namespace mapviz
     pluginlib::ClassLoader<MapvizPlugin>* loader_;
     MapCanvas* canvas_;
     std::map<QListWidgetItem*, MapvizPluginPtr> plugins_;
+
+    Stopwatch meas_spin_;
 
     void Open(const std::string& filename);
     void Save(const std::string& filename);

--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -52,6 +52,8 @@
 
 #include <mapviz/widgets.h>
 
+#include "stopwatch.h"
+
 namespace mapviz
 {
   class MapvizPlugin : public QObject
@@ -121,9 +123,13 @@ namespace mapviz
     {
       if (visible_ && initialized_)
       {
+        meas_transform_.start();
         Transform();
+        meas_transform_.stop();
 
+        meas_draw_.start();
         Draw(x, y, scale);
+        meas_draw_.stop();
       }
     }
     
@@ -131,9 +137,13 @@ namespace mapviz
     {
       if (visible_ && initialized_)
       {
+        meas_transform_.start();
         Transform();
+        meas_transform_.stop();
          
+        meas_paint_.start();
         Paint(painter, x, y, scale);
+        meas_paint_.start();
       }
     }
 
@@ -142,7 +152,11 @@ namespace mapviz
       if (frame_id != target_frame_)
       {
         target_frame_ = frame_id;
+
+        meas_transform_.start();
         Transform();
+        meas_transform_.stop();
+
         Q_EMIT TargetFrameChanged(target_frame_);
       }
     }
@@ -243,6 +257,14 @@ namespace mapviz
 
     void SetIcon(IconWidget* icon) { icon_ = icon; }
 
+    void PrintMeasurements()
+    {
+      std::string header = type_ + " (" + name_ + ")";
+      meas_transform_.printInfo(header + " Transform()");
+      meas_paint_.printInfo(header + " Paint()");
+      meas_draw_.printInfo(header + " Draw()");
+    }
+
   public Q_SLOTS:
     virtual void DrawIcon() {}
 
@@ -296,9 +318,15 @@ namespace mapviz
       source_frame_(""),
       use_latest_transforms_(false),
       draw_order_(0) {}
+
+   private:
+    // Collect basic profiling info to know how much time each plugin
+    // spends in Transform(), Paint(), and Draw().
+    Stopwatch meas_transform_;
+    Stopwatch meas_paint_;
+    Stopwatch meas_draw_;
   };
   typedef boost::shared_ptr<MapvizPlugin> MapvizPluginPtr;
 }
-
 #endif  // MAPVIZ_MAPVIZ_PLUGIN_H_
 

--- a/mapviz/include/mapviz/stopwatch.h
+++ b/mapviz/include/mapviz/stopwatch.h
@@ -1,0 +1,112 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#pragma once
+
+#include <ros/time.h>
+#include <ros/console.h>
+
+namespace mapviz
+{
+/* This class measures the wall time of an interval and keeps track of
+ * the number of intervals, the average duration, and the maximum
+ * duration.  This is used to provide some simple measurements to keep
+ * an eye on performance.
+ */
+class Stopwatch
+{
+ public:
+  Stopwatch()
+    :
+    count_(0)
+  {
+  }
+
+  /* Start measuring a new time interval. */
+  void start()
+  {
+    start_ = ros::WallTime::now();
+  }
+
+  /* End the current time interval and update the measurements.
+   * Behavior is undefined if start() was not called prior to this.
+   */
+  void stop()
+  {
+    ros::WallDuration dt = ros::WallTime::now() - start_;
+    count_ += 1;
+    total_time_ += dt;
+    max_time_ = std::max(max_time_, dt);
+  }
+
+  /* Return the number of intervals measured. */
+  int count() const { return count_; }
+
+  /* Returns the longest observed duration. */
+  ros::WallDuration maxTime() const { return max_time_; }
+
+  /* Returns the average duration spent in the interval. */
+  ros::WallDuration avgTime() const
+  {
+    if (count_)
+    {
+      return total_time_*(1.0/count_);
+    }
+    else
+    {
+      return ros::WallDuration();
+    }
+  }
+
+  /* Print measurement info to the ROS console. */
+  void printInfo(const std::string &name) const
+  {
+    if (count_)
+    {
+      ROS_INFO("%s -- calls: %d, avg time: %.2fms, max time: %.2fms",
+               name.c_str(),
+               count_,
+               avgTime().toSec()*1000.0,
+               maxTime().toSec()*1000.0);
+    }
+    else
+    {
+      ROS_INFO("%s -- calls: %d, avg time: --ms, max time: --ms",
+               name.c_str(),
+               count_);
+    }
+  }
+
+ private:
+  int count_;
+  ros::WallDuration total_time_;
+  ros::WallDuration max_time_;
+
+  ros::WallTime start_;
+};  // class PluginInstrumentation
+}  // namespace mapviz

--- a/mapviz/launch/mapviz.launch
+++ b/mapviz/launch/mapviz.launch
@@ -2,7 +2,11 @@
 
   <env name="ROSCONSOLE_FORMAT" value="[${thread}] [${node}/${function}:${line}]: ${message}"/>
 
-  <node pkg="mapviz" type="mapviz" name="$(anon mapviz)" required="true"/>
+  <arg name="print_profile_data" default="false"/>
+
+  <node pkg="mapviz" type="mapviz" name="$(anon mapviz)" required="true">
+    <param name="print_profile_data" value="$(arg print_profile_data)"/>
+  </node>
 
   <node pkg="swri_transform_util" type="initialize_origin.py" name="initialize_origin" >
     <param name="local_xy_frame" value="/far_field"/>

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -287,6 +287,14 @@ void Mapviz::Initialize()
     
     connect(&record_timer_, SIGNAL(timeout()), this, SLOT(CaptureVideoFrame()));
 
+    bool print_profile_data;
+    priv.param("print_profile_data", print_profile_data, false);
+    if (print_profile_data)
+    {
+      profile_timer_.start(2000);
+      connect(&profile_timer_, SIGNAL(timeout()), this, SLOT(HandleProfileTimer()));
+    }
+
     initialized_ = true;
   }
 }
@@ -295,7 +303,9 @@ void Mapviz::SpinOnce()
 {
   if (ros::ok())
   {
+    meas_spin_.start();
     ros::spinOnce();
+    meas_spin_.stop();
   }
   else
   {
@@ -1465,6 +1475,20 @@ void Mapviz::SetCaptureDirectory()
   if (dialog.result() == QDialog::Accepted && dialog.selectedFiles().count() == 1)
   {
     capture_directory_ = dialog.selectedFiles().first().toStdString();
+  }
+}
+
+void Mapviz::HandleProfileTimer()
+{
+  ROS_INFO("Mapviz Profiling Data");
+  meas_spin_.printInfo("ROS SpinOnce()");
+  for (auto& display: plugins_)
+  {
+    MapvizPluginPtr plugin = display.second;
+    if (plugin)
+    {
+      plugin->PrintMeasurements();
+    }
   }
 }
 }


### PR DESCRIPTION
This commit adds some basic measurements (avg time, max time) for time
spent in ros::spinOnce(), mapviz_plugin::Transform(),
mapviz_plugin::Draw(), and mapviz_plugin::Paint().

It adds a ROS parameter called "print_profile_data" to mapviz (that
defaults to false) that will print out the measurements to the ROS
console every two seconds when true.