### PR TITLE
Default show background and measuring text to true

### DIFF
--- a/mapviz_plugins/ui/measuring_config.ui
+++ b/mapviz_plugins/ui/measuring_config.ui
@@ -109,6 +109,9 @@
      <property name="text">
       <string/>
      </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="5" column="0">
@@ -178,6 +181,9 @@
     <widget class="QCheckBox" name="show_bkgnd_color">
      <property name="text">
       <string/>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Makes the text and background box visible by default in measuring plugin