### PR TITLE
Disable when hidden

### DIFF
--- a/mapviz_plugins/src/coordinate_picker_plugin.cpp
+++ b/mapviz_plugins/src/coordinate_picker_plugin.cpp
@@ -104,6 +104,12 @@ bool CoordinatePickerPlugin::Initialize(QGLWidget* canvas)
 
 bool CoordinatePickerPlugin::eventFilter(QObject* object, QEvent* event)
 {
+  if(!this->Visible())
+  {
+    ROS_DEBUG("Ignoring mouse event, since coordinate picker plugin is hidden");
+    return false;
+  }
+
   switch (event->type())
   {
     case QEvent::MouseButtonPress:

--- a/mapviz_plugins/src/draw_polygon_plugin.cpp
+++ b/mapviz_plugins/src/draw_polygon_plugin.cpp
@@ -194,6 +194,12 @@ namespace mapviz_plugins
 
   bool DrawPolygonPlugin::handleMousePress(QMouseEvent* event)
   {
+    if(!this->Visible())
+    {
+      ROS_DEBUG("Ignoring mouse press, since draw polygon plugin is hidden");
+      return false;
+    }
+    
     selected_point_ = -1;
     int closest_point = 0;
     double closest_distance = std::numeric_limits<double>::max();

--- a/mapviz_plugins/src/measuring_plugin.cpp
+++ b/mapviz_plugins/src/measuring_plugin.cpp
@@ -121,6 +121,12 @@ bool MeasuringPlugin::Initialize(QGLWidget* canvas)
 
 bool MeasuringPlugin::eventFilter(QObject* object, QEvent* event)
 {
+  if(!this->Visible())
+  {
+    ROS_DEBUG("Ignoring mouse event, since measuring plugin is hidden");
+    return false;
+  }
+
   switch (event->type())
   {
   case QEvent::MouseButtonPress:

--- a/mapviz_plugins/src/point_click_publisher_plugin.cpp
+++ b/mapviz_plugins/src/point_click_publisher_plugin.cpp
@@ -133,10 +133,6 @@ namespace mapviz_plugins
       transformed.setY(tfPoint.y());
     }
 
-    std::stringstream ss;
-    ss << "Point in " << output_frame.c_str() << ": " << transformed.x() << "," << transformed.y();
-    PrintInfo(ss.str());
-
     boost::shared_ptr<geometry_msgs::PointStamped> stamped = boost::make_shared<geometry_msgs::PointStamped>();
     stamped->header.frame_id = output_frame;
     stamped->header.stamp = ros::Time::now();
@@ -144,7 +140,20 @@ namespace mapviz_plugins
     stamped->point.y = transformed.y();
     stamped->point.z = 0.0;
 
-    point_publisher_.publish(stamped);
+    std::stringstream ss;
+    ss << "Point in " << output_frame.c_str() << ": " << transformed.x() << "," << transformed.y();
+
+    // Only publish if this plugin is visible
+    if(this->Visible())
+    {
+      point_publisher_.publish(stamped);
+    }
+    else
+    {
+      ss << " (but not publishing since plugin is hidden)";
+    }
+    
+    PrintInfo(ss.str());
   }
 
   void PointClickPublisherPlugin::SetNode(const ros::NodeHandle& node)


### PR DESCRIPTION
Fixes #677 by disabling the effect of the mouse (when plugin is hidden) for coordinate_picker, measure, draw_polygon, and point_click_publisher.