### PR TITLE
Restore GL_UNPACK_ALIGNMENT to 4 to prevent corruption of Qt font rendering.

### DIFF
--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -413,6 +413,8 @@ namespace mapviz_plugins
     glPixelZoom(1.0f, -1.0f);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glDrawPixels(image->cols, image->rows, format, GL_UNSIGNED_BYTE, image->ptr());
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+
 
     PrintInfo("OK");
   }

--- a/mapviz_plugins/src/occupancy_grid_plugin.cpp
+++ b/mapviz_plugins/src/occupancy_grid_plugin.cpp
@@ -350,6 +350,8 @@ namespace mapviz_plugins
           color_buffer_.data());
 
     glBindTexture(GL_TEXTURE_2D, 0);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+
   }
 
 

--- a/mapviz_plugins/src/textured_marker_plugin.cpp
+++ b/mapviz_plugins/src/textured_marker_plugin.cpp
@@ -325,6 +325,8 @@ namespace mapviz_plugins
         glTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE );
 
         glBindTexture(GL_TEXTURE_2D, 0);
+
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
       }
       
       glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(markerData.texture_id_));


### PR DESCRIPTION
For some reason setting GL_UNPACK_ALIGNMENT to something other than 4 can effect Qt font rendering: https://forum.qt.io/topic/90149/qpainter-drawtext-display-corrupted-text-on-a-qopenglwidget

This PR restores GL_UNPACK_ALIGNMENT back to 4 in various places it is modified in the plug-ins after the relevant data has been unpacked.

Before: 
![mapviz_20190723T204911_772000](https://user-images.githubusercontent.com/3259020/61746697-e7914100-ad61-11e9-9bb0-88b7cadbde5f.png)

After:
![mapviz_20190723T204707_874595](https://user-images.githubusercontent.com/3259020/61746689-e233f680-ad61-11e9-8e55-9d858cfd9807.png)