### PR TITLE
Fix Plan Route plugin in ROS2 Humble

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/plan_route_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/plan_route_plugin.h
@@ -112,7 +112,7 @@ class PlanRoutePlugin : public mapviz::MapvizPlugin
 
   std::string route_topic_;
 
-  rclcpp::Publisher<swri_route_util::Route>::SharedPtr route_pub_;
+  rclcpp::Publisher<marti_nav_msgs::msg::Route>::SharedPtr route_pub_;
   rclcpp::TimerBase::SharedPtr retry_timer_;
 
   bool failed_service_;

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -130,12 +130,12 @@ namespace mapviz_plugins
       {
         route_topic_ = ui_.topic->text().toStdString();
         route_pub_.reset();
-        route_pub_ = node_->create_publisher<swri_route_util::Route>(
+        route_pub_ = node_->create_publisher<marti_nav_msgs::msg::Route>(
           route_topic_,
           rclcpp::QoS(1));
       }
 
-      route_pub_->publish(*route_preview_);
+      route_pub_->publish(*route_preview_->toMsgPtr());
     }
   }
 


### PR DESCRIPTION
The Plan Route plugin was previously creating a publisher for the swri_route_util::Route class, which is not an actual ROS message but a wrapper around the marti_nav_msgs::Route message.  ROS2 Humble appears to have a compile-time check that prevents creating publishers for classes that are not ROS2 message definitions, so that will fail.

This changes the type of the publisher to marti_nav_msgs::Route and manually converts the message to that type before publishing it.

Signed-off-by: P. J. Reed <phillipreed@hatchbed.com>