### PR TITLE
638 add text to measuring plugin

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
@@ -55,6 +55,7 @@ namespace mapviz_plugins
       bool Initialize(QGLWidget* canvas);
       void Shutdown() { };
 
+      void Paint(QPainter* painter, double x, double y, double scale);
       void Draw(double x, double y, double scale);
       void Transform() { };
 
@@ -68,6 +69,11 @@ namespace mapviz_plugins
       void PrintError(const std::string& message);
       void PrintInfo(const std::string& message);
       void PrintWarning(const std::string& message);
+
+      bool SupportsPainting()
+      {
+        return true;
+      }
 
     protected:
       bool eventFilter(QObject* object, QEvent* event);
@@ -95,6 +101,7 @@ namespace mapviz_plugins
 
       qint64 max_ms_;
       qreal max_distance_;
+      std::vector<double> measurements_;
   };
 
 

--- a/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
@@ -87,6 +87,7 @@ namespace mapviz_plugins
       void BkgndColorToggled(bool) { };
       void MeasurementsToggled(bool) { };
       void FontSizeChanged(int) { };
+      void AlphaChanged(double) { };
 
     private:
       Ui::measuring_config ui_;

--- a/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS_MEASURING_PLUGIN_H_
 
 #include <mapviz/mapviz_plugin.h>
+#include <mapviz_plugins/point_drawing_plugin.h>
 
 // ROS Libraries
 #include <ros/ros.h>
@@ -83,7 +84,9 @@ namespace mapviz_plugins
 
     protected Q_SLOTS:
       void Clear();
-      void ToggleMeasurements();
+      void BkgndColorToggled(bool) { };
+      void MeasurementsToggled(bool) { };
+      void FontSizeChanged(int) { };
 
     private:
       Ui::measuring_config ui_;
@@ -96,7 +99,6 @@ namespace mapviz_plugins
       std::vector<tf::Vector3> transformed_vertices_;
 
       int selected_point_;
-      bool toggle_measurements_;
       bool is_mouse_down_;
       QPointF mouse_down_pos_;
       qint64 mouse_down_time_;
@@ -106,6 +108,11 @@ namespace mapviz_plugins
       std::vector<double> measurements_;
   };
 
+  struct MeasurementBox
+  {
+    QRectF rect;
+    QString string;
+  };
 
 }
 

--- a/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
@@ -31,7 +31,6 @@
 #define MAPVIZ_PLUGINS_MEASURING_PLUGIN_H_
 
 #include <mapviz/mapviz_plugin.h>
-#include <mapviz_plugins/point_drawing_plugin.h>
 
 // ROS Libraries
 #include <ros/ros.h>

--- a/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/measuring_plugin.h
@@ -83,6 +83,7 @@ namespace mapviz_plugins
 
     protected Q_SLOTS:
       void Clear();
+      void ToggleMeasurements();
 
     private:
       Ui::measuring_config ui_;
@@ -95,6 +96,7 @@ namespace mapviz_plugins
       std::vector<tf::Vector3> transformed_vertices_;
 
       int selected_point_;
+      bool toggle_measurements_;
       bool is_mouse_down_;
       QPointF mouse_down_pos_;
       qint64 mouse_down_time_;

--- a/mapviz_plugins/ui/measuring_config.ui
+++ b/mapviz_plugins/ui/measuring_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>300</width>
-    <height>216</height>
+    <height>240</height>
    </rect>
   </property>
   <property name="font">
@@ -84,14 +84,14 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Status:</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="QLabel" name="status">
      <property name="styleSheet">
       <string notr="true"/>
@@ -118,7 +118,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <widget class="QPushButton" name="clear">
      <property name="maximumSize">
       <size>
@@ -185,18 +185,18 @@
     <widget class="QSpinBox" name="font_size">
      <property name="maximumSize">
       <size>
-       <width>36</width>
+       <width>48</width>
        <height>16777215</height>
       </size>
      </property>
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
      </property>
-     <property name="maximum">
-      <number>40</number>
-     </property>
      <property name="minimum">
       <number>5</number>
+     </property>
+     <property name="maximum">
+      <number>40</number>
      </property>
      <property name="value">
       <number>10</number>
@@ -207,6 +207,38 @@
     <widget class="QLabel" name="label_8">
      <property name="text">
       <string>Font Size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QDoubleSpinBox" name="alpha">
+     <property name="maximumSize">
+      <size>
+       <width>48</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::PlusMinus</enum>
+     </property>
+     <property name="minimum">
+      <double>0.0</double>
+     </property>
+     <property name="maximum">
+      <double>1.0</double>
+     </property>
+     <property name="value">
+      <double>0.5</double>
+     </property>
+     <property name="singleStep">
+      <double>0.1</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Alpha:</string>
      </property>
     </widget>
    </item>

--- a/mapviz_plugins/ui/measuring_config.ui
+++ b/mapviz_plugins/ui/measuring_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>348</width>
-    <height>128</height>
+    <height>163</height>
    </rect>
   </property>
   <property name="font">
@@ -107,7 +107,7 @@
     <widget class="QPushButton" name="clear">
      <property name="maximumSize">
       <size>
-       <width>100</width>
+       <width>140</width>
        <height>16777215</height>
       </size>
      </property>
@@ -122,14 +122,33 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="4" column="1">
+    <widget class="QPushButton" name="toggle_measurements">
+     <property name="maximumSize">
+      <size>
+       <width>140</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Toggle Measurements</string>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Status:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QLabel" name="status">
      <property name="styleSheet">
       <string notr="true"/>

--- a/mapviz_plugins/ui/measuring_config.ui
+++ b/mapviz_plugins/ui/measuring_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>348</width>
-    <height>163</height>
+    <width>300</width>
+    <height>216</height>
    </rect>
   </property>
   <property name="font">
@@ -68,27 +68,8 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>50</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Color: </string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
-    <widget class="mapviz::ColorButton" name="color">
+    <widget class="mapviz::ColorButton" name="main_color">
      <property name="maximumSize">
       <size>
        <width>24</width>
@@ -103,7 +84,41 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Status:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QLabel" name="status">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>No topic</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="show_measurements">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Show Measurements:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
     <widget class="QPushButton" name="clear">
      <property name="maximumSize">
       <size>
@@ -122,42 +137,76 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QPushButton" name="toggle_measurements">
+   <item row="3" column="1">
+    <widget class="mapviz::ColorButton" name="bkgnd_color">
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="default">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Main Color: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Background Color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Show Background Color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QCheckBox" name="show_bkgnd_color">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QSpinBox" name="font_size">
+     <property name="maximumSize">
+      <size>
+       <width>36</width>
        <height>16777215</height>
       </size>
      </property>
-     <property name="text">
-      <string>Toggle Measurements</string>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::PlusMinus</enum>
      </property>
-     <property name="iconSize">
-      <size>
-       <width>16</width>
-       <height>16</height>
-      </size>
+     <property name="maximum">
+      <number>40</number>
      </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Status:</string>
+     <property name="minimum">
+      <number>5</number>
+     </property>
+     <property name="value">
+      <number>10</number>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QLabel" name="status">
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_8">
      <property name="text">
-      <string>No topic</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+      <string>Font Size:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Add ability to display measurement tags alongside measurement lines on main map. Tags can be edited for color, font size, and transparency. 