### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/mapviz/src/rqt_mapviz.cpp
+++ b/mapviz/src/rqt_mapviz.cpp
@@ -63,4 +63,4 @@ namespace mapviz
   }
 }
 
-PLUGINLIB_DECLARE_CLASS(mapviz, rqt_mapviz, mapviz::RqtMapviz, rqt_gui_cpp::Plugin)
+PLUGINLIB_EXPORT_CLASS(mapviz::RqtMapviz, rqt_gui_cpp::Plugin)

--- a/mapviz_plugins/src/attitude_indicator_plugin.cpp
+++ b/mapviz_plugins/src/attitude_indicator_plugin.cpp
@@ -47,11 +47,7 @@
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
 
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    attitude_indicator,
-    mapviz_plugins::AttitudeIndicatorPlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::AttitudeIndicatorPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/disparity_plugin.cpp
+++ b/mapviz_plugins/src/disparity_plugin.cpp
@@ -49,12 +49,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    disparity,
-    mapviz_plugins::DisparityPlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::DisparityPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/draw_polygon_plugin.cpp
+++ b/mapviz_plugins/src/draw_polygon_plugin.cpp
@@ -51,8 +51,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins, draw_polygon, mapviz_plugins::DrawPolygonPlugin,
-                        mapviz::MapvizPlugin);
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::DrawPolygonPlugin, mapviz::MapvizPlugin)
 
 namespace stu = swri_transform_util;
 

--- a/mapviz_plugins/src/gps_plugin.cpp
+++ b/mapviz_plugins/src/gps_plugin.cpp
@@ -39,10 +39,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins,
-                        gps,
-                        mapviz_plugins::GpsPlugin,
-                        mapviz::MapvizPlugin);
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::GpsPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/grid_plugin.cpp
+++ b/mapviz_plugins/src/grid_plugin.cpp
@@ -43,11 +43,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    grid,
-    mapviz_plugins::GridPlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::GridPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -46,11 +46,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    image,
-    mapviz_plugins::ImagePlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::ImagePlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -58,11 +58,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    laserscan,
-    mapviz_plugins::LaserScanPlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::LaserScanPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -50,11 +50,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    marker,
-    mapviz_plugins::MarkerPlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::MarkerPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -40,10 +40,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins,
-                        navsat,
-                        mapviz_plugins::NavSatPlugin,
-                        mapviz::MapvizPlugin);
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::NavSatPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -50,10 +50,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins,
-                        odometry,
-                        mapviz_plugins::OdometryPlugin,
-                        mapviz::MapvizPlugin);
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::OdometryPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -44,10 +44,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins,
-                        path,
-                        mapviz_plugins::PathPlugin,
-                        mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::PathPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -54,8 +54,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins, plan_route, mapviz_plugins::PlanRoutePlugin,
-                        mapviz::MapvizPlugin);
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::PlanRoutePlugin, mapviz::MapvizPlugin)
 
 namespace mnm = marti_nav_msgs;
 namespace sru = swri_route_util;

--- a/mapviz_plugins/src/point_click_publisher_plugin.cpp
+++ b/mapviz_plugins/src/point_click_publisher_plugin.cpp
@@ -36,11 +36,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    point_click_publisher,
-    mapviz_plugins::PointClickPublisherPlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::PointClickPublisherPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -60,11 +60,7 @@
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
 
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    PointCloud2,
-    mapviz_plugins::PointCloud2Plugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::PointCloud2Plugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/robot_image_plugin.cpp
+++ b/mapviz_plugins/src/robot_image_plugin.cpp
@@ -47,11 +47,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    robot_image,
-    mapviz_plugins::RobotImagePlugin,
-    mapviz::MapvizPlugin);
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::RobotImagePlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/route_plugin.cpp
+++ b/mapviz_plugins/src/route_plugin.cpp
@@ -54,8 +54,7 @@
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
 
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins, route, mapviz_plugins::RoutePlugin,
-                        mapviz::MapvizPlugin);
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::RoutePlugin, mapviz::MapvizPlugin)
 
 namespace sru = swri_route_util;
 namespace stu = swri_transform_util;

--- a/mapviz_plugins/src/string_plugin.cpp
+++ b/mapviz_plugins/src/string_plugin.cpp
@@ -35,11 +35,7 @@
 
 #include <QFontDialog>
 
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    string,
-    mapviz_plugins::StringPlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::StringPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/textured_marker_plugin.cpp
+++ b/mapviz_plugins/src/textured_marker_plugin.cpp
@@ -51,11 +51,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    mapviz_plugins,
-    textured_marker,
-    mapviz_plugins::TexturedMarkerPlugin,
-    mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::TexturedMarkerPlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -45,10 +45,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins,
-                        tf_frame,
-                        mapviz_plugins::TfFramePlugin,
-                        mapviz::MapvizPlugin);
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::TfFramePlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/multires_image/src/multires_image_plugin.cpp
+++ b/multires_image/src/multires_image_plugin.cpp
@@ -43,7 +43,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins, multires_image, mapviz_plugins::MultiresImagePlugin, mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::MultiresImagePlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {

--- a/tile_map/src/tile_map_plugin.cpp
+++ b/tile_map/src/tile_map_plugin.cpp
@@ -50,7 +50,7 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins, tile_map, tile_map::TileMapPlugin, mapviz::MapvizPlugin)
+PLUGINLIB_EXPORT_CLASS(tile_map::TileMapPlugin, mapviz::MapvizPlugin)
 
 namespace tile_map
 {


### PR DESCRIPTION
These macros deprecated for now 8 years will be removed in the next ROS release (ROS Melodic)