### PR TITLE
missing "arrows" in NavSat plugin

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/navsat_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/navsat_plugin.h
@@ -72,6 +72,7 @@ namespace mapviz_plugins
    protected Q_SLOTS:
     void SelectTopic();
     void TopicEdited();
+    virtual void SetDrawStyle(QString style) override;
 
    private:
     Ui::navsat_config ui_;

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -255,6 +255,11 @@ namespace mapviz_plugins
         draw_style_ = POINTS;
         ui_.drawstyle->setCurrentIndex(1);
       }
+      else if (draw_style == "arrows")
+      {
+        draw_style_ = ARROWS;
+        ui_.drawstyle->setCurrentIndex(2);
+      }
     }
 
     if (node["position_tolerance"])

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -70,6 +70,8 @@ namespace mapviz_plugins
                      SLOT(BufferSizeChanged(int)));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
                      SLOT(SetDrawStyle(QString)));
+    QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
+                     SLOT(SetDrawStyle2(QString)));
     QObject::connect(ui_.static_arrow_sizes, SIGNAL(clicked(bool)),
                      this, SLOT(SetStaticArrowSizes(bool)));
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
@@ -113,6 +115,29 @@ namespace mapviz_plugins
         ROS_INFO("Subscribing to %s", topic_.c_str());
       }
     }
+  }
+
+  void NavSatPlugin::SetDrawStyle(QString style)
+  {
+    if (style == "lines")
+    {
+      draw_style_ = LINES;
+    }
+    else if (style == "points")
+    {
+      draw_style_ = POINTS;
+    }
+    else if (style == "arrows")
+    {
+      draw_style_ = ARROWS;
+    }
+
+    const bool is_arrow = (draw_style_ == ARROWS);
+    ui_.label_arrow->setVisible(is_arrow);
+    ui_.arrow_size->setVisible(is_arrow);
+    ui_.static_arrow_sizes->setVisible(is_arrow);
+
+    DrawIcon();
   }
 
   void NavSatPlugin::NavSatFixCallback(
@@ -247,19 +272,17 @@ namespace mapviz_plugins
 
       if (draw_style == "lines")
       {
-        draw_style_ = LINES;
         ui_.drawstyle->setCurrentIndex(0);
       }
       else if (draw_style == "points")
       {
-        draw_style_ = POINTS;
         ui_.drawstyle->setCurrentIndex(1);
       }
       else if (draw_style == "arrows")
       {
-        draw_style_ = ARROWS;
         ui_.drawstyle->setCurrentIndex(2);
       }
+      SetDrawStyle(QString::fromStdString(draw_style));
     }
 
     if (node["position_tolerance"])

--- a/mapviz_plugins/ui/navsat_config.ui
+++ b/mapviz_plugins/ui/navsat_config.ui
@@ -268,7 +268,7 @@
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="label_5">
+    <widget class="QLabel" name="label_arrow">
      <property name="font">
       <font>
        <family>Sans Serif</family>

--- a/mapviz_plugins/ui/navsat_config.ui
+++ b/mapviz_plugins/ui/navsat_config.ui
@@ -17,11 +17,20 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
    <property name="verticalSpacing">
     <number>4</number>
-   </property>
-   <property name="margin">
-    <number>2</number>
    </property>
    <item row="5" column="1" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -249,6 +258,11 @@
      <item>
       <property name="text">
        <string>points</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>arrows</string>
       </property>
      </item>
     </widget>


### PR DESCRIPTION
Hi,

sorry if I bother you again, but I guess this was either a bug or dead code.
I am using NavSat plugin and despite the fact that I see options to resize the arrow (?) there is no "arrows" option in the combo box.

Cheers

Davide