### PR TITLE
Improvement of image plugin. Transport is selected automatically for compressed images

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/image_plugin.h
@@ -112,7 +112,7 @@ namespace mapviz_plugins
     void SetWidth(int width);
     void SetHeight(int height);
     void SetSubscription(bool visible);
-    void SetTransport(const QString& transport);
+    void SetTransport(int index);
 
   private:
     Ui::image_config ui_;

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -84,8 +84,8 @@ namespace mapviz_plugins
     QObject::connect(ui_.width, SIGNAL(valueChanged(int)), this, SLOT(SetWidth(int)));
     QObject::connect(ui_.height, SIGNAL(valueChanged(int)), this, SLOT(SetHeight(int)));
     QObject::connect(this,SIGNAL(VisibleChanged(bool)),this,SLOT(SetSubscription(bool)));
-    QObject::connect(ui_.transport_combo_box, SIGNAL(activated(const QString&)),
-                     this, SLOT(SetTransport(const QString&)));
+    QObject::connect(ui_.transport_combo_box, SIGNAL(currentIndexChanged(int)),
+                     this, SLOT(SetTransport(int)));
   }
 
   ImagePlugin::~ImagePlugin()
@@ -176,15 +176,15 @@ namespace mapviz_plugins
     }
     else
     {
-      image_transport::ImageTransport it(local_node_);
-      image_sub_ = it.subscribe(topic_, 1, &ImagePlugin::imageCallback, this);
-
+      force_resubscribe_ = true;
+      TopicEdited();
       ROS_INFO("Subscribing to %s", topic_.c_str());
     }
   }
 
-  void ImagePlugin::SetTransport(const QString& transport)
+  void ImagePlugin::SetTransport(int index)
   {
+    QString transport = ui_.transport_combo_box->itemText(index);
     ROS_INFO("Changing image_transport to %s.", transport.toStdString().c_str());
     transport_ = transport;
     TopicEdited();
@@ -201,25 +201,50 @@ namespace mapviz_plugins
 
   void ImagePlugin::SelectTopic()
   {
-    ros::master::TopicInfo topic = mapviz::SelectTopicDialog::selectTopic(
-      "sensor_msgs/Image");
+    const std::vector<std::string> datatypes = {"sensor_msgs/Image", "sensor_msgs/CompressedImage"};
+    const ros::master::TopicInfo topic = mapviz::SelectTopicDialog::selectTopic(datatypes);
 
-    if(topic.name.empty())
-    {
-      topic.name.clear();
-      TopicEdited();
-
-    }
-    if (!topic.name.empty())
-    {
-      ui_.topic->setText(QString::fromStdString(topic.name));
-      TopicEdited();
-    }
+    ui_.topic->setText(QString::fromStdString(topic.name));
+    TopicEdited();
   }
+
 
   void ImagePlugin::TopicEdited()
   {
+    ros::master::V_TopicInfo topics_info;
+    ros::master::getTopics(topics_info);
+
     std::string topic = ui_.topic->text().trimmed().toStdString();
+
+    for( ros::master::TopicInfo& info: topics_info)
+    {
+      if( info.name == topic)
+      {
+        if( info.datatype == "sensor_msgs/Image") // raw
+        {
+          int combo_index = ui_.transport_combo_box->findText("raw");
+          if( combo_index >=0 )
+          {
+            ui_.transport_combo_box->setCurrentIndex(combo_index);
+          }
+        }
+        else if( info.datatype == "sensor_msgs/CompressedImage") // compressed
+        {
+          const int last_separator = topic.find_last_of('/');
+          const std::string suffix = topic.substr(last_separator+1);
+
+          int combo_index = ui_.transport_combo_box->findText( suffix.c_str() );
+
+          if( combo_index >=0 )
+          {
+            ui_.transport_combo_box->setCurrentIndex(combo_index);
+            topic = topic.substr(0,last_separator);
+          }
+        }
+        break;
+      }
+    }
+
     if(!this->Visible())
     {
       PrintWarning("Topic is Hidden");
@@ -267,7 +292,6 @@ namespace mapviz_plugins
                                                                      ros::TransportHints(),
                                                                      local_node_));
         }
-
         ROS_INFO("Subscribing to %s", topic_.c_str());
       }
     }

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -216,6 +216,8 @@ namespace mapviz_plugins
 
     std::string topic = ui_.topic->text().trimmed().toStdString();
 
+    const bool comboWasBlocked = ui_.transport_combo_box->blockSignals(true);
+
     for( ros::master::TopicInfo& info: topics_info)
     {
       if( info.name == topic)
@@ -226,6 +228,7 @@ namespace mapviz_plugins
           if( combo_index >=0 )
           {
             ui_.transport_combo_box->setCurrentIndex(combo_index);
+            transport_ = "raw";
           }
         }
         else if( info.datatype == "sensor_msgs/CompressedImage") // compressed
@@ -238,12 +241,14 @@ namespace mapviz_plugins
           if( combo_index >=0 )
           {
             ui_.transport_combo_box->setCurrentIndex(combo_index);
+            transport_ = QString::fromStdString(suffix);
             topic = topic.substr(0,last_separator);
           }
         }
         break;
       }
     }
+    ui_.transport_combo_box->blockSignals(comboWasBlocked);
 
     if(!this->Visible())
     {

--- a/mapviz_plugins/ui/image_config.ui
+++ b/mapviz_plugins/ui/image_config.ui
@@ -17,11 +17,20 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
    <property name="verticalSpacing">
     <number>4</number>
-   </property>
-   <property name="margin">
-    <number>2</number>
    </property>
    <item row="7" column="1">
     <widget class="QSpinBox" name="height">
@@ -115,17 +124,18 @@
    </item>
    <item row="9" column="1">
     <widget class="QComboBox" name="transport_combo_box">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
        <height>25</height>
       </size>
      </property>
-     <item>
-      <property name="text">
-       <string>default</string>
-      </property>
-     </item>
+     <property name="editable">
+      <bool>false</bool>
+     </property>
     </widget>
    </item>
    <item row="4" column="0">


### PR DESCRIPTION
Hi,

as a newbie a spent quite a lot of time understanding how to use correctly the image plugin when my image is compressed.

In my case for, instance,I have a __/zed/right/image_raw/compressed__.

 I have to first select transport "compressed" in the combo box and then type manually __/zed/right/image_raw__ because the topic selector doesn't work.

With this PR the topics of types __sensor_msgs/CompressedImage__ is visible in the topic selector.
If one of those topics is selected, the suffic of the topic name is used to automatically select the proper combo box ("compressed", "theora", "compressedDepth").

Cheers