### PR TITLE
Set RUNTIME_DEPS

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -207,6 +207,22 @@ install(FILES plugin.xml
   DESTINATION share/${PROJECT_NAME} 
 )
 
+set(RUNTIME_DEPS
+  cv_bridge
+  geometry_msgs
+  image_transport
+  mapviz_interfaces
+  marti_common_msgs
+  pluginlib
+  rclcpp
+  rqt_gui_cpp
+  std_srvs
+  swri_math_util
+  swri_transform_util
+  tf2
+  tf2_ros
+)
+
 ament_export_dependencies(${RUNTIME_DEPS}
   Qt5Concurrent
   Qt5Core

--- a/mapviz_plugins/CMakeLists.txt
+++ b/mapviz_plugins/CMakeLists.txt
@@ -228,6 +228,32 @@ install(TARGETS ${PROJECT_NAME}
 
 pluginlib_export_plugin_description_file(mapviz mapviz_plugins.xml)
 
+set(RUNTIME_DEPS
+  cv_bridge
+  gps_msgs
+  image_transport
+  map_msgs
+  mapviz
+  marti_common_msgs
+  marti_nav_msgs
+  marti_sensor_msgs
+  marti_visualization_msgs
+  nav_msgs
+  pluginlib
+  rclcpp
+  sensor_msgs
+  std_msgs
+  stereo_msgs
+  swri_image_util
+  swri_math_util
+  swri_route_util
+  swri_transform_util
+  tf2_geometry_msgs
+  tf2
+  tf2_ros
+  visualization_msgs
+)
+
 ament_export_dependencies(${RUNTIME_DEPS} Qt)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/multires_image/CMakeLists.txt
+++ b/multires_image/CMakeLists.txt
@@ -163,7 +163,26 @@ install(DIRECTORY launch
 
 pluginlib_export_plugin_description_file(mapviz mapviz_plugins.xml)
 
-ament_export_dependencies(${RUNTIME_DEPS} Qt)
+set(RUNTIME_DEPS
+  ament_cmake
+  Boost
+  cv_bridge
+  gps_msgs
+  mapviz
+  OpenCV
+  OpenGL
+  pluginlib
+  Qt5Core
+  Qt5Gui
+  Qt5OpenGL
+  Qt5Widgets
+  rclcpp
+  swri_math_util
+  swri_transform_util
+  tf2
+)
+
+ament_export_dependencies(${RUNTIME_DEPS})
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -129,6 +129,15 @@ install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_plugin
 
 pluginlib_export_plugin_description_file(mapviz mapviz_plugins.xml)
 
+set(RUNTIME_DEPS
+  mapviz
+  pluginlib
+  rclcpp
+  swri_math_util
+  swri_transform_util
+  tf2
+)
+
 ament_export_dependencies(${RUNTIME_DEPS}
   Qt5::Network
   Qt5::Core


### PR DESCRIPTION
I set RUNTIME_DEPS (in a few different packages) to include the ROS packages other than the ament ones. I might need to add others like OpenCV, too, but I wasn't 100% sure. For multires_image, I copied the lines from dashing-devel.

I'm setting this up to be merged into galactic-devel.