### PR TITLE
Specify default configuration extension on save

### DIFF
--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -889,6 +889,7 @@ void Mapviz::SaveConfig()
   dialog.setFileMode(QFileDialog::AnyFile);
   dialog.setAcceptMode(QFileDialog::AcceptSave);
   dialog.setNameFilter(tr("Mapviz Config Files (*.mvc)"));
+  dialog.setDefaultSuffix("mvc");
 
   dialog.exec();
 


### PR DESCRIPTION
Fixes issue #610 by specifying default extension in QFileDialog for config saves