### PR TITLE
[tile_map] Output human-readable error message

### DIFF
--- a/tile_map/include/tile_map/image_cache.h
+++ b/tile_map/include/tile_map/image_cache.h
@@ -110,7 +110,6 @@ namespace tile_map
   public Q_SLOTS:
     void ProcessRequest(QString uri);
     void ProcessReply(QNetworkReply* reply);
-    void NetworkError(QNetworkReply::NetworkError error);
     void Clear();
 
   private:

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -202,8 +202,6 @@ namespace tile_map
         true);
 
     QNetworkReply *reply = network_manager_.get(request);
-    connect(reply, SIGNAL(error(QNetworkReply::NetworkError)),
-            this, SLOT(NetworkError(QNetworkReply::NetworkError)));
   }
 
   void ImageCache::ProcessReply(QNetworkReply* reply)
@@ -229,6 +227,7 @@ namespace tile_map
       }
       else
       {
+        ROS_ERROR("NETWORK ERROR: %s", reply->errorString().toStdString().c_str());
         image->AddFailure();
       }
     }
@@ -244,12 +243,6 @@ namespace tile_map
     unprocessed_mutex_.unlock();
 
     reply->deleteLater();
-  }
-
-  void ImageCache::NetworkError(QNetworkReply::NetworkError error)
-  {
-    ROS_ERROR("NETWORK ERROR: %d", error);
-    // TODO add failure
   }
 
   const int CacheThread::MAXIMUM_SEQUENTIAL_REQUESTS = 12;

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -227,7 +227,7 @@ namespace tile_map
       }
       else
       {
-        ROS_ERROR("NETWORK ERROR: %s", reply->errorString().toStdString().c_str());
+        ROS_ERROR_THROTTLE(1.0, "NETWORK ERROR: %s", reply->errorString().toStdString().c_str());
         image->AddFailure();
       }
     }


### PR DESCRIPTION
Rather than using the signal error(QNetworkReply::NetworkError), which does not expose the underlying QNetworkReply and only provides the QNetworkReply::NetworkError value, use the QNetworkReply::errorString() method to get a human-readable error message.