### PR TITLE
Fix launch files in ROS 2 Foxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ cmake-build-debug/
 .vscode/
 Gemfile.lock
 _site/
+venv/
+__pycache__/

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -201,7 +201,6 @@ install(TARGETS ${PROJECT_NAME} rqt_${PROJECT_NAME}
 
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
-  FILES_MATCHING PATTERN ".py" PATTERN ".launch"
 )
 
 install(FILES plugin.xml

--- a/mapviz/launch/mapviz.launch.py
+++ b/mapviz/launch/mapviz.launch.py
@@ -3,21 +3,22 @@ import launch.actions
 import launch.substitutions
 import launch_ros.actions
 
+
 def generate_launch_description():
     return launch.LaunchDescription([
         launch_ros.actions.Node(
             package="mapviz",
-            node_executable="mapviz",
-            node_name="mapviz",
+            executable="mapviz",
+            name="mapviz",
         ),
         launch_ros.actions.Node(
             package="swri_transform_util",
-            node_executable="initialize_origin.py",
-            node_name="initialize_origin",
+            executable="initialize_origin.py",
+            name="initialize_origin",
             parameters=[
                 {"name": "local_xy_frame", "value": "map"},
                 {"name": "local_xy_origin", "value": "swri"},
-                {"name": "local_xy_origins", "value": [
+                {"name": "local_xy_origins", "value": """[
                     {"name": "swri",
                         "latitude": 29.45196669,
                         "longitude": -98.61370577,
@@ -28,13 +29,13 @@ def generate_launch_description():
                         "longitude": -98.629367,
                         "altitude": 200.0,
                         "heading": 0.0}
-                ]}
+                ]"""}
             ]
         ),
         launch_ros.actions.Node(
-            package="tf2",
-            node_executable="static_transform_publisher",
-            node_name="swri_transform",
-            arguments="0 0 0 0 0 0 /map /origin 100"
+            package="tf2_ros",
+            executable="static_transform_publisher",
+            name="swri_transform",
+            arguments=["0", "0", "0", "0", "0", "0", "map", "origin"]
         )
     ])

--- a/mapviz/launch/mapviz.launch.xml
+++ b/mapviz/launch/mapviz.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <!-- Note that the XML-based launch format is only supported in ROS Eloquent and newer. -->
 
   <node pkg="mapviz" exec="mapviz" name="mapviz"/>
 

--- a/mapviz/launch/mapviz.launch.xml
+++ b/mapviz/launch/mapviz.launch.xml
@@ -1,8 +1,8 @@
 <launch>
 
-  <node pkg="mapviz" exec="mapviz" name="mapviz"></node>
+  <node pkg="mapviz" exec="mapviz" name="mapviz"/>
 
-  <node pkg="swri_transform_util" exec="initialize_origin.py" name="initialize_origin" >
+  <node pkg="swri_transform_util" exec="initialize_origin.py" name="initialize_origin">
     <param name="local_xy_frame" value="map"/>
     <param name="local_xy_origin" value="swri"/>
     <param name="local_xy_origins" value="
@@ -19,8 +19,8 @@
          heading: 0.0}]"/>
   </node>
 
-  <node pkg="tf" type="static_transform_publisher" name="swri_transform" args="0 0 0 0 0 0 /map /origin 100"  />
-
-
-
+  <node pkg="tf2_ros"
+        exec="static_transform_publisher"
+        name="swri_transform"
+        args="0 0 0 0 0 0 map origin"/>
 </launch>

--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -41,7 +41,7 @@
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
 
-  <exec_depend>launch_xml</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != dashing">launch_xml</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>
 
   <export>

--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -41,6 +41,7 @@
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
 
+  <exec_depend>launch_xml</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>
 
   <export>


### PR DESCRIPTION
There were a bunch of issues in both the XML and Python example launch files that prevented them from working in ROS 2 Foxy.  This fixes them.

Fixes #712

Distribution Statement A; OPSEC #2893

Signed-off-by: P. J. Reed <preed@swri.org>