### PR TITLE
Fix plan route visibility

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/plan_route_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/plan_route_plugin.h
@@ -100,6 +100,7 @@ namespace mapviz_plugins
     void PublishRoute();
     void PlanRoute();
     void Clear();
+    void VisibilityChanged(bool);
 
    private:
     void Retry(const ros::TimerEvent& e);

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -133,7 +133,7 @@ namespace mapviz_plugins
   {
     route_preview_ = sru::RoutePtr();
     bool start_from_vehicle = ui_.start_from_vehicle->isChecked();
-    if (waypoints_.size() + start_from_vehicle < 2)
+    if (waypoints_.size() + start_from_vehicle < 2 || !Visible())
     {
       return;
     }

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -88,11 +88,27 @@ namespace mapviz_plugins
                      SLOT(PublishRoute()));
     QObject::connect(ui_.clear, SIGNAL(clicked()), this,
                      SLOT(Clear()));
+    QObject::connect(this,
+                     SIGNAL(VisibleChanged(bool)),
+                     this,
+                     SLOT(VisibilityChanged(bool)));
   }
 
   PlanRoutePlugin::~PlanRoutePlugin()
   {
     if (map_canvas_)
+    {
+      map_canvas_->removeEventFilter(this);
+    }
+  }
+
+  void PlanRoutePlugin::VisibilityChanged(bool visible)
+  {
+    if (visible)
+    {
+      map_canvas_->installEventFilter(this);
+    }
+    else
     {
       map_canvas_->removeEventFilter(this);
     }


### PR DESCRIPTION
This disables the event filter and stops replanning when hidden. It was stealing clicks from other plugins and causing extra load when disabled.