### PR TITLE
Add support for newlines in text marker plugin (kinetic)

### DIFF
--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -675,7 +675,11 @@ namespace mapviz_plugins
         StampedPoint& rosPoint = marker.points.front();
         QPointF point = tf.map(QPointF(rosPoint.transformed_point.x(),
                                        rosPoint.transformed_point.y()));
-        painter->drawText(point, QString(marker.text.c_str()));
+
+        // Get bounding rectangle
+        QRectF rect(point, QSizeF(10,10));
+        rect = painter->boundingRect(rect, Qt::AlignLeft ,QString(marker.text.c_str()));
+        painter->drawText(rect, QString(marker.text.c_str()));
 
         PrintInfo("OK");
       }


### PR DESCRIPTION
Current method of displaying text markers does not handle newline character, so displaying multiple lines can only be performed by adding multiple text markers. This change auto-calculates the bounding box needed to display the text and then draws text using this box.
![newline_support_to_mapviz](https://user-images.githubusercontent.com/8130042/37116040-9743a214-2212-11e8-8902-b49962e00154.png)

