### PR TITLE
Fix issue with loading Bing map tiles

### DIFF
--- a/tile_map/include/tile_map/image_cache.h
+++ b/tile_map/include/tile_map/image_cache.h
@@ -152,7 +152,7 @@ namespace tile_map
       void RequestImage(QString);
 
     private:
-      ImageCache* p;
+      ImageCache* image_cache_;
       QMutex waiting_mutex_;
 
       static const int MAXIMUM_SEQUENTIAL_REQUESTS;

--- a/tile_map/include/tile_map/tile_map_view.h
+++ b/tile_map/include/tile_map/tile_map_view.h
@@ -63,6 +63,8 @@ namespace tile_map
   public:
     TileMapView();
 
+    bool IsReady();
+
     void ResetCache();
 
     void SetTileSource(const boost::shared_ptr<TileSource>& tile_source);

--- a/tile_map/include/tile_map/tile_source.h
+++ b/tile_map/include/tile_map/tile_source.h
@@ -56,6 +56,8 @@ namespace tile_map
 
     virtual bool IsCustom() const;
 
+    virtual bool IsReady() const { return is_ready_; };
+
     virtual void SetCustom(bool is_custom);
 
     virtual int32_t GetMaxZoom() const;
@@ -101,10 +103,16 @@ namespace tile_map
     void InfoMessage(const std::string& info_msg) const;
 
   protected:
-    TileSource() {};
+    TileSource() :
+      is_custom_(false),
+      is_ready_(false),
+      max_zoom_(20),
+      min_zoom_(0)
+    {};
 
     QString base_url_;
     bool is_custom_;
+    bool is_ready_;
     int32_t max_zoom_;
     int32_t min_zoom_;
     QString name_;

--- a/tile_map/src/bing_source.cpp
+++ b/tile_map/src/bing_source.cpp
@@ -180,6 +180,8 @@ namespace tile_map
       }
 
       Q_EMIT InfoMessage("API Key Set.");
+
+      is_ready_ = true;
     }
   }
 }

--- a/tile_map/src/tile_map_plugin.cpp
+++ b/tile_map/src/tile_map_plugin.cpp
@@ -322,7 +322,7 @@ namespace tile_map
         last_width_ = canvas_->width();
         last_height_ = canvas_->height();
         tile_map_.SetView(center.y(), center.x(), scale, canvas_->width(), canvas_->height());
-        ROS_INFO("TileMapPlugin::Draw: Successfully set view");
+        ROS_DEBUG("TileMapPlugin::Draw: Successfully set view");
       }
       tile_map_.Draw();
     }

--- a/tile_map/src/tile_map_plugin.cpp
+++ b/tile_map/src/tile_map_plugin.cpp
@@ -297,11 +297,17 @@ namespace tile_map
 
   void TileMapPlugin::Draw(double x, double y, double scale)
   {
+    if (!tile_map_.IsReady())
+    {
+      return;
+    }
+
     swri_transform_util::Transform to_wgs84;
     if (tf_manager_.GetTransform(source_frame_, target_frame_, to_wgs84))
     {
       tf::Vector3 center(x, y, 0);
       center = to_wgs84 * center;
+
       if (center.y() != last_center_y_ ||
           center.x() != last_center_x_ ||
           scale != last_scale_ ||
@@ -316,6 +322,7 @@ namespace tile_map
         last_width_ = canvas_->width();
         last_height_ = canvas_->height();
         tile_map_.SetView(center.y(), center.x(), scale, canvas_->width(), canvas_->height());
+        ROS_INFO("TileMapPlugin::Draw: Successfully set view");
       }
       tile_map_.Draw();
     }

--- a/tile_map/src/tile_map_view.cpp
+++ b/tile_map/src/tile_map_view.cpp
@@ -56,6 +56,11 @@ namespace tile_map
     tile_cache_ = boost::make_shared<TextureCache>(image_cache);
   }
 
+  bool TileMapView::IsReady()
+  {
+    return tile_source_ && tile_source_->IsReady();
+  }
+
   void TileMapView::ResetCache()
   {
     tile_cache_->Clear();


### PR DESCRIPTION
The Bing API requires making an initial authorization call before it can
generate URLs for requesting tiles.  A side effect of this was that if
the tile_map plugin tried to request any times before that initial call
completed, those tiles would fail to load, and they would *never* load
properly after that.

This adds a mechanism for the tile source to indicate whether it is
ready to load tiles or not, and the tile_map plugin will wait until it
is ready before requesting images, so Bing maps should always load
properly on startup.