### PR TITLE
Fix bing tiles not rendering

### DIFF
--- a/tile_map/src/bing_source.cpp
+++ b/tile_map/src/bing_source.cpp
@@ -51,6 +51,7 @@ namespace tile_map
     network_manager_(this)
   {
     name_ = name;
+    is_ready_ = false;
     is_custom_ = false;
     max_zoom_ = 19;
     base_url_ = "https://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial?uriScheme=https&include=ImageryProviders&key={api_key}";


### PR DESCRIPTION
There's a race condition causing bing map tiles to not work properly. This issue is probably only noticed intermittently or in some workflows but not others.

If the transform from `wgs84` to `map` is ready before the bing server reply has been received, no bing tiles will be displayed. If you have mapviz open before starting up the ros service, you won't see this issue, but if you start mapviz (or change to the bing tile source after the transform is ready, you're unlikely to see any tiles displayed. You might get lucky if you're using launch files and mapviz gets the bing reply just in time before the transform is ready.