### PR TITLE
Add ability to use relative paths for images in the robot image plugin

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/robot_image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/robot_image_plugin.h
@@ -81,6 +81,7 @@ namespace mapviz_plugins
     void SelectFile();
     void SelectFrame();
     void FrameEdited();
+    void ImageEdited();
     void WidthChanged(double value);
     void HeightChanged(double value);
     void OffsetXChanged(double value);

--- a/mapviz_plugins/src/robot_image_plugin.cpp
+++ b/mapviz_plugins/src/robot_image_plugin.cpp
@@ -296,9 +296,11 @@ namespace mapviz_plugins
       }
 
       std::string real_filename;
-      if (filename_.find("$(find ") != -1)
+      size_t spos = filename_.find("$(find ");
+      bool has_close = spos != -1 ? filename_.find(')', spos) != -1: false;
+      if (spos != -1 && spos + 7 < filename_.size() && has_close)
       {
-        std::string package = filename_.substr(filename_.find("$(find ") + 7);
+        std::string package = filename_.substr(spos + 7);
         package = package.substr(0, package.find(")"));
 
         real_filename = ros::package::getPath(package) + filename_.substr(filename_.find(')')+1);

--- a/mapviz_plugins/src/robot_image_plugin.cpp
+++ b/mapviz_plugins/src/robot_image_plugin.cpp
@@ -295,12 +295,13 @@ namespace mapviz_plugins
         texture_loaded_ = false;
       }
 
+      const std::string prefix = "$(find ";
       std::string real_filename;
-      size_t spos = filename_.find("$(find ");
+      size_t spos = filename_.find(prefix);
       bool has_close = spos != -1 ? filename_.find(')', spos) != -1: false;
-      if (spos != -1 && spos + 7 < filename_.size() && has_close)
+      if (spos != -1 && spos + prefix.length() < filename_.size() && has_close)
       {
-        std::string package = filename_.substr(spos + 7);
+        std::string package = filename_.substr(spos + prefix.length());
         package = package.substr(0, package.find(")"));
 
         real_filename = ros::package::getPath(package) + filename_.substr(filename_.find(')')+1);


### PR DESCRIPTION
Add ability to use relative paths for images in the robot image plugin using the $(find x) syntax from launch files