### PR TITLE
Added "keep image ratio" to Image plugin

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/image_plugin.h
@@ -109,10 +109,11 @@ namespace mapviz_plugins
     void SetUnits(QString units);
     void SetOffsetX(int offset);
     void SetOffsetY(int offset);
-    void SetWidth(int width);
-    void SetHeight(int height);
+    void SetWidth(double width);
+    void SetHeight(double height);
     void SetSubscription(bool visible);
     void SetTransport(const QString& transport);
+    void KeepRatioChanged(bool checked);
 
   private:
     Ui::image_config ui_;
@@ -123,8 +124,8 @@ namespace mapviz_plugins
     Units units_;
     int offset_x_;
     int offset_y_;
-    int width_;
-    int height_;
+    double width_;
+    double height_;
     QString transport_;
 
     bool force_resubscribe_;
@@ -132,6 +133,7 @@ namespace mapviz_plugins
 
     double last_width_;
     double last_height_;
+    double original_aspect_ratio_;
 
     ros::NodeHandle local_node_;
     image_transport::Subscriber image_sub_;

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -88,6 +88,9 @@ namespace mapviz_plugins
     QObject::connect(ui_.keep_ratio, SIGNAL(toggled(bool)), this, SLOT(KeepRatioChanged(bool)));
     QObject::connect(ui_.transport_combo_box, SIGNAL(activated(const QString&)),
                      this, SLOT(SetTransport(const QString&)));
+
+    ui_.width->setKeyboardTracking(false);
+    ui_.height->setKeyboardTracking(false);
   }
 
   ImagePlugin::~ImagePlugin()

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -61,7 +61,8 @@ namespace mapviz_plugins
     transport_("default"),
     has_image_(false),
     last_width_(0),
-    last_height_(0)
+    last_height_(0),
+    original_aspect_ratio_(1.0)
   {
     ui_.setupUi(config_widget_);
 
@@ -81,9 +82,10 @@ namespace mapviz_plugins
     QObject::connect(ui_.units, SIGNAL(activated(QString)), this, SLOT(SetUnits(QString)));
     QObject::connect(ui_.offsetx, SIGNAL(valueChanged(int)), this, SLOT(SetOffsetX(int)));
     QObject::connect(ui_.offsety, SIGNAL(valueChanged(int)), this, SLOT(SetOffsetY(int)));
-    QObject::connect(ui_.width, SIGNAL(valueChanged(int)), this, SLOT(SetWidth(int)));
-    QObject::connect(ui_.height, SIGNAL(valueChanged(int)), this, SLOT(SetHeight(int)));
+    QObject::connect(ui_.width, SIGNAL(valueChanged(double)), this, SLOT(SetWidth(double)));
+    QObject::connect(ui_.height, SIGNAL(valueChanged(double)), this, SLOT(SetHeight(double)));
     QObject::connect(this,SIGNAL(VisibleChanged(bool)),this,SLOT(SetSubscription(bool)));
+    QObject::connect(ui_.keep_ratio, SIGNAL(toggled(bool)), this, SLOT(KeepRatioChanged(bool)));
     QObject::connect(ui_.transport_combo_box, SIGNAL(activated(const QString&)),
                      this, SLOT(SetTransport(const QString&)));
   }
@@ -102,12 +104,12 @@ namespace mapviz_plugins
     offset_y_ = offset;
   }
 
-  void ImagePlugin::SetWidth(int width)
+  void ImagePlugin::SetWidth(double width)
   {
     width_ = width;
   }
 
-  void ImagePlugin::SetHeight(int height)
+  void ImagePlugin::SetHeight(double height)
   {
     height_ = height;
   }
@@ -154,14 +156,39 @@ namespace mapviz_plugins
 
   void ImagePlugin::SetUnits(QString units)
   {
+    // do this in both cases to avoid image clamping
+    ui_.width->setMaximum(10000);
+    ui_.height->setMaximum(10000);
+
     if (units == "pixels")
     {
+      ui_.width->setDecimals(0);
+      ui_.height->setDecimals(0);
       units_ = PIXELS;
+      width_  = width_ * double(canvas_->width()) / 100.0;
+      height_ = height_ * double(canvas_->height()) / 100.0;
+      ui_.width->setSuffix(" px");
+      ui_.height->setSuffix(" px");
     }
     else if (units == "percent")
     {
+      ui_.width->setDecimals(1);
+      ui_.height->setDecimals(1);
       units_ = PERCENT;
+      width_ = width_ * 100.0 / double(canvas_->width());
+      height_ =  height_ * 100.0 / double(canvas_->height());
+      ui_.width->setSuffix(" %");
+      ui_.height->setSuffix(" %");
     }
+    ui_.width->setValue( width_ );
+    ui_.height->setValue( height_ );
+
+    if( units_ == PERCENT)
+    {
+      ui_.width->setMaximum(100);
+      ui_.height->setMaximum(100);
+    }
+
   }
   void ImagePlugin::SetSubscription(bool visible)
   {
@@ -188,6 +215,15 @@ namespace mapviz_plugins
     ROS_INFO("Changing image_transport to %s.", transport.toStdString().c_str());
     transport_ = transport;
     TopicEdited();
+  }
+
+  void ImagePlugin::KeepRatioChanged(bool checked)
+  {
+    ui_.height->setEnabled( !checked );
+    if( checked )
+    {
+      ui_.height->setValue( width_ * original_aspect_ratio_ );
+    }
   }
 
   void ImagePlugin::Resubscribe()
@@ -295,6 +331,17 @@ namespace mapviz_plugins
 
     last_width_ = 0;
     last_height_ = 0;
+    original_aspect_ratio_ = (double)image->height / (double)image->width;
+
+    if( ui_.keep_ratio->isChecked() )
+    {
+      double height =  width_ * original_aspect_ratio_;
+      if (units_ == PERCENT)
+      {
+        height *= (double)canvas_->width() / (double)canvas_->height();
+      }
+      ui_.height->setValue(height);
+    }
 
     has_image_ = true;
   }
@@ -377,12 +424,18 @@ namespace mapviz_plugins
     double y_offset = offset_y_;
     double width = width_;
     double height = height_;
+
     if (units_ == PERCENT)
     {
       x_offset = offset_x_ * canvas_->width() / 100.0;
       y_offset = offset_y_ * canvas_->height() / 100.0;
       width = width_ * canvas_->width() / 100.0;
       height = height_ * canvas_->height() / 100.0;
+    }
+
+    if( ui_.keep_ratio->isChecked() )
+    {
+      height = original_aspect_ratio_ * width;
     }
 
     // Scale the source image if necessary
@@ -524,6 +577,13 @@ namespace mapviz_plugins
       node["height"] >> height_;
       ui_.height->setValue(height_);
     }
+
+    if (node["keep_ratio"])
+    {
+      bool keep;
+      node["keep_ratio"] >> keep;
+      ui_.keep_ratio->setChecked( keep );
+    }
   }
 
   void ImagePlugin::SaveConfig(YAML::Emitter& emitter, const std::string& path)
@@ -535,6 +595,7 @@ namespace mapviz_plugins
     emitter << YAML::Key << "offset_y" << YAML::Value << offset_y_;
     emitter << YAML::Key << "width" << YAML::Value << width_;
     emitter << YAML::Key << "height" << YAML::Value << height_;
+    emitter << YAML::Key << "keep_ratio" << YAML::Value << ui_.keep_ratio->isChecked();
     emitter << YAML::Key << "image_transport" << YAML::Value << transport_.toStdString();
   }
 

--- a/mapviz_plugins/ui/image_config.ui
+++ b/mapviz_plugins/ui/image_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>334</width>
-    <height>262</height>
+    <width>396</width>
+    <height>371</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,23 +17,146 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="verticalSpacing">
-    <number>4</number>
-   </property>
-   <property name="margin">
-    <number>2</number>
-   </property>
-   <item row="7" column="1">
-    <widget class="QSpinBox" name="height">
-     <property name="maximum">
-      <number>2000</number>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
      </property>
-     <property name="value">
-      <number>240</number>
+     <property name="text">
+      <string>Topic:</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="1" colspan="2">
+   <item row="8" column="1" rowspan="2" colspan="2">
+    <widget class="QComboBox" name="transport_combo_box">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>25</height>
+      </size>
+     </property>
+     <item>
+      <property name="text">
+       <string>default</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Anchor:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QCheckBox" name="keep_ratio">
+     <property name="text">
+      <string>Keep original aspect ratio</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Units:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Height:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="2">
+    <widget class="QComboBox" name="units">
+     <property name="maximumSize">
+      <size>
+       <width>16777213</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>9</pointsize>
+      </font>
+     </property>
+     <item>
+      <property name="text">
+       <string>pixels</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>percent</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="8" column="0" rowspan="2">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Transport:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Status:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Width:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -52,30 +175,8 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>Select</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="label_5">
      <property name="font">
       <font>
        <family>Sans Serif</family>
@@ -83,52 +184,11 @@
       </font>
      </property>
      <property name="text">
-      <string>Anchor:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Width:</string>
+      <string>Offset Y:</string>
      </property>
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Topic:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QComboBox" name="transport_combo_box">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>25</height>
-      </size>
-     </property>
-     <item>
-      <property name="text">
-       <string>default</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -141,33 +201,34 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
+   <item row="10" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="text">
-      <string>Units:</string>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
      </property>
-    </widget>
-   </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Status:</string>
-     </property>
-    </widget>
+    </spacer>
    </item>
    <item row="3" column="1">
+    <widget class="QSpinBox" name="offsety">
+     <property name="maximum">
+      <number>2000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QSpinBox" name="offsetx">
+     <property name="maximum">
+      <number>2000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
     <widget class="QComboBox" name="anchor">
      <property name="maximumSize">
       <size>
@@ -228,17 +289,7 @@
      </item>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QSpinBox" name="width">
-     <property name="maximum">
-      <number>2000</number>
-     </property>
-     <property name="value">
-      <number>320</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
+   <item row="0" column="1">
     <widget class="QLineEdit" name="topic">
      <property name="font">
       <font>
@@ -248,97 +299,59 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Height:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Offset Y:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QSpinBox" name="offsetx">
-     <property name="maximum">
-      <number>2000</number>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QComboBox" name="units">
+   <item row="0" column="2">
+    <widget class="QPushButton" name="selecttopic">
      <property name="maximumSize">
       <size>
-       <width>16777213</width>
-       <height>25</height>
+       <width>55</width>
+       <height>16777215</height>
       </size>
      </property>
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>9</pointsize>
-      </font>
-     </property>
-     <item>
-      <property name="text">
-       <string>pixels</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>percent</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_9">
      <property name="font">
       <font>
        <family>Sans Serif</family>
        <pointsize>8</pointsize>
       </font>
      </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="text">
-      <string>Transport:</string>
+      <string>Select</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QSpinBox" name="offsety">
+   <item row="5" column="1" colspan="2">
+    <widget class="QDoubleSpinBox" name="width">
+     <property name="decimals">
+      <number>0</number>
+     </property>
+     <property name="minimum">
+      <double>1.000000000000000</double>
+     </property>
      <property name="maximum">
-      <number>2000</number>
+      <double>10000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>320.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="6" column="1" colspan="2">
+    <widget class="QDoubleSpinBox" name="height">
+     <property name="decimals">
+      <number>0</number>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
+     <property name="minimum">
+      <double>1.000000000000000</double>
      </property>
-    </spacer>
+     <property name="maximum">
+      <double>10000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>240.000000000000000</double>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Hi,

I believe this PR would help making the Image Plugin more usable.

1) Added "Keep original image ratio" to the Widget. When checked, the height is automatically adjust, both in "percent" and "pixel" mode. The user should only modify the __Width__ whilst the Height is updated accordingly.

2) When changing the mode from "percent" to "pixel" and vice versa, the image size is preserved.

3) To be sure that no resize is introduced in step 2), I had to change the width and height __type__ and QSpinBox to double and QDoubleSpinBox, and percend must have 1 decimal.

Cheers