### PR TITLE
Disable coordinate picker and measuring plugin when hidden (#678)

### DIFF
--- a/mapviz_plugins/src/coordinate_picker_plugin.cpp
+++ b/mapviz_plugins/src/coordinate_picker_plugin.cpp
@@ -106,6 +106,12 @@ bool CoordinatePickerPlugin::Initialize(QGLWidget* canvas)
 
 bool CoordinatePickerPlugin::eventFilter(QObject* object, QEvent* event)
 {
+  if(!this->Visible())
+  {
+    RCLCPP_DEBUG(node_->get_logger(), "Ignoring mouse event, since coordinate picker plugin is hidden");
+    return false;
+  }
+
   switch (event->type())
   {
     case QEvent::MouseButtonPress:

--- a/mapviz_plugins/src/draw_polygon_plugin.cpp
+++ b/mapviz_plugins/src/draw_polygon_plugin.cpp
@@ -198,6 +198,12 @@ namespace mapviz_plugins
 
   bool DrawPolygonPlugin::handleMousePress(QMouseEvent* event)
   {
+    if(!this->Visible())
+    {
+      RCLCPP_DEBUG(node_->get_logger(), "Ignoring mouse press, since draw polygon plugin is hidden");
+      return false;
+    }
+    
     selected_point_ = -1;
     int closest_point = 0;
     double closest_distance = std::numeric_limits<double>::max();

--- a/mapviz_plugins/src/measuring_plugin.cpp
+++ b/mapviz_plugins/src/measuring_plugin.cpp
@@ -36,11 +36,7 @@
 #include <QTextStream>
 #include <QPainter>
 
-#if QT_VERSION >= 0x050000
 #include <QGuiApplication>
-#else
-#include <QApplication>
-#endif
 
 // ROS Libraries
 #include <rclcpp/rclcpp.hpp>
@@ -130,6 +126,12 @@ bool MeasuringPlugin::Initialize(QGLWidget* canvas)
 
 bool MeasuringPlugin::eventFilter(QObject* object, QEvent* event)
 {
+  if(!this->Visible())
+  {
+    RCLCPP_DEBUG(node_->get_logger(), "Ignoring mouse event, since measuring plugin is hidden");
+    return false;
+  }
+
   switch (event->type())
   {
   case QEvent::MouseButtonPress:

--- a/mapviz_plugins/src/point_click_publisher_plugin.cpp
+++ b/mapviz_plugins/src/point_click_publisher_plugin.cpp
@@ -139,10 +139,6 @@ namespace mapviz_plugins
       transformed.setY(tfPoint.y());
     }
 
-    std::stringstream ss;
-    ss << "Point in " << output_frame.c_str() << ": " << transformed.x() << "," << transformed.y();
-    PrintInfo(ss.str());
-
     std::unique_ptr<geometry_msgs::msg::PointStamped> stamped =
       std::make_unique<geometry_msgs::msg::PointStamped>();
     stamped->header.frame_id = output_frame;
@@ -151,7 +147,20 @@ namespace mapviz_plugins
     stamped->point.y = transformed.y();
     stamped->point.z = 0.0;
 
-    point_publisher_->publish(*stamped);
+    std::stringstream ss;
+    ss << "Point in " << output_frame.c_str() << ": " << transformed.x() << "," << transformed.y();
+
+    // Only publish if this plugin is visible
+    if(this->Visible())
+    {
+      point_publisher_->publish(*stamped);
+    }
+    else
+    {
+      ss << " (but not publishing since plugin is hidden)";
+    }
+    
+    PrintInfo(ss.str());
   }
 
   void PointClickPublisherPlugin::SetNode(rclcpp::Node& node)


### PR DESCRIPTION
Cherry-picking this into the ROS2 branch.