### PR TITLE
Speed up improvement in LaserScan and PointCloud2

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
@@ -120,6 +120,7 @@ namespace mapviz_plugins
 
       void laserScanCallback(const sensor_msgs::LaserScanConstPtr& scan);
       QColor CalculateColor(const StampedPoint& point, bool has_intensity);
+      void updatePreComputedTriginometic(const sensor_msgs::LaserScanConstPtr& msg);
 
       Ui::laserscan_config ui_;
       QWidget* config_widget_;
@@ -138,6 +139,8 @@ namespace mapviz_plugins
       // decay time (evenator)
       std::deque<Scan> scans_;
       ros::Subscriber laserscan_sub_;
+      std::vector<double> precomputed_cos_;
+      std::vector<double> precomputed_sin_;
   };
 }
 

--- a/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.h
@@ -141,6 +141,9 @@ namespace mapviz_plugins
       ros::Subscriber laserscan_sub_;
       std::vector<double> precomputed_cos_;
       std::vector<double> precomputed_sin_;
+      size_t prev_ranges_size_;
+      float  prev_angle_min_;
+      float  prev_increment_;
   };
 }
 

--- a/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.h
@@ -117,7 +117,7 @@ namespace mapviz_plugins
     {
       ros::Time stamp;
       QColor color;
-      std::deque<StampedPoint> points;
+      std::vector<StampedPoint> points;
       std::string source_frame;
       bool transformed;
       std::map<std::string, FieldInfo> new_features;

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -72,7 +72,10 @@ namespace mapviz_plugins
           alpha_(1.0),
           min_value_(0.0),
           max_value_(100.0),
-          point_size_(3)
+          point_size_(3),
+          prev_ranges_size_(0),
+          prev_angle_min_(0.0),
+          prev_increment_(0.0)
   {
     ui_.setupUi(config_widget_);
 
@@ -326,21 +329,18 @@ namespace mapviz_plugins
 
   void LaserScanPlugin::updatePreComputedTriginometic(const sensor_msgs::LaserScanConstPtr& msg)
   {
-      static size_t prev_size      = 0;
-      static float  prev_angle_min = msg->angle_min;
-      static float  prev_increment = msg->angle_increment;
-
-      if( msg->ranges.size() != prev_size ||
-          msg->angle_min !=  prev_angle_min  ||
-          msg->angle_increment != prev_increment   )
+      if( msg->ranges.size() != prev_ranges_size_ ||
+          msg->angle_min !=  prev_angle_min_  ||
+          msg->angle_increment != prev_increment_   )
       {
-          prev_size = msg->ranges.size();
-          prev_angle_min = msg->angle_min;
-          prev_increment = msg->angle_increment;
-          precomputed_cos_.resize( prev_size );
-          precomputed_sin_.resize( prev_size );
+          prev_ranges_size_ = msg->ranges.size();
+          prev_angle_min_ = msg->angle_min;
+          prev_increment_ = msg->angle_increment;
 
-          for (size_t i = 0; i < prev_size; i++)
+          precomputed_cos_.resize( msg->ranges.size() );
+          precomputed_sin_.resize( msg->ranges.size() );
+
+          for (size_t i = 0; i < msg->ranges.size(); i++)
           {
               double angle = msg->angle_min + msg->angle_increment * i;
               precomputed_cos_[i] = cos(angle);

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -292,7 +292,7 @@ namespace mapviz_plugins
       std::deque<Scan>::iterator scan_it = scans_.begin();
       for (; scan_it != scans_.end(); ++scan_it)
       {
-        std::deque<StampedPoint>::iterator point_it = scan_it->points.begin();
+        std::vector<StampedPoint>::iterator point_it = scan_it->points.begin();
         for (; point_it != scan_it->points.end(); point_it++)
         {
           point_it->color = CalculateColor(*point_it);
@@ -395,11 +395,25 @@ namespace mapviz_plugins
     // them individually.
 
     Scan scan;
+    {
+      QMutexLocker locker(&scan_mutex_);
+      if (buffer_size_ > 0 )
+      {
+          if( scans_.size() >= buffer_size_)
+          {
+              scan = std::move( scans_.front() );
+          }
+          while (scans_.size() >= buffer_size_)
+          {
+            scans_.pop_front();
+          }
+      }
+    }
+
     scan.stamp = msg->header.stamp;
     scan.color = QColor::fromRgbF(1.0f, 0.0f, 0.0f, 1.0f);
     scan.source_frame = msg->header.frame_id;
     scan.transformed = true;
-    scan.points.clear();
 
     swri_transform_util::Transform transform;
     if (!GetTransform(scan.source_frame, msg->header.stamp, transform))
@@ -477,19 +491,22 @@ namespace mapviz_plugins
     if (!msg->data.empty())
     {
       const uint8_t* ptr = &msg->data.front();
-      const uint8_t* ptr_end = &msg->data.back();
       const uint32_t point_step = msg->point_step;
       const uint32_t xoff = msg->fields[xi].offset;
       const uint32_t yoff = msg->fields[yi].offset;
       const uint32_t zoff = msg->fields[zi].offset;
-      for (; ptr < ptr_end; ptr += point_step)
+      const size_t N_POINTS = msg->data.size() / point_step;
+      scan.points.resize(N_POINTS);
+
+      for (size_t i = 0; i < N_POINTS; i++, ptr += point_step)
       {
         float x = *reinterpret_cast<const float*>(ptr + xoff);
         float y = *reinterpret_cast<const float*>(ptr + yoff);
         float z = *reinterpret_cast<const float*>(ptr + zoff);
 
-        StampedPoint point;
+        StampedPoint& point = scan.points[i];
         point.point = tf::Point(x, y, z);
+
         point.features.resize(scan.new_features.size());
         int count = 0;
         std::map<std::string, FieldInfo>::const_iterator it;
@@ -503,16 +520,13 @@ namespace mapviz_plugins
         {
           point.transformed_point = transform * point.point;
         }
-
         point.color = CalculateColor(point);
-
-        scan.points.push_back(point);
       }
     }
 
     {
       QMutexLocker locker(&scan_mutex_);
-      scans_.push_back(scan);
+      scans_.push_back( std::move(scan) );
       if (buffer_size_ > 0)
       {
         while (scans_.size() > buffer_size_)
@@ -615,7 +629,7 @@ namespace mapviz_plugins
     glBegin(GL_POINTS);
 
     std::deque<Scan>::const_iterator scan_it;
-    std::deque<StampedPoint>::const_iterator point_it;
+    std::vector<StampedPoint>::const_iterator point_it;
     {
       QMutexLocker locker(&scan_mutex_);
 
@@ -680,7 +694,7 @@ namespace mapviz_plugins
           if (GetTransform(scan.source_frame, scan.stamp, transform))
           {
             scan.transformed = true;
-            std::deque<StampedPoint>::iterator point_it = scan.points.begin();
+            std::vector<StampedPoint>::iterator point_it = scan.points.begin();
             for (; point_it != scan.points.end(); ++point_it)
             {
               point_it->transformed_point = transform * point_it->point;

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -396,6 +396,7 @@ namespace mapviz_plugins
 
     Scan scan;
     {
+        // recycle already allocated memory, reusing an old scan
       QMutexLocker locker(&scan_mutex_);
       if (buffer_size_ > 0 )
       {
@@ -422,7 +423,6 @@ namespace mapviz_plugins
       PrintError("No transform between " + scan.source_frame + " and " + target_frame_);
     }
 
-
     int32_t xi = findChannelIndex(msg, "x");
     int32_t yi = findChannelIndex(msg, "y");
     int32_t zi = findChannelIndex(msg, "z");
@@ -434,7 +434,6 @@ namespace mapviz_plugins
 
     if (new_topic_)
     {
-
       for (size_t i = 0; i < msg->fields.size(); ++i)
       {
         FieldInfo input;
@@ -463,7 +462,6 @@ namespace mapviz_plugins
         {
           ui_.color_transformer->removeItem(static_cast<int>(num_of_feats_));
           num_of_feats_--;
-
         }
 
         for (it = scan.new_features.begin(); it != scan.new_features.end(); ++it)
@@ -527,13 +525,6 @@ namespace mapviz_plugins
     {
       QMutexLocker locker(&scan_mutex_);
       scans_.push_back( std::move(scan) );
-      if (buffer_size_ > 0)
-      {
-        while (scans_.size() > buffer_size_)
-        {
-          scans_.pop_front();
-        }
-      }
     }
     new_topic_ = true;
     canvas_->update();


### PR DESCRIPTION
Hi,

it is possible to reduce dramatically the memory allocation in both **std::vector::reserve** or recycling instances popped from the **scan_** buffers.

In my benchmarks, these change roughly reduce the amount of CPU used by these two plugins to 1/3rd.