### PR TITLE
Rolling Update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,12 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: foxy,  ROS_REPO: testing}
-          - {ROS_DISTRO: foxy,  ROS_REPO: main}
-          - {ROS_DISTRO: galactic,  ROS_REPO: testing}
-          - {ROS_DISTRO: galactic,  ROS_REPO: main}
+          - {ROS_DISTRO: humble,  ROS_REPO: testing}
+          - {ROS_DISTRO: humble,  ROS_REPO: main}
+          - {ROS_DISTRO: iron,    ROS_REPO: testing}
+          - {ROS_DISTRO: iron,    ROS_REPO: main}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing}
+          - {ROS_DISTRO: rolling, ROS_REPO: main}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -38,14 +38,7 @@ find_package(swri_transform_util REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-# tf2_geometry_msgs 0.12.1 broke API compatibility, so check which version
-# we need to use
 find_package(tf2_geometry_msgs REQUIRED)
-if("${tf2_geometry_msgs_VERSION}" VERSION_GREATER "0.12.0")
-  set(USE_NEW_TF2_TOMSG 1)
-else()
-  set(USE_NEW_TF2_TOMSG 0)
-endif()
 
 ### PkgConfig ###
 find_package(PkgConfig REQUIRED)
@@ -128,16 +121,8 @@ target_include_directories(rqt_${PROJECT_NAME}
     include
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
-target_compile_definitions(rqt_${PROJECT_NAME}
-  PRIVATE
-    USE_NEW_TF2_TOMSG=${USE_NEW_TF2_TOMSG}
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
-
-# Foxy uses TF2 .h files, not .hpp files
-if ("$ENV{ROS_DISTRO}" STRLESS_EQUAL "galactic")
-  target_compile_definitions(rqt_${PROJECT_NAME} PRIVATE "-DUSE_TF2_H_FILES")
-endif()
 
 target_link_libraries(rqt_${PROJECT_NAME}
   OpenGL::GL

--- a/mapviz/include/mapviz/map_canvas.h
+++ b/mapviz/include/mapviz/map_canvas.h
@@ -40,12 +40,8 @@
 // ROS libraries
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/transform_datatypes.h>
-#include <tf2_ros/transform_listener.h>
-#ifdef USE_TF2_H_FILES
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#endif
+#include <tf2_ros/transform_listener.h>
 
 #include <mapviz/mapviz_plugin.h>
 

--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -30,9 +30,7 @@
   <depend>mapviz_interfaces</depend>
   <depend>marti_common_msgs</depend>
   <depend>pluginlib</depend>
-  <!-- <depend>rosapi</depend> -->
   <depend>rclcpp</depend>
-  <!-- <depend>rqt</depend> -->
   <depend>rqt_gui_cpp</depend>
   <depend>rqt_gui</depend>
   <depend>std_srvs</depend>
@@ -43,7 +41,6 @@
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
 
-  <exec_depend condition="$ROS_DISTRO != dashing">launch_xml</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>
 
   <export>

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -73,18 +73,13 @@ geometry_msgs::msg::PointStamped make_point_stamped(double x, double y, double z
 
 /**
  * Convenience method for converting a tf2::Stamped<tf2::Transform> object into
- * the equivalent ROS message.  This has to be done differently between ROS Dashing
- * and Eloquent, so this wraps it up conveniently.
+ * the equivalent ROS message.
  * @param transform The source object
  * @return That tf as a ROS message
  */
 auto tf2_to_msg(const tf2::Stamped<tf2::Transform>& transform)
 {
-#if USE_NEW_TF2_TOMSG == 1
   return tf2::toMsg(transform);
-#else
-  return tf2::toMsg<tf2::Stamped<tf2::Transform>, geometry_msgs::msg::TransformStamped>(transform);
-#endif
 }
 
 MapCanvas::MapCanvas(QWidget* parent) :


### PR DESCRIPTION
Updates code for Rolling, and removes support for EOL distributions. Not currently auto-building in Rolling because not all of the dependencies have been released.