### PR TITLE
Add ros_environment as Dependency

### DIFF
--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -18,6 +18,7 @@
 
   <depend>libqt5-core</depend>
   <build_depend>libqt5-opengl-dev</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>

--- a/mapviz_plugins/package.xml
+++ b/mapviz_plugins/package.xml
@@ -17,6 +17,7 @@
 
   <depend>libqt5-core</depend>
   <build_depend>libqt5-opengl-dev</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>cv_bridge</depend>


### PR DESCRIPTION
Adds ros_environment as a dependency so the build farm can correctly figure out the ROS_DISTRO variables.