### PR TITLE
Fix linking to OpenGL GLU library

### DIFF
--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 add_library(${PROJECT_NAME} ${TILE_SRC_FILES})
 target_link_libraries(${PROJECT_NAME}
   ${Qt_LIBRARIES}
-  ${GLU_LIBRARY}
+  ${OPENGL_glu_LIBRARY}
   ${JSONCPP_LIBRARIES}
   ${catkin_LIBRARIES}
 )


### PR DESCRIPTION
The `GLU_LIBRARY` variable was set by the deprecated `FindGLU.cmake` script. This package now uses `FindOpenGL.cmake`, which sets `OPENGL_glu_LIBRARY`.