### PR TITLE
Update GPS subscrption to use sensor qos

### DIFF
--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -108,7 +108,7 @@ namespace mapviz_plugins
       {
         navsat_sub_ = node_->create_subscription<sensor_msgs::msg::NavSatFix>(
             topic_,
-            rclcpp::QoS(1),
+            rclcpp::SensorDataQoS(rclcpp::KeepLast(1)),
             std::bind(&NavSatPlugin::NavSatFixCallback, this, std::placeholders::_1));
 
         RCLCPP_INFO(node_->get_logger(), "Subscribing to %s", topic_.c_str());


### PR DESCRIPTION
All sensors are generally expected to use the sensor QoS. There is even a REP proposal to standardise it https://github.com/ros-infrastructure/rep/pull/212. Besides that one of the most commonly use packages for localization i.e. robot_localization also uses that [QoS](https://github.com/cra-ros-pkg/robot_localization/blob/5c9d411e3823859f240b7594de41cfe896327914/src/navsat_transform.cpp#L171), so it would make sensr for Mapviz to also support it.