### PR TITLE
Constrain the minimum line and point marker sizes to be 1 pixel wide.

### DIFF
--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -495,7 +495,7 @@ namespace mapviz_plugins
         glEnd();
       }
       else if (marker.display_type == visualization_msgs::Marker::LINE_STRIP) {
-        glLineWidth(marker.scale_x);
+        glLineWidth(std::max(1.0f, marker.scale_x));
         glBegin(GL_LINE_STRIP);
 
         for (const auto &point : marker.points) {
@@ -509,7 +509,7 @@ namespace mapviz_plugins
         glEnd();
       }
       else if (marker.display_type == visualization_msgs::Marker::LINE_LIST) {
-        glLineWidth(marker.scale_x);
+        glLineWidth(std::max(1.0f, marker.scale_x));
         glBegin(GL_LINES);
 
         for (const auto &point : marker.points) {
@@ -523,7 +523,7 @@ namespace mapviz_plugins
         glEnd();
       }
       else if (marker.display_type == visualization_msgs::Marker::POINTS) {
-        glPointSize(marker.scale_x);
+        glLineWidth(std::max(1.0f, marker.scale_x));
         glBegin(GL_POINTS);
 
         for (const auto &point : marker.points) {

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -523,7 +523,7 @@ namespace mapviz_plugins
         glEnd();
       }
       else if (marker.display_type == visualization_msgs::Marker::POINTS) {
-        glLineWidth(std::max(1.0f, marker.scale_x));
+        glPointSize(std::max(1.0f, marker.scale_x));
         glBegin(GL_POINTS);
 
         for (const auto &point : marker.points) {


### PR DESCRIPTION
Mapviz interprets the scale field of line and point markers as pixels instead of meters as specified in the Marker message.  There are some advantage to visualizing the line and point widths in mapviz in a zoom independent way.

However, this means that line and point markers don't display correctly in both mapviz and rviz (which does interpret the size as meters).

Since line and point markers with scale defined in meters for rviz usually have scales less than 1.0, they don't show up in mapviz very well.

This PR constrains the pixel size of line an point markers to be at least 1.0 in mapviz.