### PR TITLE
Support transparent tiles in multires_image (Jade)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ msg_gen/
 srv_gen/
 *.cfgc
 version.txt
+cmake-build-debug/

--- a/multires_image/src/tile.cpp
+++ b/multires_image/src/tile.cpp
@@ -149,7 +149,7 @@ namespace multires_image
         m_textureId = ids[0];
 
         glBindTexture(GL_TEXTURE_2D, m_textureId);
-        glTexImage2D(GL_TEXTURE_2D, 0, 3, m_dimension, m_dimension, 0, GL_RGBA, GL_UNSIGNED_BYTE, m_image.bits());
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_dimension, m_dimension, 0, GL_RGBA, GL_UNSIGNED_BYTE, m_image.bits());
 
         // TODO(malban): check for GL error
 


### PR DESCRIPTION
The multires_image plugin was internally loading textures without an
alpha channel, so tiles that had transparent regions would show
black instead.  This will cause transparent regions to render properly.

Fixes #501