### PR TITLE
Restore and refactor use_latest_transforms option for position history plugins.

### DIFF
--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -71,7 +71,6 @@ namespace mapviz
     void ToggleFixOrientation(bool on);
     void ToggleRotate90(bool on);
     void ToggleEnableAntialiasing(bool on);
-    void ToggleUseLatestTransforms(bool on);
     void UpdateView();
     void ReorderDisplays();
     void ResetLocation();

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -95,7 +95,6 @@ namespace mapviz
     void ReorderDisplays();
     void FixedFrameSelected(const QString& text);
     void TargetFrameSelected(const QString& text);
-    void ToggleUseLatestTransforms(bool on);
     void UpdateFrames();
     void SpinOnce();
     void UpdateSizeHints();

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -448,15 +448,6 @@ void MapCanvas::ToggleEnableAntialiasing(bool on)
   this->setFormat(format);
 }
 
-void MapCanvas::ToggleUseLatestTransforms(bool on)
-{
-  std::list<MapvizPluginPtr>::iterator it;
-  for (it = plugins_.begin(); it != plugins_.end(); ++it)
-  {
-    (*it)->SetUseLatestTransforms(on);
-  }
-}
-
 void MapCanvas::AddPlugin(MapvizPluginPtr plugin, int order)
 {
   plugins_.push_back(plugin);

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -690,14 +690,6 @@ void Mapviz::Open(const std::string& filename)
       node_->setParam(IMAGE_TRANSPORT_PARAM, image_transport);
     }
 
-    bool use_latest_transforms = true;
-    if (swri_yaml_util::FindValue(doc, "use_latest_transforms"))
-    {
-      doc["use_latest_transforms"] >> use_latest_transforms;
-    }
-    ui_.uselatesttransforms->setChecked(use_latest_transforms);
-    canvas_->ToggleUseLatestTransforms(use_latest_transforms);
-
     if (swri_yaml_util::FindValue(doc, "background"))
     {
       std::string color;
@@ -790,7 +782,6 @@ void Mapviz::Save(const std::string& filename)
   out << YAML::Key << "view_scale" << YAML::Value << canvas_->ViewScale();
   out << YAML::Key << "offset_x" << YAML::Value << canvas_->OffsetX();
   out << YAML::Key << "offset_y" << YAML::Value << canvas_->OffsetY();
-  out << YAML::Key << "use_latest_transforms" << YAML::Value << ui_.uselatesttransforms->isChecked();
   out << YAML::Key << "background" << YAML::Value << background_.name().toStdString();
   std::string image_transport;
   if (node_->getParam(IMAGE_TRANSPORT_PARAM, image_transport))
@@ -1216,7 +1207,6 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
 
   // Add plugin to canvas
   plugin->SetTargetFrame(ui_.fixedframe->currentText().toStdString());
-  plugin->SetUseLatestTransforms(ui_.uselatesttransforms->isChecked());
   plugins_[item] = plugin;
   canvas_->AddPlugin(plugin, -1);
 
@@ -1264,11 +1254,6 @@ void Mapviz::TargetFrameSelected(const QString& text)
       canvas_->SetTargetFrame(text.toStdString().c_str());
     }
   }
-}
-
-void Mapviz::ToggleUseLatestTransforms(bool on)
-{
-  canvas_->ToggleUseLatestTransforms(on);
 }
 
 void Mapviz::ToggleFixOrientation(bool on)

--- a/mapviz/src/mapviz.ui
+++ b/mapviz/src/mapviz.ui
@@ -254,24 +254,6 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0" colspan="3">
-         <widget class="QCheckBox" name="uselatesttransforms">
-          <property name="toolTip">
-           <string>Use the current time when transforming data instead of using the
-                                                timestamps associated with the data
-                                            </string>
-          </property>
-          <property name="layoutDirection">
-           <enum>Qt::LeftToRight</enum>
-          </property>
-          <property name="text">
-           <string>Use Latest Transforms</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
        </layout>
       </widget>
      </item>
@@ -514,7 +496,6 @@
  <tabstops>
   <tabstop>fixedframe</tabstop>
   <tabstop>targetframe</tabstop>
-  <tabstop>uselatesttransforms</tabstop>
   <tabstop>bg_color</tabstop>
   <tabstop>configs</tabstop>
   <tabstop>addbutton</tabstop>
@@ -701,22 +682,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>uselatesttransforms</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mapviz</receiver>
-   <slot>ToggleUseLatestTransforms(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>58</x>
-     <y>130</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>460</x>
-     <y>242</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>actionSet_Capture_Directory</sender>
    <signal>triggered()</signal>
    <receiver>mapviz</receiver>
@@ -828,7 +793,6 @@
   <slot>Force720p(bool)</slot>
   <slot>Force480p(bool)</slot>
   <slot>SetResizable(bool)</slot>
-  <slot>ToggleUseLatestTransforms(bool)</slot>
   <slot>SetCaptureDirectory()</slot>
   <slot>ToggleStatusBar(bool)</slot>
   <slot>ToggleCaptureTools(bool)</slot>

--- a/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/point_drawing_plugin.h
@@ -94,6 +94,7 @@ namespace mapviz_plugins
     virtual void CollectLaps();
     virtual bool DrawLapsArrows();
     virtual bool TransformPoint(StampedPoint& point);
+    virtual void TransformPoint(StampedPoint& point, const swri_transform_util::Transform& transform);
     virtual void UpdateColor(QColor base_color, int i);
     virtual void DrawCovariance();
 
@@ -109,6 +110,8 @@ namespace mapviz_plugins
     virtual void LapToggled(bool checked);
     virtual void CovariancedToggled(bool checked);
     virtual void ShowAllCovariancesToggled(bool checked);
+    virtual void SetUseLatestTransforms(bool checked);
+
     void ResetTransformedPoints();
     void ClearPoints();
 
@@ -117,6 +120,8 @@ namespace mapviz_plugins
     double bufferSize() const;
     double positionTolerance() const;
     const std::deque<StampedPoint>& points() const;
+    bool single_frame_;
+
 
    private:
     int arrow_size_;
@@ -133,6 +138,7 @@ namespace mapviz_plugins
     int buffer_holder_;
     double scale_;
     bool static_arrow_sizes_;
+    bool use_latest_transforms_;
 
    private:
     std::vector<std::deque<StampedPoint> > laps_;

--- a/mapviz_plugins/src/gps_plugin.cpp
+++ b/mapviz_plugins/src/gps_plugin.cpp
@@ -73,6 +73,8 @@ namespace mapviz_plugins
                      this, SLOT(SetStaticArrowSizes(bool)));
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
+    QObject::connect(ui_.use_latest_transforms, SIGNAL(clicked(bool)),
+                     this, SLOT(SetUseLatestTransforms(bool)));
     QObject::connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
             SLOT(SetColor(const QColor&)));
     QObject::connect(ui_.show_laps, SIGNAL(toggled(bool)), this,
@@ -266,6 +268,13 @@ namespace mapviz_plugins
       SetArrowSize(arrow_size);
     }
 
+    if (node["use_latest_transforms"])
+    {
+      bool use_latest_transforms = node["use_latest_transforms"].as<bool>();
+      ui_.use_latest_transforms->setChecked(use_latest_transforms);
+      SetUseLatestTransforms(use_latest_transforms);
+    }
+
     TopicEdited();
   }
 
@@ -291,5 +300,7 @@ namespace mapviz_plugins
     emitter << YAML::Key << "static_arrow_sizes" << YAML::Value << ui_.static_arrow_sizes->isChecked();
 
     emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
+
+    emitter << YAML::Key << "use_latest_transforms" << YAML::Value << ui_.use_latest_transforms->isChecked();
   }
 }

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -362,18 +362,7 @@ namespace mapviz_plugins
 
   bool LaserScanPlugin::GetScanTransform(const Scan& scan, swri_transform_util::Transform& transform)
   {
-      bool was_using_latest_transforms = this->use_latest_transforms_;
-      //Try first with use_latest_transforms_ = false
-      this->use_latest_transforms_ = false;
       bool has_tranform = GetTransform(scan.source_frame_, scan.stamp, transform);
-      if( !has_tranform && was_using_latest_transforms)
-      {
-          //If failed use_latest_transforms_ = true
-          this->use_latest_transforms_ = true;
-          has_tranform = GetTransform(scan.source_frame_, scan.stamp, transform);
-      }
-
-      this->use_latest_transforms_ = was_using_latest_transforms;
       return has_tranform;
   }
 

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -64,6 +64,8 @@ namespace mapviz_plugins
                      SLOT(SelectTopic()));
     QObject::connect(ui_.topic, SIGNAL(editingFinished()), this,
                      SLOT(TopicEdited()));
+    QObject::connect(ui_.use_latest_transforms, SIGNAL(clicked(bool)),
+                     this, SLOT(SetUseLatestTransforms(bool)));
     QObject::connect(ui_.positiontolerance, SIGNAL(valueChanged(double)), this,
                      SLOT(PositionToleranceChanged(double)));
     QObject::connect(ui_.buffersize, SIGNAL(valueChanged(int)), this,
@@ -212,6 +214,13 @@ namespace mapviz_plugins
       }
     }
 
+    if (node["use_latest_transforms"])
+    {
+      bool use_latest_transforms = node["use_latest_transforms"].as<bool>();
+      ui_.use_latest_transforms->setChecked(use_latest_transforms);
+      SetUseLatestTransforms(use_latest_transforms);
+    }
+
     if (node["position_tolerance"])
     {
       double position_tolerance;
@@ -241,6 +250,8 @@ namespace mapviz_plugins
 
     std::string draw_style = ui_.drawstyle->currentText().toStdString();
     emitter << YAML::Key << "draw_style" << YAML::Value << draw_style;
+
+    emitter << YAML::Key << "use_latest_transforms" << YAML::Value << ui_.use_latest_transforms->isChecked();
 
     emitter << YAML::Key << "position_tolerance" <<
                YAML::Value << positionTolerance();

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -81,6 +81,8 @@ namespace mapviz_plugins
                      SLOT(SetDrawStyle(QString)));
     QObject::connect(ui_.static_arrow_sizes, SIGNAL(clicked(bool)),
                      this, SLOT(SetStaticArrowSizes(bool)));
+    QObject::connect(ui_.use_latest_transforms, SIGNAL(clicked(bool)),
+                     this, SLOT(SetUseLatestTransforms(bool)));
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     QObject::connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
@@ -150,6 +152,11 @@ namespace mapviz_plugins
     StampedPoint stamped_point;
     stamped_point.stamp = odometry->header.stamp;
     stamped_point.source_frame = odometry->header.frame_id;
+
+    if (!points().empty() && points().back().source_frame != stamped_point.source_frame)
+    {
+      single_frame_ = false;
+    }
 
     stamped_point.point = tf::Point(odometry->pose.pose.position.x,
                                     odometry->pose.pose.position.y,
@@ -371,6 +378,13 @@ namespace mapviz_plugins
       SetArrowSize(arrow_size);
     }
 
+    if (node["use_latest_transforms"])
+    {
+      bool use_latest_transforms = node["use_latest_transforms"].as<bool>();
+      ui_.use_latest_transforms->setChecked(use_latest_transforms);
+      SetUseLatestTransforms(use_latest_transforms);
+    }
+
     if (node["show_timestamps"])
     {
       ui_.show_timestamps->setValue(node["show_timestamps"].as<int>());
@@ -408,6 +422,8 @@ namespace mapviz_plugins
     emitter << YAML::Key << "static_arrow_sizes" << YAML::Value << ui_.static_arrow_sizes->isChecked();
 
     emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
+
+    emitter << YAML::Key << "use_latest_transforms" << YAML::Value << ui_.use_latest_transforms->isChecked();
 
     emitter << YAML::Key << "show_timestamps" << YAML::Value << ui_.show_timestamps->value();
   }

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -690,8 +690,6 @@ namespace mapviz_plugins
     {
       QMutexLocker locker(&scan_mutex_);
 
-      bool was_using_latest_transforms = use_latest_transforms_;
-      use_latest_transforms_ = false;
       for (Scan& scan: scans_)
       {
         if (!scan.transformed)
@@ -717,7 +715,6 @@ namespace mapviz_plugins
           }
         }
       }
-      use_latest_transforms_ = was_using_latest_transforms;
     }
     // Z color is based on transformed color, so it is dependent on the
     // transform

--- a/mapviz_plugins/src/pose_plugin.cpp
+++ b/mapviz_plugins/src/pose_plugin.cpp
@@ -82,6 +82,8 @@ namespace mapviz_plugins
                      SLOT(SetDrawStyle(QString)));
     QObject::connect(ui_.static_arrow_sizes, SIGNAL(clicked(bool)),
                      this, SLOT(SetStaticArrowSizes(bool)));
+    QObject::connect(ui_.use_latest_transforms, SIGNAL(clicked(bool)),
+                     this, SLOT(SetUseLatestTransforms(bool)));
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     QObject::connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
@@ -141,6 +143,11 @@ namespace mapviz_plugins
     StampedPoint stamped_point;
     stamped_point.stamp = pose->header.stamp;
     stamped_point.source_frame = pose->header.frame_id;
+
+    if (!points().empty() && points().back().source_frame != stamped_point.source_frame)
+    {
+      single_frame_ = false;
+    }
 
     stamped_point.point = tf::Point(pose->pose.position.x,
                                     pose->pose.position.y,
@@ -271,6 +278,13 @@ namespace mapviz_plugins
       SetArrowSize(arrow_size);
     }
 
+    if (node["use_latest_transforms"])
+    {
+      bool use_latest_transforms = node["use_latest_transforms"].as<bool>();
+      ui_.use_latest_transforms->setChecked(use_latest_transforms);
+      SetUseLatestTransforms(use_latest_transforms);
+    }
+
     TopicEdited();
   }
 
@@ -296,5 +310,7 @@ namespace mapviz_plugins
     emitter << YAML::Key << "static_arrow_sizes" << YAML::Value << ui_.static_arrow_sizes->isChecked();
 
     emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
+
+    emitter << YAML::Key << "use_latest_transforms" << YAML::Value << ui_.use_latest_transforms->isChecked();
   }
 }

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -77,11 +77,17 @@ namespace mapviz_plugins
                      SLOT(SetDrawStyle(QString)));
     QObject::connect(ui_.static_arrow_sizes, SIGNAL(clicked(bool)),
                      this, SLOT(SetStaticArrowSizes(bool)));
+    QObject::connect(ui_.use_latest_transforms, SIGNAL(clicked(bool)),
+                     this, SLOT(SetUseLatestTransforms(bool)));
     QObject::connect(ui_.arrow_size, SIGNAL(valueChanged(int)),
                      this, SLOT(SetArrowSize(int)));
     QObject::connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
                      SLOT(SetColor(const QColor&)));
     QObject::connect(ui_.buttonResetBuffer, SIGNAL(pressed()), this,
+                     SLOT(ClearPoints()));
+    QObject::connect(this,
+                     SIGNAL(TargetFrameChanged(const std::string&)),
+                     this,
                      SLOT(ClearPoints()));
   }
 
@@ -105,6 +111,8 @@ namespace mapviz_plugins
     PrintWarning("Waiting for transform.");
 
     ROS_INFO("Setting target frame to to %s", source_frame_.c_str());
+
+    ClearPoints();
 
     initialized_ = true;
   }
@@ -236,6 +244,13 @@ namespace mapviz_plugins
       SetArrowSize(arrow_size);
     }
 
+    if (node["use_latest_transforms"])
+    {
+      bool use_latest_transforms = node["use_latest_transforms"].as<bool>();
+      ui_.use_latest_transforms->setChecked(use_latest_transforms);
+      SetUseLatestTransforms(use_latest_transforms);
+    }
+
     FrameEdited();
   }
 
@@ -258,5 +273,7 @@ namespace mapviz_plugins
     emitter << YAML::Key << "static_arrow_sizes" << YAML::Value << ui_.static_arrow_sizes->isChecked();
 
     emitter << YAML::Key << "arrow_size" << YAML::Value << ui_.arrow_size->value();
+
+    emitter << YAML::Key << "use_latest_transforms" << YAML::Value << ui_.use_latest_transforms->isChecked();
   }
 }

--- a/mapviz_plugins/ui/gps_config.ui
+++ b/mapviz_plugins/ui/gps_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>222</height>
+    <height>319</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -178,7 +178,7 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -191,7 +191,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="positiontolerance">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -210,7 +210,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -223,7 +223,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QSpinBox" name="buffersize">
@@ -250,21 +250,21 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Show Laps</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <widget class="QCheckBox" name="show_laps">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -277,7 +277,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -296,7 +296,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="10" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -308,6 +308,25 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Use Latest Transforms:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="use_latest_transforms">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/mapviz_plugins/ui/navsat_config.ui
+++ b/mapviz_plugins/ui/navsat_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>159</height>
+    <height>186</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,22 +17,13 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>2</number>
-   </property>
-   <property name="topMargin">
-    <number>2</number>
-   </property>
-   <property name="rightMargin">
-    <number>2</number>
-   </property>
-   <property name="bottomMargin">
-    <number>2</number>
-   </property>
    <property name="verticalSpacing">
     <number>4</number>
    </property>
-   <item row="6" column="0">
+   <property name="margin">
+    <number>2</number>
+   </property>
+   <item row="7" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -45,7 +36,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="2">
+   <item row="8" column="1" colspan="2">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -64,7 +55,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -77,7 +68,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="QSpinBox" name="buffersize">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
@@ -100,7 +91,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
+   <item row="7" column="2">
     <widget class="QPushButton" name="buttonResetBuffer">
      <property name="maximumSize">
       <size>
@@ -135,7 +126,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="positiontolerance">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -222,7 +213,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -248,7 +239,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -260,6 +251,25 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="use_latest_transforms">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Use Latest Transforms:</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/mapviz_plugins/ui/odometry_config.ui
+++ b/mapviz_plugins/ui/odometry_config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>286</width>
-    <height>312</height>
+    <width>287</width>
+    <height>428</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,33 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnminimumwidth="0,1,0">
-   <item row="9" column="0">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Static Arrow Sizes:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
     <widget class="QLabel" name="label_10">
      <property name="font">
       <font>
@@ -43,14 +69,14 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QCheckBox" name="show_covariance">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="QCheckBox" name="show_laps">
      <property name="text">
       <string/>
@@ -67,7 +93,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="9" column="1">
     <widget class="QDoubleSpinBox" name="positiontolerance">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -86,7 +112,7 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
+   <item row="12" column="1">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -124,7 +150,7 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="12" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -159,7 +185,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -172,7 +198,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="10" column="1">
     <widget class="QSpinBox" name="buffersize">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
@@ -182,7 +208,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="2">
+   <item row="10" column="2">
     <widget class="QPushButton" name="buttonResetBuffer">
      <property name="maximumSize">
       <size>
@@ -195,7 +221,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="label_5">
      <property name="font">
       <font>
@@ -252,7 +278,7 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="1">
+   <item row="14" column="1">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -265,7 +291,7 @@
      </property>
     </spacer>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_8">
      <property name="font">
       <font>
@@ -277,33 +303,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Color:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Static Arrow Sizes:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -316,7 +316,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="11" column="1">
     <widget class="QDoubleSpinBox" name="show_timestamps">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -368,7 +368,7 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_11">
      <property name="font">
       <font>
@@ -381,8 +381,27 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QCheckBox" name="show_all_covariances">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Use Latest Transforms:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QCheckBox" name="use_latest_transforms">
      <property name="text">
       <string/>
      </property>

--- a/mapviz_plugins/ui/pose_config.ui
+++ b/mapviz_plugins/ui/pose_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>222</height>
+    <height>354</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -178,7 +178,7 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -191,7 +191,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="positiontolerance">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -210,7 +210,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -223,7 +223,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QSpinBox" name="buffersize">
@@ -250,21 +250,26 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="label_5">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
      <property name="text">
-      <string>Show Laps</string>
+      <string>Show Laps:</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <widget class="QCheckBox" name="show_laps">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -277,7 +282,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="10" column="1">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -296,7 +301,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="11" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -308,6 +313,25 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Use Latest Transforms:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="use_latest_transforms">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/mapviz_plugins/ui/tf_frame_config.ui
+++ b/mapviz_plugins/ui/tf_frame_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>383</width>
-    <height>197</height>
+    <height>284</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,7 +30,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QDoubleSpinBox" name="positiontolerance">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -134,7 +134,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="6" column="2">
     <widget class="QPushButton" name="buttonResetBuffer">
      <property name="maximumSize">
       <size>
@@ -147,7 +147,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -160,7 +160,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -173,7 +173,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QSpinBox" name="buffersize">
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
@@ -183,7 +183,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -196,7 +196,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="QLabel" name="status">
      <property name="font">
       <font>
@@ -278,7 +278,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -290,6 +290,25 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="4" column="1">
+    <widget class="QCheckBox" name="use_latest_transforms">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Use Latest Transforms:</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
The `use_latest_transforms`  checkbox doesn't appear to work as intended since https://github.com/swri-robotics/mapviz/commit/bc5f5c5a9060357259528f22e71ec711df4d95e7.

It was originally intended to allow drawing the position history of a bot in the frame of the position topic, but rigidly transformed using the latest transform between the position topic frame and the fixed from of mapviz.   This makes it somewhat intuitive to see the divergence of different localization sources such as a relative state estimate and an absolute state estimate.

As it works now, like in rviz, the positions are converted to the fixed frame at the time they are received using the stamp of the position.  This results in eliminating the divergence of the position histories from the rendering, which is not very helpful.

This MR refactors the `use_latest_transforms` parameter to be per-plugin instead of a global setting.  The global setting was problematic because it only applied to position history plugins like Odometry, Tf, Pose, etc.   It also restores honoring that option to the position history plugins.