### PR TITLE
736 add a duplicate feature for plugins

### DIFF
--- a/mapviz/include/mapviz/config_item.h
+++ b/mapviz/include/mapviz/config_item.h
@@ -33,6 +33,7 @@
 // C++ standard libraries
 #include <string>
 #include <vector>
+#include <iostream>
 
 // QT libraries
 #include <QWidget>
@@ -66,11 +67,13 @@ namespace mapviz
   Q_SIGNALS:
     void UpdateSizeHint();
     void ToggledDraw(QListWidgetItem* plugin, bool visible);
+    void DuplicateRequest(QListWidgetItem* plugin);
     void RemoveRequest(QListWidgetItem* plugin);
 
   public Q_SLOTS:
     void Hide();
     void EditName();
+    void Duplicate();
     void Remove();
     void ToggleDraw(bool toggled);
 
@@ -82,6 +85,7 @@ namespace mapviz
     QString name_;
     QString type_;
     QAction* edit_name_action_;
+    QAction* duplicate_item_action_;
     QAction* remove_item_action_;
     bool visible_;
   };

--- a/mapviz/include/mapviz/config_item.h
+++ b/mapviz/include/mapviz/config_item.h
@@ -33,7 +33,6 @@
 // C++ standard libraries
 #include <string>
 #include <vector>
-#include <iostream>
 
 // QT libraries
 #include <QWidget>

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -51,7 +51,6 @@
 #include <QWidget>
 #include <QStringList>
 #include <QMainWindow>
-#include <QShortcut>
 
 // ROS libraries
 #include <ros/ros.h>

--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -51,6 +51,7 @@
 #include <QWidget>
 #include <QStringList>
 #include <QMainWindow>
+#include <QShortcut>
 
 // ROS libraries
 #include <ros/ros.h>
@@ -92,6 +93,8 @@ namespace mapviz
     void SelectNewDisplay();
     void RemoveDisplay();
     void RemoveDisplay(QListWidgetItem* item);
+    void DuplicateDisplay();
+    void DuplicateDisplay(QListWidgetItem *item);
     void ReorderDisplays();
     void FixedFrameSelected(const QString& text);
     void TargetFrameSelected(const QString& text);

--- a/mapviz/src/config_item.cpp
+++ b/mapviz/src/config_item.cpp
@@ -43,7 +43,6 @@ namespace mapviz
 
     edit_name_action_   = new  QAction("Edit Name", this);
     duplicate_item_action_ = new QAction("Duplicate", this);
-    duplicate_item_action_->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_D));
     remove_item_action_ = new  QAction("Remove", this);
     remove_item_action_->setIcon(QIcon(":/images/remove-icon-th.png"));
 

--- a/mapviz/src/config_item.cpp
+++ b/mapviz/src/config_item.cpp
@@ -42,10 +42,13 @@ namespace mapviz
     ui_.setupUi(this);
 
     edit_name_action_   = new  QAction("Edit Name", this);
+    duplicate_item_action_ = new QAction("Duplicate", this);
+    duplicate_item_action_->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_D));
     remove_item_action_ = new  QAction("Remove", this);
     remove_item_action_->setIcon(QIcon(":/images/remove-icon-th.png"));
 
     connect(edit_name_action_, SIGNAL(triggered()), this, SLOT(EditName()));
+    connect(duplicate_item_action_, SIGNAL(triggered()), this, SLOT(Duplicate()));
     connect(remove_item_action_, SIGNAL(triggered()), this, SLOT(Remove()));
   }
 
@@ -71,6 +74,7 @@ namespace mapviz
   {
     QMenu menu(this);
     menu.addAction(edit_name_action_);
+    menu.addAction(duplicate_item_action_);
     menu.addAction(remove_item_action_);
     menu.exec(event->globalPos());
   }
@@ -107,6 +111,11 @@ namespace mapviz
     {
       SetName(text);
     }
+  }
+
+  void ConfigItem::Duplicate()
+  {
+    Q_EMIT DuplicateRequest(item_);
   }
 
   void ConfigItem::Remove()

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -1531,9 +1531,9 @@ void Mapviz::DuplicateDisplay(QListWidgetItem* item)
   out << YAML::Key << "type" << YAML::Value << target_plugin->Type();
   out << YAML::Key << "name" << YAML::Value << target_config_item->Name().toStdString();
   out << YAML::Key << "config" << YAML::Value;
-  out << YAML::BeginMap; 
+  out << YAML::BeginMap;
   out << YAML::Key << "visible" << YAML::Value << target_plugin->Visible();
-  out << YAML::Key << "collapsed" << YAML::Value << target_config_item->Collapsed(); 
+  out << YAML::Key << "collapsed" << YAML::Value << target_config_item->Collapsed();
   target_plugin->SaveConfig(out, "");
   out << YAML::EndMap;
   out << YAML::EndMap;
@@ -1551,9 +1551,9 @@ void Mapviz::DuplicateDisplay(QListWidgetItem* item)
   try
   {
     MapvizPluginPtr duplicate_plugin = CreateNewDisplay(
-        target_config_item->Name().toStdString(), 
-        target_plugin->Type(), 
-        target_plugin->Visible(), 
+        target_config_item->Name().toStdString(),
+        target_plugin->Type(),
+        target_plugin->Visible(),
         target_config_item->Collapsed());
     duplicate_plugin->LoadConfig(temp_config_node, "");
     duplicate_plugin->DrawIcon();

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -201,10 +201,6 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
 
   ui_.bg_color->setColor(background_);
   canvas_->SetBackground(background_);
-
-  // Keyboard shortcuts for the main window
-  QShortcut *duplicate_display_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_D), this);
-  connect(duplicate_display_shortcut, SIGNAL(activated()), this, SLOT(DuplicateDisplay()));
 }
 
 Mapviz::~Mapviz()


### PR DESCRIPTION
Closes #736. Added a "duplicate" feature to quickly create a deep copy of a plugin including all its configurations. Current methods for creating a duplicate:

- Right click on the plugin to duplicate and select the "duplicate" option in the drop down
- Select the plugin to duplicate and press the "Ctrl+d" hotkey


https://user-images.githubusercontent.com/33141599/120910447-b9126b80-c644-11eb-82f6-048480bb7eb5.mp4

