### PR TITLE
Replace deprecated plugin macro with newer version

### DIFF
--- a/mapviz_plugins/src/move_base_plugin.cpp
+++ b/mapviz_plugins/src/move_base_plugin.cpp
@@ -51,10 +51,8 @@
 
 // Declare plugin
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(mapviz_plugins,
-                        plan_route_grape,
-                        mapviz_plugins::MoveBasePlugin,
-                        mapviz::MapvizPlugin)
+
+PLUGINLIB_EXPORT_CLASS(mapviz_plugins::MoveBasePlugin, mapviz::MapvizPlugin)
 
 namespace mapviz_plugins
 {


### PR DESCRIPTION
This was preventing compilation on ROS Melodic, since the deprecated macro has been removed.

No need to backport this to Indigo since it really only affects Melodic.