### PR TITLE
Set main window as in focus on start #630

### DIFF
--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -329,6 +329,8 @@ void Mapviz::Initialize()
       connect(&profile_timer_, SIGNAL(timeout()), this, SLOT(HandleProfileTimer()));
     }
 
+    setFocus(); // Set the main window as focused object, prevent other fields from obtaining focus at startup
+
     initialized_ = true;
   }
 }


### PR DESCRIPTION
Fixes issue #630 by setting the main window as the focused object.  This prevents other widgets from gaining focus by default, such as the Fixed Frame input field.