### PR TITLE
Move video recording into its own thread (Jade)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.bag
 *~
 .idea
+cmake-build-debug/
 lib/
 _gtest_from_src/
 bin/

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -82,6 +82,7 @@ file (GLOB HEADER_FILES
   include/mapviz/select_frame_dialog.h
   include/mapviz/select_service_dialog.h
   include/mapviz/select_topic_dialog.h
+  include/mapviz/video_writer.h
   include/mapviz/widgets.h
 )
 file (GLOB SRC_FILES
@@ -94,6 +95,7 @@ file (GLOB SRC_FILES
   src/select_frame_dialog.cpp
   src/select_service_dialog.cpp
   src/select_topic_dialog.cpp
+  src/video_writer.cpp
 )
 QT4_ADD_RESOURCES(RCC_SRCS src/resources/icons.qrc)
 QT4_WRAP_UI(SRC_FILES ${UI_FILES})

--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -117,6 +117,30 @@ namespace mapviz
       update();
     }
 
+    /**
+     * Copies the current capture buffer into the target buffer.  The target
+     * buffer must already be initialized to a size of:
+     * height * width * 4
+     * @param buffer An initialize buffer to copy data into
+     * @return false if the current capture buffer is empty
+     */
+    bool CopyCaptureBuffer(uchar* buffer)
+    {
+      if (!capture_buffer_.empty())
+      {
+        memcpy(&buffer[0], &capture_buffer_[0], capture_buffer_.size());
+        return true;
+      }
+
+      return false;
+    }
+
+    /**
+     * Resizes a vector to be large enough to hold the current capture buffer
+     * and then copies the capture buffer into it.
+     * @param buffer A vector to copy the capture buffer into.
+     * @return false if the current capture buffer is empty
+     */
     bool CopyCaptureBuffer(std::vector<uint8_t>& buffer)
     {
       buffer.clear();

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -39,8 +39,6 @@
 
 #include <GL/glew.h>
 
-#include <opencv2/highgui/highgui.hpp>
-
 // QT libraries
 #include <QtGui/QtGui>
 #include <QDialog>
@@ -72,6 +70,7 @@
 #include <mapviz/AddMapvizDisplay.h>
 #include <mapviz/mapviz_plugin.h>
 #include <mapviz/map_canvas.h>
+#include <mapviz/video_writer.h>
 
 #include "stopwatch.h"
 
@@ -123,6 +122,13 @@ namespace mapviz
     void HandleProfileTimer();
 
   Q_SIGNALS:
+    /**
+     * Emitted every time a frame is grabbed when Mapviz is in video recording
+     * mode, typically at a rate of 30 FPS.
+     * Note that the QImage emitted says its format is ARGB, but its pixel
+     * order is actually BGRA.
+     */
+    void FrameGrabbed(QImage);
     void ImageTransportChanged();
 
   protected:
@@ -146,8 +152,6 @@ namespace mapviz
     QPushButton* rec_button_;
     QPushButton* stop_button_;
     QPushButton* screenshot_button_;
-    
-    boost::shared_ptr<cv::VideoWriter> video_writer_;
 
     int    argc_;
     char** argv_;
@@ -160,6 +164,8 @@ namespace mapviz
     QColor background_;
     
     std::string capture_directory_;
+    QThread video_thread_;
+    VideoWriter* vid_writer_;
     
     bool updating_frames_;
 

--- a/mapviz/include/mapviz/video_writer.h
+++ b/mapviz/include/mapviz/video_writer.h
@@ -1,0 +1,69 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef MAPVIZ_VIDEO_WRITER_H
+#define MAPVIZ_VIDEO_WRITER_H
+
+#include <QObject>
+#include <QMutex>
+#include <QImage>
+
+#include <boost/shared_ptr.hpp>
+
+#ifndef Q_MOC_RUN
+#include <opencv2/highgui/highgui.hpp>
+#endif
+
+namespace mapviz
+{
+  class VideoWriter : public QObject
+  {
+    Q_OBJECT
+
+  public:
+    VideoWriter() :
+        video_mutex_(QMutex::Recursive)
+    {}
+
+    bool initializeWriter(const std::string& directory, int width, int height);
+    bool isRecording();
+    void stop();
+
+  public Q_SLOTS:
+    void processFrame(QImage frame);
+
+  private:
+    int height_;
+    int width_;
+    QMutex video_mutex_;
+    boost::shared_ptr<cv::VideoWriter> video_writer_;
+  };
+}
+
+#endif //MAPVIZ_VIDEO_WRITER_H

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -190,7 +190,6 @@ void MapCanvas::CaptureFrame(bool force)
     GLubyte* data = reinterpret_cast<GLubyte*>(glMapBufferARB(GL_PIXEL_PACK_BUFFER_ARB, GL_READ_ONLY_ARB));
     if(data)
     {
-      capture_buffer_.clear();
       capture_buffer_.resize(pixel_buffer_size_);
 
       memcpy(&capture_buffer_[0], data, pixel_buffer_size_);

--- a/mapviz/src/video_writer.cpp
+++ b/mapviz/src/video_writer.cpp
@@ -1,0 +1,121 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <mapviz/video_writer.h>
+
+#include <ros/ros.h>
+
+#include <opencv2/imgproc/imgproc.hpp>
+
+namespace mapviz
+{
+  bool VideoWriter::initializeWriter(const std::string& directory, int width, int height)
+  {
+    QMutexLocker locker(&video_mutex_);
+    if (!video_writer_)
+    {
+      width_ = width;
+      height_ = height;
+
+      ROS_INFO("Initializing recording:\nWidth/Height/Filename: %d / %d / %s", width_, height_, directory.c_str() );
+      video_writer_ = boost::make_shared<cv::VideoWriter>(
+          directory,
+          CV_FOURCC('M', 'J', 'P', 'G'),
+          30,
+          cv::Size(width_, height_));
+
+      if (!video_writer_->isOpened())
+      {
+        ROS_ERROR("Failed to open video file for writing.");
+        stop();
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  bool VideoWriter::isRecording()
+  {
+    return video_writer_.get() != NULL;
+  }
+
+  void VideoWriter::processFrame(QImage frame)
+  {
+    try
+    {
+      ROS_DEBUG_THROTTLE(1.0, "VideoWriter::processFrame()");
+      {
+        QMutexLocker locker(&video_mutex_);
+        if (!video_writer_)
+        {
+          ROS_WARN_THROTTLE(1.0, "Got frame, but video writer wasn't open.");
+          return;
+        }
+      }
+
+      cv::Mat image;
+      cv::Mat temp_image;
+      switch (frame.format())
+      {
+        case QImage::Format_ARGB32:
+          // The image received should have its format set to ARGB32, but it's
+          // actually BGRA.  Need to convert it to BGR and flip it vertically
+          // before giving it to the cv::VideoWriter.
+          image = cv::Mat(frame.height(), frame.width(), CV_8UC4, frame.bits());
+          cv::cvtColor(image, temp_image, CV_BGRA2BGR);
+          cv::flip(temp_image, image, 0);
+          break;
+        default:
+          ROS_WARN_THROTTLE(1.0, "Unexpected image format: %d", frame.format());
+          return;
+      }
+
+      {
+        QMutexLocker locker(&video_mutex_);
+        if (video_writer_)
+        {
+          ROS_DEBUG_THROTTLE(1.0, "Writing frame.");
+          video_writer_->write(image);
+        }
+      }
+    }
+    catch (const std::exception& e)
+    {
+      ROS_ERROR_THROTTLE(1.0, "Error when processing video frame: %s", e.what());
+    }
+  }
+
+  void VideoWriter::stop()
+  {
+    ROS_INFO("Stopping video recording.");
+    QMutexLocker locker(&video_mutex_);
+    video_writer_.reset();
+  }
+}


### PR DESCRIPTION
This creates a worker that handles the image conversion and file writing for
video recording and places it in its own thread.  Video recording is fairly
CPU intensive, so when video recording is enabled, this should provide for
a smoother GUI as well as a more consistent frame rate in the video.