### PR TITLE
Remove dep on libopencv-dev from multires_image (Kinetic/Lunar)

### DIFF
--- a/multires_image/package.xml
+++ b/multires_image/package.xml
@@ -13,11 +13,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>libopencv-dev</depend>
+  <build_depend>libqt5-opengl-dev</build_depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-opengl</depend>
-  <build_depend>libqt5-opengl-dev</build_depend>
   <depend>libqt5-widgets</depend>
   <depend>mapviz</depend>
   <depend>pluginlib</depend>

--- a/multires_image/package.xml
+++ b/multires_image/package.xml
@@ -13,10 +13,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>libqt5-opengl-dev</build_depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-opengl</depend>
+  <build_depend>libqt5-opengl-dev</build_depend>
   <depend>libqt5-widgets</depend>
   <depend>mapviz</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
It doesn't actually use it at all, and it's the only thing preventing the
kinetic-devel branch from compiling on lunar.