### PR TITLE
Add missing boost header.

### DIFF
--- a/tile_map/src/tile_map_plugin.cpp
+++ b/tile_map/src/tile_map_plugin.cpp
@@ -28,6 +28,9 @@
 // *****************************************************************************
 
 #include <tile_map/tile_map_plugin.h>
+
+#include <boost/algorithm/string/trim.hpp>
+
 #include <tile_map/tile_source.h>
 #include <tile_map/bing_source.h>
 #include <tile_map/wmts_source.h>


### PR DESCRIPTION
Add missing boost header.

It looks like a change in marti_common exposed that we need to include boost/algorithm/string/trim.hpp 