### PR TITLE
plan_route_plugin: waypoints_ relative to target_frame

### DIFF
--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -135,12 +135,12 @@ namespace mapviz_plugins
     {
       plan_route.request.header.frame_id = stu::_wgs84_frame;
 
-      for(int i=0; i<waypoints_.size(); i++ )
+      for( geometry_msgs::Pose& waypoint: plan_route.request.waypoints )
       {
-        tf::Vector3 point( waypoints_[i].position.x, waypoints_[i].position.y, 0.0);
+        tf::Vector3 point( waypoint.position.x, waypoint.position.y, 0.0);
         point = transform * point;
-        plan_route.request.waypoints[i].position.x = point.x();
-        plan_route.request.waypoints[i].position.y = point.y();
+        waypoint.position.x = point.x();
+        waypoint.position.y = point.y();
       }
     }
     else{
@@ -344,9 +344,9 @@ namespace mapviz_plugins
       glLineWidth(2);
       sru::Route route = *route_preview_;
       sru::transform(route, transform, target_frame_);
-      for (size_t i = 0; i < route.points.size(); i++)
+      for (const swri_route_util::RoutePoint& point: route.points)
       {
-        glVertex2d(route.points[i].position().x(), route.points[i].position().y());
+        glVertex2d(point.position().x(), point.position().y());
       }
       PrintInfo("OK");
     }
@@ -391,7 +391,6 @@ namespace mapviz_plugins
         painter->drawText(rect, Qt::AlignHCenter | Qt::AlignVCenter,
                           QString::fromStdString(std::to_string(i + 1)));
     }
-
     painter->restore();
   }
 

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -388,8 +388,7 @@ namespace mapviz_plugins
         QPointF gl_point = map_canvas_->FixedFrameToMapGlCoord(point);
         QPointF corner(gl_point.x() - 20, gl_point.y() - 20);
         QRectF rect(corner, QSizeF(40, 40));
-        painter->drawText(rect, Qt::AlignHCenter | Qt::AlignVCenter,
-                          QString::fromStdString(std::to_string(i + 1)));
+        painter->drawText(rect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(i + 1));
     }
     painter->restore();
   }


### PR DESCRIPTION
Hi,

this modification of plan_route_plugin is mostly related to code simplification.

1) __waypoints__ will contain poses relative to **target_frame_**, not  **stu::_wgs84_frame**. This greatly reduces the need for **tf_manager_.GetTransform()** in many locations of the file, making it more readable.

2) Only inside the method **PlanRoute()** the conversion from **target_frame_** to **stu::_wgs84_frame** is done.

3) if the latter transform fails, the mnm::PlanRoute is still send, with:

         plan_route.request.header.frame_id = target_frame_;

but maybe you do NOT want to do this...

4) Similarly, in Draw(), if this fails

        tf_manager_.GetTransform(stu::_wgs84_frame, target_frame_, transform)

a straight line is drawn instead. Personal taste I guess.
Since I don't have the PlanRoute server, I am not able to thoughtfully test it, though.

UPDATE: of course I did test 90% of these changes on my own fork, but I am unable to properly check anything related to the Route server

Davide

