### PR TITLE
Use python3 in mapviz_tile_loader shebang

### DIFF
--- a/multires_image/nodes/mapviz_tile_loader
+++ b/multires_image/nodes/mapviz_tile_loader
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #


### PR DESCRIPTION
ROS 2 uses Python 3 exclusively.

Should resolve "ambiguous python shebang" errors in RPM builds: https://build.ros2.org/view/Gbin_rhel_el864/job/Gbin_rhel_el864__multires_image__rhel_8_x86_64__binary/51/console