### PR TITLE
Fix the "File" menu actions

### DIFF
--- a/mapviz/src/mapviz.ui
+++ b/mapviz/src/mapviz.ui
@@ -595,7 +595,7 @@
   </connection>
   <connection>
    <sender>actionOpen_config</sender>
-   <signal>activated()</signal>
+   <signal>triggered()</signal>
    <receiver>mapviz</receiver>
    <slot>OpenConfig()</slot>
    <hints>
@@ -611,7 +611,7 @@
   </connection>
   <connection>
    <sender>actionSave_config</sender>
-   <signal>activated()</signal>
+   <signal>triggered()</signal>
    <receiver>mapviz</receiver>
    <slot>SaveConfig()</slot>
    <hints>
@@ -691,7 +691,7 @@
   </connection>
   <connection>
    <sender>actionSet_Capture_Directory</sender>
-   <signal>activated()</signal>
+   <signal>triggered()</signal>
    <receiver>mapviz</receiver>
    <slot>SetCaptureDirectory()</slot>
    <hints>


### PR DESCRIPTION
In Qt4, QMenu emitted a "activated" signal for its actions; in Qt5, this has been changed to "triggered".

Fixes #510