### PR TITLE
Fix timestamp interval

### DIFF
--- a/mapviz_plugins/ui/odometry_config.ui
+++ b/mapviz_plugins/ui/odometry_config.ui
@@ -306,7 +306,7 @@
       <string/>
      </property>
      <property name="value">
-      <double>1.000000000000000</double>
+      <double>0.000000000000000</double>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Previous default was 1 which was quite annoying as it showed on every timestamp. This sets it to zero to disable.