### PR TITLE
Remove dep on libopencv-dev from multires_image (Indigo)

### DIFF
--- a/multires_image/package.xml
+++ b/multires_image/package.xml
@@ -13,7 +13,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>libopencv-dev</depend>
   <exec_depend>libqt4</exec_depend>
   <build_depend>libqt4-dev</build_depend>
   <exec_depend>libqt4-opengl</exec_depend>


### PR DESCRIPTION
It doesn't actually use it at all.