### PR TITLE
fix for  tile_map_plugin.cpp:411:31: error: ‘trim_copy’ is not a member of ‘boost’

### DIFF
--- a/tile_map/include/tile_map/tile_map_plugin.h
+++ b/tile_map/include/tile_map/tile_map_plugin.h
@@ -37,6 +37,7 @@
 // Boost libraries
 #include <boost/filesystem.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/algorithm/string/trim.hpp>
 
 #include <mapviz/mapviz_plugin.h>
 


### PR DESCRIPTION
Added #include <boost/algorithm/string/trim.hpp> to tile_map_plugin.h to fix the error:

```
/mapviz/tile_map/src/tile_map_plugin.cpp:408:31: error: ‘trim_copy’ is not a member of ‘boost’
                YAML::Value << boost::trim_copy(bing_source->GetApiKey().toStdString());
                               ^
/mapviz/tile_map/src/tile_map_plugin.cpp:411:31: error: ‘trim_copy’ is not a member of ‘boost’
                YAML::Value << boost::trim_copy(ui_.source_combo->currentText().toStdString());
                               ^
make[2]: *** [CMakeFiles/tile_map_plugin.dir/src/tile_map_plugin.cpp.o] Error 1
make[1]: *** [CMakeFiles/tile_map_plugin.dir/all] Error 2
make: *** [all] Error 2
```

Its not clear to me why the travisci is not failing on this.