### PR TITLE
change the signal that triggers AlphaEdited + minor changes

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
@@ -88,7 +88,7 @@ namespace mapviz_plugins
     protected Q_SLOTS:
       void SelectTopic();
       void TopicEdited();
-      void AlphaEdited();
+      void AlphaEdited(double val);
       void ColorTransformerChanged(int index);
       void MinValueChanged(double value);
       void MaxValueChanged(double value);

--- a/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.h
@@ -92,7 +92,7 @@ namespace mapviz_plugins
   protected Q_SLOTS:
     void SelectTopic();
     void TopicEdited();
-    void AlphaEdited();
+    void AlphaEdited(double new_value);
     void ColorTransformerChanged(int index);
     void MinValueChanged(double value);
     void MaxValueChanged(double value);

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -107,9 +107,9 @@ namespace mapviz_plugins
         this,
         SLOT(TopicEdited()));
     QObject::connect(ui_.alpha,
-        SIGNAL(editingFinished()),
+        SIGNAL(valueChanged(double)),
         this,
-        SLOT(AlphaEdited()));
+        SLOT(AlphaEdited(double)));
     QObject::connect(ui_.color_transformer,
         SIGNAL(currentIndexChanged(int)),
         this,
@@ -600,7 +600,6 @@ namespace mapviz_plugins
     {
       node["alpha"] >> alpha_;
       ui_.alpha->setValue(alpha_);
-      AlphaEdited();
     }
 
     if (node["use_rainbow"])
@@ -655,10 +654,9 @@ namespace mapviz_plugins
   /**
    * Coerces alpha to [0.0, 1.0] and stores it in alpha_
    */
-  void LaserScanPlugin::AlphaEdited()
+  void LaserScanPlugin::AlphaEdited(double val)
   {
-    alpha_ = std::max(0.0f, std::min(ui_.alpha->text().toFloat(), 1.0f));
-    ui_.alpha->setValue(alpha_);
+    alpha_ = std::max(0.0f, std::min((float)val, 1.0f));
   }
 
   void LaserScanPlugin::SaveConfig(YAML::Emitter& emitter,

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -646,19 +646,19 @@ namespace mapviz_plugins
   void PointCloud2Plugin::UseRainbowChanged(int check_state)
   {
     UpdateMinMaxWidgets();
-
     UpdateColors();
   }
 
   void PointCloud2Plugin::UseAutomaxminChanged(int check_state)
   {
-    if (check_state == need_minmax_)
+    need_minmax_ = check_state == Qt::Checked;
+    if(!need_minmax_ )
     {
-      need_minmax_ = true;
+        min_value_ = ui_.minValue->value();
+        max_value_ = ui_.maxValue->value();
     }
 
     UpdateMinMaxWidgets();
-
     UpdateColors();
   }
 

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -109,9 +109,9 @@ namespace mapviz_plugins
                      this,
                      SLOT(TopicEdited()));
     QObject::connect(ui_.alpha,
-                     SIGNAL(editingFinished()),
+                     SIGNAL(valueChanged(double)),
                      this,
-                     SLOT(AlphaEdited()));
+                     SLOT(AlphaEdited(double)));
     QObject::connect(ui_.color_transformer,
                      SIGNAL(currentIndexChanged(int)),
                      this,
@@ -761,7 +761,6 @@ namespace mapviz_plugins
     {      
       node["alpha"] >> alpha_;
       ui_.alpha->setValue(alpha_);
-      AlphaEdited();
     }
 
     if (node["use_rainbow"])
@@ -827,10 +826,9 @@ namespace mapviz_plugins
   /**
    * Coerces alpha to [0.0, 1.0] and stores it in alpha_
    */
-  void PointCloud2Plugin::AlphaEdited()
+  void PointCloud2Plugin::AlphaEdited(double value)
   {
-    alpha_ = std::max(0.0f, std::min(ui_.alpha->text().toFloat(), 1.0f));
-    ui_.alpha->setValue(alpha_);
+    alpha_ = std::max(0.0f, std::min((float)value, 1.0f));
   }
 
   void PointCloud2Plugin::SaveConfig(YAML::Emitter& emitter,
@@ -851,9 +849,9 @@ namespace mapviz_plugins
     emitter << YAML::Key << "max_color" <<
       YAML::Value << ui_.max_color->color().name().toStdString();
     emitter << YAML::Key << "value_min" <<
-      YAML::Value << ui_.minValue->text().toDouble();
+      YAML::Value << ui_.minValue->value();
     emitter << YAML::Key << "value_max" <<
-      YAML::Value << ui_.maxValue->text().toDouble();
+      YAML::Value << ui_.maxValue->value();
     emitter << YAML::Key << "use_rainbow" <<
       YAML::Value << ui_.use_rainbow->isChecked();
     emitter << YAML::Key << "use_automaxmin" <<

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -652,7 +652,7 @@ namespace mapviz_plugins
   void PointCloud2Plugin::UseAutomaxminChanged(int check_state)
   {
     need_minmax_ = check_state == Qt::Checked;
-    if(!need_minmax_ )
+    if( !need_minmax_ )
     {
         min_value_ = ui_.minValue->value();
         max_value_ = ui_.maxValue->value();

--- a/mapviz_plugins/ui/laserscan_config.ui
+++ b/mapviz_plugins/ui/laserscan_config.ui
@@ -17,11 +17,20 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
    <property name="verticalSpacing">
     <number>4</number>
-   </property>
-   <property name="margin">
-    <number>2</number>
    </property>
    <item row="15" column="0">
     <widget class="QLabel" name="label_2">
@@ -165,7 +174,7 @@
       <double>1.000000000000000</double>
      </property>
      <property name="singleStep">
-      <double>0.010000000000000</double>
+      <double>0.100000000000000</double>
      </property>
      <property name="value">
       <double>1.000000000000000</double>

--- a/mapviz_plugins/ui/pointcloud2_config.ui
+++ b/mapviz_plugins/ui/pointcloud2_config.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>306</width>
+    <width>307</width>
     <height>341</height>
    </rect>
   </property>
@@ -17,11 +17,20 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
    <property name="verticalSpacing">
     <number>4</number>
-   </property>
-   <property name="margin">
-    <number>2</number>
    </property>
    <item row="14" column="0">
     <widget class="QLabel" name="label_2">
@@ -102,8 +111,11 @@
    </item>
    <item row="3" column="1">
     <widget class="QSpinBox" name="bufferSize">
+     <property name="minimum">
+      <number>1</number>
+     </property>
      <property name="maximum">
-      <number>99999999</number>
+      <number>100</number>
      </property>
      <property name="value">
       <number>1</number>
@@ -116,7 +128,7 @@
       <double>1.000000000000000</double>
      </property>
      <property name="singleStep">
-      <double>0.010000000000000</double>
+      <double>0.100000000000000</double>
      </property>
      <property name="value">
       <double>1.000000000000000</double>
@@ -247,7 +259,16 @@
      <item>
       <widget class="QWidget" name="min_max_color_widget" native="true">
        <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -336,11 +357,20 @@
       </size>
      </property>
      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,1">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <property name="verticalSpacing">
        <number>4</number>
-      </property>
-      <property name="margin">
-       <number>0</number>
       </property>
       <item row="0" column="0">
        <widget class="QLabel" name="minValueLabel">


### PR DESCRIPTION
Hi, 

I consider counter intuitive the fact that you must press ENTER to update Alpha value in the UI.
For this reason I suggest using the signal valueChanged(double).

Furthermore:

- I limit the size of buffer in the range [1,100] and 
- use the method value() in QDoubleSpinBox instead of text()->toDouble().

