### PR TITLE
Add ability to set offset for multires image

### DIFF
--- a/multires_image/include/multires_image/multires_image_plugin.h
+++ b/multires_image/include/multires_image/multires_image_plugin.h
@@ -81,11 +81,15 @@ namespace mapviz_plugins
   protected Q_SLOTS:
     void SelectFile();
     void AcceptConfiguration();
+    void SetXOffset(double long_offset);
+    void SetYOffset(double latitude_offset);
 
   private:
     bool     loaded_;
     double center_x_;
     double center_y_;
+    double offset_x_;
+    double offset_y_;
 
     multires_image::TileSet* tile_set_;
     MultiresView* tile_view_;

--- a/multires_image/include/multires_image/tile.h
+++ b/multires_image/include/multires_image/tile.h
@@ -77,6 +77,7 @@ namespace multires_image
     void Draw();
 
     void Transform(const swri_transform_util::Transform& transform);
+    void Transform(const swri_transform_util::Transform& transform, const swri_transform_util::Transform& offset_tf);
 
   private:
     const std::string   m_path;

--- a/multires_image/src/multires_config.ui
+++ b/multires_image/src/multires_config.ui
@@ -17,13 +17,22 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
    <property name="verticalSpacing">
     <number>4</number>
    </property>
-   <property name="margin">
-    <number>2</number>
-   </property>
-   <item row="3" column="0">
+   <item row="6" column="1">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -36,7 +45,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="2">
+   <item row="6" column="2" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -55,7 +64,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="3">
     <widget class="QPushButton" name="browse">
      <property name="maximumSize">
       <size>
@@ -78,16 +87,6 @@
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QLineEdit" name="path">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="font">
       <font>
@@ -97,6 +96,65 @@
      </property>
      <property name="text">
       <string>Geo File:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="path">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="label_3">
+     <property name="font">
+      <font>
+       <family>Sans</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>X (East) offset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="label_4">
+     <property name="font">
+      <font>
+       <family>Sans</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Y (North) offset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QDoubleSpinBox" name="x_offset_spin_box">
+     <property name="minimum">
+      <double>-100.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QDoubleSpinBox" name="y_offset_spin_box">
+     <property name="minimum">
+      <double>-100.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
      </property>
     </widget>
    </item>

--- a/multires_image/src/multires_image_plugin.cpp
+++ b/multires_image/src/multires_image_plugin.cpp
@@ -330,6 +330,17 @@ namespace mapviz_plugins
 
       AcceptConfiguration();
     }
+
+    if (node["offset_x"])
+    {
+        node["offset_x"] >> offset_x_;
+        ui_.x_offset_spin_box->setValue(offset_x_);
+    }
+    if (node["offset_y"])
+    {
+        node["offset_y"] >> offset_y_;
+        ui_.y_offset_spin_box->setValue(offset_y_);
+    }
   }
 
   void MultiresImagePlugin::SaveConfig(YAML::Emitter& emitter, const std::string& path)
@@ -339,6 +350,8 @@ namespace mapviz_plugins
     boost::filesystem::path rel_path = MakePathRelative(abs_path, base_path);
 
     emitter << YAML::Key << "path" << YAML::Value << rel_path.string();
+    emitter << YAML::Key << "offset_x" << YAML::Value << offset_x_;
+    emitter << YAML::Key << "offset_y" << YAML::Value << offset_y_;
   }
 }
 

--- a/multires_image/src/multires_image_plugin.cpp
+++ b/multires_image/src/multires_image_plugin.cpp
@@ -52,7 +52,9 @@ namespace mapviz_plugins
     tile_set_(NULL),
     tile_view_(NULL),
     config_widget_(new QWidget()),
-    transformed_(false)
+    transformed_(false),
+    offset_x_(0.0),
+    offset_y_(0.0)
   {
     ui_.setupUi(config_widget_);
 
@@ -66,6 +68,8 @@ namespace mapviz_plugins
 
     QObject::connect(ui_.browse, SIGNAL(clicked()), this, SLOT(SelectFile()));
     QObject::connect(ui_.path, SIGNAL(editingFinished()), this, SLOT(AcceptConfiguration()));
+    QObject::connect(ui_.x_offset_spin_box, SIGNAL(valueChanged(double)), this, SLOT(SetXOffset(double)));
+    QObject::connect(ui_.y_offset_spin_box, SIGNAL(valueChanged(double)), this, SLOT(SetYOffset(double)));
 
     source_frame_ = "/";
   }
@@ -171,6 +175,17 @@ namespace mapviz_plugins
     }
   }
 
+
+  void MultiresImagePlugin::SetXOffset(double offset_x)
+  {
+      offset_x_ = offset_x;
+  }
+
+  void MultiresImagePlugin::SetYOffset(double offset_y)
+  {
+      offset_y_ = offset_y;
+  }
+
   QWidget* MultiresImagePlugin::GetConfigWidget(QWidget* parent)
   {
     config_widget_->setParent(parent);
@@ -225,6 +240,12 @@ namespace mapviz_plugins
       return;
     }
 
+    // Add in user-specified offset to map
+    swri_transform_util::Transform offset(
+                tf::Transform(
+                    tf::createIdentityQuaternion(),
+                    tf::Vector3(offset_x_, offset_y_, 0.0)));
+
     // Set relative positions of tile points based on tf transform
     for (int i = 0; i < tile_set_->LayerCount(); i++)
     {
@@ -235,7 +256,7 @@ namespace mapviz_plugins
         {
           multires_image::Tile* tile = layer->GetTile(c, r);
 
-          tile->Transform(transform_);
+          tile->Transform(transform_, offset);
         }
       }
     }

--- a/multires_image/src/tile.cpp
+++ b/multires_image/src/tile.cpp
@@ -215,5 +215,13 @@ namespace multires_image
     m_transformed_bottom_left = transform * m_bottom_left;
     m_transformed_bottom_right = transform * m_bottom_right;
   }
+
+  void Tile::Transform(const swri_transform_util::Transform& transform, const swri_transform_util::Transform& offset_tf)
+  {
+    m_transformed_top_left = offset_tf * (transform * m_top_left);
+    m_transformed_top_right = offset_tf * (transform * m_top_right);
+    m_transformed_bottom_left = offset_tf * (transform * m_bottom_left);
+    m_transformed_bottom_right = offset_tf * (transform * m_bottom_right);
+  }
 }
 


### PR DESCRIPTION
Closes #564 by adding ability to set an x,y offset (applied in Easting and Northing) to a multires image to correct for inaccuracy in the original map data.

Example of map data that is inaccurate:
![mapviz-add-multires-before](https://user-images.githubusercontent.com/8130042/37714860-90275bfc-2ce8-11e8-9604-d267120ca9fc.png)


Corrected map data using offset:
![mapviz-add-multires-after](https://user-images.githubusercontent.com/8130042/37714866-93686e78-2ce8-11e8-8f11-07f474d815e4.png)

