### PR TITLE
Use shared tf manager in measuring_plugin

### DIFF
--- a/mapviz_plugins/src/measuring_plugin.cpp
+++ b/mapviz_plugins/src/measuring_plugin.cpp
@@ -135,7 +135,7 @@ bool MeasuringPlugin::handleMousePress(QMouseEvent* event)
   //
   // Then we translate from that frame into *our* target frame, `frame`.
   double distance = -1.0;
-  if (tf_manager_.GetTransform(frame, target_frame_, transform))
+  if (tf_manager_->GetTransform(frame, target_frame_, transform))
   {
     ROS_DEBUG("Transforming from fixed frame '%s' to (plugin) target frame '%s'",
               target_frame_.c_str(),


### PR DESCRIPTION
The measuring plugin fails to compile if not using the shared tf_manager syntax