### PR TITLE
Avoid deprecated GLUT_LIBRARY variable

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -137,7 +137,7 @@ add_library(rqt_${PROJECT_NAME}
 target_link_libraries(rqt_${PROJECT_NAME}
   ${Qt_LIBRARIES}
   ${OpenGL_LIBRARY}
-  ${GLUT_LIBRARY}
+  ${GLUT_LIBRARIES}
   ${GLEW_LIBRARIES}
   ${OpenCV_LIBS}
   ${catkin_LIBRARIES}
@@ -167,7 +167,7 @@ target_link_libraries(${PROJECT_NAME}
   ${Qt_LIBRARIES}
   ${Boost_LIBRARIES}
   ${OpenGL_LIBRARY}
-  ${GLUT_LIBRARY}
+  ${GLUT_LIBRARIES}
   ${GLEW_LIBRARIES}
   ${GLU_LIBRARY}
   ${OpenCV_LIBRARIES}


### PR DESCRIPTION
`GLUT_LIBRARY` is deprecated, and, more importantly, is not normally set since CMake 3.22. This looks like a [CMake bug](https://gitlab.kitware.com/cmake/cmake/-/issues/23370), but it is good to not use deprecated things anyway.