### PR TITLE
Move plugins to separate pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -41,6 +41,14 @@ collections:
   plugins:
     output: true
 
+defaults:
+  - scope:
+      path: ''
+      type: 'plugins'
+    values:
+      layout: 'plugin'
+      parent: 'Plugins'
+
 compress_html:
   clippings: all
   comments: all

--- a/docs/_layouts/plugin.md
+++ b/docs/_layouts/plugin.md
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+{% capture content %}
+
+# {{ page.title }}
+
+{{ page.description }}
+
+{% if page.image and page.image != "" %}
+![]({{ site.baseurl | append: '/assets/images/' }}{{ page.image }})
+{% endif %}
+
+## Parameters
+
+{% if page.parameters %}
+  {% for param in page.parameters %}
+| {{ param.name }} | {{ param.description | replace: "|","/"}} |
+  {%- endfor -%}
+{% else %}
+  No parameters.
+{% endif %}
+
+{% endcapture %}
+
+{{ content | markdownify }}

--- a/docs/_plugins/attitude_indicator.md
+++ b/docs/_plugins/attitude_indicator.md
@@ -1,8 +1,6 @@
 ---
-name: "Attitude Indicator"
+title: "Attitude Indicator"
 description: ""
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/coordinate_picker.md
+++ b/docs/_plugins/coordinate_picker.md
@@ -1,10 +1,8 @@
 ---
-name: "Coordinate Picker"
+title: "Coordinate Picker"
 description: "Transforms coordinates of clicked points on the map to a specified frame. The most recent coordinate is placed on the clipboard, and a list of coordinates is displayed in the GUI."
 image: "screenshot_coordinate_picker.png"
 parameters:
   - name: frame
     description: "Coordinate frame into which to transform the clicked point"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/disparity.md
+++ b/docs/_plugins/disparity.md
@@ -1,5 +1,5 @@
 ---
-name: "Disparity"
+title: "Disparity"
 description: "Overlays a [sensor_msgs::DisparityImage](http://docs.ros.org/api/stereo_msgs/html/msg/DisparityImage.html) onto the display using the ''jet'' color map."
 image: "disparity.png"
 parameters:
@@ -18,5 +18,3 @@ parameters:
   - name: Units
     description: (pixels | percent of window)
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/draw_polygon.md
+++ b/docs/_plugins/draw_polygon.md
@@ -1,8 +1,6 @@
 ---
-name: "Draw Polygon"
+title: "Draw Polygon"
 description: "Draw a polygon on the canvas and publish to a topic."
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/float.md
+++ b/docs/_plugins/float.md
@@ -1,5 +1,5 @@
 ---
-name: "Float"
+title: "Float"
 description: "Displays the most recent value from a `std_msgs::Float32/64, marti_common_msgs/Float32/64Stamped` or a `marti_sensor_msgs/Velocity` message at a fixed location on the scene."
 image: ""
 parameters:
@@ -20,5 +20,3 @@ parameters:
   - name: "Postfix"
     description: "Text to append to the displayed value (ex. to show units)"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/gps.md
+++ b/docs/_plugins/gps.md
@@ -1,5 +1,5 @@
 ---
-name: "GPS"
+title: "GPS"
 description: "Projects [gps_common::GPSFix](http://docs.ros.org/kinetic/api/gps_common/html/msg/GPSFix.html) message data into the scene."
 image: ""
 parameters:
@@ -18,5 +18,3 @@ parameters:
   - name: Show Laps
     description: If checked, multiple loops of GPS coordinates will have different colors
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/grid.md
+++ b/docs/_plugins/grid.md
@@ -1,5 +1,5 @@
 ---
-name: "Grid"
+title: "Grid"
 description: "Projects a 2D grid into the scene."
 image: ""
 parameters:
@@ -20,5 +20,3 @@ parameters:
   - name: Columns
     description: Number of grid columns
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/image.md
+++ b/docs/_plugins/image.md
@@ -1,5 +1,5 @@
 ---
-name: "Image"
+title: "Image"
 description: "Overlays a [sensor_msgs::Image](http://docs.ros.org/api/sensor_msgs/html/msg/Image.html) onto the display."
 image: ""
 parameters:
@@ -18,5 +18,3 @@ parameters:
   - name: Units
     description: (pixels | percent of window)
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/laserscan.md
+++ b/docs/_plugins/laserscan.md
@@ -1,5 +1,5 @@
 ---
-name: "LaserScan"
+title: "LaserScan"
 description: "Projects a [sensor_msgs::LaserScan](http://docs.ros.org/api/sensor_msgs/html/msg/LaserScan.html) message into the scene."
 image: ""
 parameters:
@@ -18,5 +18,3 @@ parameters:
   - name: "Buffer Size"
     description: "Size of circular buffer of laser scan messages points"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/marker.md
+++ b/docs/_plugins/marker.md
@@ -1,5 +1,5 @@
 ---
-name: "Marker"
+title: "Marker"
 description: "Projects a [visualization_msgs::Marker](http://docs.ros.org/api/visualization_msgs/html/msg/Marker.html) or [visualization_msgs::MarkerArray](http://docs.ros.org/api/visualization_msgs/html/msg/MarkerArray.html) into the scene.
 
 [Markers](http://wiki.ros.org/rviz/DisplayTypes/Marker) are the most flexible display type and more or less mirror the [OpenGL primitives](https://www.opengl.org/wiki/Primitive)."
@@ -8,5 +8,3 @@ parameters:
   - name: "Topic"
     description: "The marker topic"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/measuring.md
+++ b/docs/_plugins/measuring.md
@@ -1,8 +1,6 @@
 ---
-name: "Measuring"
+title: "Measuring"
 description: "Measure distance on the canvas with the mouse."
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/move_base.md
+++ b/docs/_plugins/move_base.md
@@ -1,8 +1,6 @@
 ---
-name: "Move Base"
+title: "Move Base"
 description: "Allows the user to send goals to [move_base](wiki.ros.org/move_base)."
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/multires_image.md
+++ b/docs/_plugins/multires_image.md
@@ -1,10 +1,8 @@
 ---
-name: "Multi-Res Image"
+title: "Multi-Res Image"
 description: "Projects a geo-referenced multi-resolution image tile map into the scene. The concept is the same as the Google Maps style pan/zoom satellite imagery."
 image: "multires2.png"
 parameters:
   - name: "Geo File"
     description: "Path to the geo-referenced map tiles."
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/navsat.md
+++ b/docs/_plugins/navsat.md
@@ -1,5 +1,5 @@
 ---
-name: "NavSat"
+title: "NavSat"
 description: "Projects [sensor_msgs::NavSatFix](https://docs.ros.org/jade/api/sensor_msgs/html/msg/NavSatFix.html) message data into the scene."
 image: ""
 parameters:
@@ -14,5 +14,3 @@ parameters:
   - name: "Buffer Size"
     description: "Size of circular buffer of GPS points"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/occupancy_grid.md
+++ b/docs/_plugins/occupancy_grid.md
@@ -1,8 +1,6 @@
 ---
-name: "Occupancy Grid"
+title: "Occupancy Grid"
 description: ""
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/odometry.md
+++ b/docs/_plugins/odometry.md
@@ -1,5 +1,5 @@
 ---
-name: "Odometry"
+title: "Odometry"
 description: "Projects [nav_msgs::Odometry](http://docs.ros.org/api/nav_msgs/html/msg/Odometry.html) message data into the scene."
 image: ""
 parameters:
@@ -16,5 +16,3 @@ parameters:
   - name: "Buffer Size"
     description: "Size of circular buffer of odometry points"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/path.md
+++ b/docs/_plugins/path.md
@@ -1,10 +1,8 @@
 ---
-name: "Path"
+title: "Path"
 description: "Projects [nav_msgs::Path](http://docs.ros.org/api/nav_msgs/html/msg/Path.html) message data into the scene."
 image: ""
 parameters:
   - name: "Topic"
     description: "The path topic"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/plan_route.md
+++ b/docs/_plugins/plan_route.md
@@ -1,8 +1,6 @@
 ---
-name: "Plan Route"
+title: "Plan Route"
 description: ""
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/point_click_publisher.md
+++ b/docs/_plugins/point_click_publisher.md
@@ -1,5 +1,5 @@
 ---
-name: "Point Click Publisher"
+title: "Point Click Publisher"
 description: "Publishes a [geometry_msgs::PointStamped](http://docs.ros.org/api/geometry_msgs/html/msg/PointStamped.html) message every time a user clicks on the map frame that corresponds to the clicked location."
 image: ""
 parameters:
@@ -8,5 +8,3 @@ parameters:
   - name: "Frame"
     description: "The target frame to transform the point to before publishing it"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/point_drawing.md
+++ b/docs/_plugins/point_drawing.md
@@ -1,8 +1,6 @@
 ---
-name: "Point Drawing"
+title: "Point Drawing"
 description: ""
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/pointcloud2.md
+++ b/docs/_plugins/pointcloud2.md
@@ -1,8 +1,6 @@
 ---
-name: "Pointcloud2"
+title: "Pointcloud2"
 description: ""
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/pose.md
+++ b/docs/_plugins/pose.md
@@ -1,8 +1,6 @@
 ---
-name: "Pose"
+title: "Pose"
 description: ""
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/robot_image.md
+++ b/docs/_plugins/robot_image.md
@@ -1,5 +1,5 @@
 ---
-name: "Robot Image"
+title: "Robot Image"
 description: "Projects an image loaded from file into the scene to represent the robot platform."
 image: ""
 parameters:
@@ -12,5 +12,3 @@ parameters:
   - name: "Height"
     description: "The physical height represented by the image"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/route.md
+++ b/docs/_plugins/route.md
@@ -1,8 +1,6 @@
 ---
-name: "Route"
+title: "Route"
 description: ""
 image: ""
 parameters:
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/string.md
+++ b/docs/_plugins/string.md
@@ -1,5 +1,5 @@
 ---
-name: "String"
+title: "String"
 description: "Displays the most recent string from a `std_msgs::String` message at a fixed location on the scene."
 image: ""
 parameters:
@@ -18,5 +18,3 @@ parameters:
   - name: "Units"
     description: "(pixels | percent of window)"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/textured_marker.md
+++ b/docs/_plugins/textured_marker.md
@@ -1,5 +1,5 @@
 ---
-name: "Textured Marker"
+title: "Textured Marker"
 description: "Projects `marti_visualization_msgs::TexturedMarker` and `marti_visualization_msgs::TexturedMarkerArray` message data into the scene.
 
 Textured markers follow the same general approach as traditional markers, but can be used to texture dense image data onto a quad which is projected into the scene."
@@ -8,5 +8,3 @@ parameters:
   - name: "Topic"
     description: "The textured marker topic"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/tf_frame.md
+++ b/docs/_plugins/tf_frame.md
@@ -1,5 +1,5 @@
 ---
-name: "TF Frame"
+title: "TF Frame"
 description: "Projects [Tf](http://wiki.ros.org/tf) data into the scene similar to the Odometry plug-in."
 image: ""
 parameters:
@@ -14,5 +14,3 @@ parameters:
   - name: "Buffer Size"
     description: "Size of circular buffer of Tf points"
 ---
-
-# {{ page.plugin }}

--- a/docs/_plugins/tile_map.md
+++ b/docs/_plugins/tile_map.md
@@ -1,5 +1,5 @@
 ---
-name: "Tile Map"
+title: "Tile Map"
 description: "Projects a geo-referenced multi-resolution image tile map into the scene.  Map tiles can be obtained from [Bing Maps](https://www.bing.com/mapspreview) or any [WMTS Tile Service](http://www.opengeospatial.org/standards/wmts).  Pre-defined services that access [Stamen Design](http://maps.stamen.com/) (terrain, watercolor, and toner) are provided.  Custom or local WMTS map servers can also be specified.  Map data is cached to disk which enables some limited use completely offline."
 image: "satellite.png"
 parameters:
@@ -12,5 +12,3 @@ parameters:
   - name: "Max Zoom"
     description: "The maximum zoom level that will be used when requesting tiles."
 ---
-
-# {{ page.plugin }}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,37 +2,26 @@
 layout: default
 title: Plugins
 nav_order: 2
+has_children: true
 ---
 
 # Plugins
 {: .no_toc }
 
-## Table of contents
-{: .no_toc .text-delta }
-
-1. TOC
-{:toc}
-
----
-
+<table>
+<tr>
+<th>Plugin Name</th>
+<th>Description</th>
+</tr>
 {% for plugin in site.plugins %}
-## {{ plugin.name }}
-
-{{ plugin.description }}
-
-{% if plugin.image and plugin.image != "" %}
+<tr>
+<td><a href="{{ site.baseurl }}{{ plugin.url }}" class="mb-1 mt-1 v-align-middle">{{ plugin.name | markdownify | remove: '<p>' | remove: '</p>' }}</a></td>
+<td>{{ plugin.description | markdownify | remove: '<p>' | remove: '</p>' }}</td>
+</tr>
+{%- comment -%}
+{%- if plugin.image and plugin.image != "" -%}
 ![]({{ site.baseurl | append: '/assets/images/' }}{{ plugin.image }})
-{% endif %}
-
-### Parameters
-{: .no_toc }
-
-{% for param in plugin.parameters %}
-*   {{ param.name }}
-
-    {{ param.description }}
-{% endfor %}
-
----
-
-{% endfor %}
+{%- endif -%}
+{%- endcomment -%}
+{%- endfor -%}
+</table>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -15,7 +15,7 @@ has_children: true
 </tr>
 {% for plugin in site.plugins %}
 <tr>
-<td><a href="{{ site.baseurl }}{{ plugin.url }}" class="mb-1 mt-1 v-align-middle">{{ plugin.name | markdownify | remove: '<p>' | remove: '</p>' }}</a></td>
+<td><a href="{{ site.baseurl }}{{ plugin.url }}" class="mb-1 mt-1 v-align-middle">{{ plugin.title | markdownify | remove: '<p>' | remove: '</p>' }}</a></td>
 <td>{{ plugin.description | markdownify | remove: '<p>' | remove: '</p>' }}</td>
 </tr>
 {%- comment -%}


### PR DESCRIPTION
Plugins now have their own pages. This will help with search; previously, searching for anything just found the giant plugins page, but not which plugin on that page. Now it will find the exact right page.

The main plugin page lists them in a table with links to the individual pages.

| Plugin Name | Description |
|-----|-----|
| My Name | My Description |

We may eventually need a short description (for the table) and a long description (for the page, which uses the same variable).

Unfortunately, getting the newlines right to create the table in Markdown with column headers was too hard, so the table is in raw HTML with Liquid variables. As a result, the plugin name and description have to be re-`markdownify`'d, which adds a `<p>` tag that then requires removing. So this code gets ugly, but the output is correct.

Each plugin page has the title, an image (if available), and a table of parameters. The table looked nicer.

Each element of the `plugins` collection has its parent set to `Plugins` to create the breadcrumbs at the top of each page. To pull this off correctly, we also needed to change each plugin's `name` attribute to be the `title` attribute, because Liquid cannot programmatically set front matter, so we need to do it ourselves. If we need a name that is not the title later, we can add `name` back in.