### PR TITLE
Plugin shortcuts

### DIFF
--- a/mapviz/include/mapviz/mapviz.hpp
+++ b/mapviz/include/mapviz/mapviz.hpp
@@ -44,6 +44,7 @@
 #include <QWidget>
 #include <QStringList>
 #include <QMainWindow>
+#include <QShortcut>
 
 #include <swri_transform_util/transform_manager.h>
 #include <mapviz_interfaces/srv/add_mapviz_display.hpp>  // Service

--- a/mapviz/include/mapviz/mapviz.hpp
+++ b/mapviz/include/mapviz/mapviz.hpp
@@ -99,6 +99,8 @@ public Q_SLOTS:
   void SelectNewDisplay();
   void RemoveDisplay();
   void RemoveDisplay(QListWidgetItem* item);
+  void RenameDisplay();
+  void RenameDisplay(QListWidgetItem* item);
   void ReorderDisplays();
   void FixedFrameSelected(const QString& text);
   void TargetFrameSelected(const QString& text);

--- a/mapviz/src/config_item.cpp
+++ b/mapviz/src/config_item.cpp
@@ -42,8 +42,10 @@ namespace mapviz
     ui_.setupUi(this);
 
     edit_name_action_   = new QAction("Edit Name", this);
+    edit_name_action_->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_R));
     remove_item_action_ = new QAction("Remove", this);
     remove_item_action_->setIcon(QIcon(":/images/remove-icon-th.png"));
+    remove_item_action_->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_X));
 
     connect(edit_name_action_, SIGNAL(triggered()), this, SLOT(EditName()));
     connect(remove_item_action_, SIGNAL(triggered()), this, SLOT(Remove()));

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -233,12 +233,12 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
   canvas_->SetBackground(background_);
 
   // Keyboard shortcuts for the main window
-  /* QShortcut * edit_display_name_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_R), this); */
-  /* connect(edit_display_name_shortcut, SIGNAL(activated()), this, SLOT()); */
   QShortcut * remove_display_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_X), this);
   connect(remove_display_shortcut, SIGNAL(activated()), this, SLOT(RemoveDisplay()));
   QShortcut * rename_display_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_R), this);
   connect(rename_display_shortcut, SIGNAL(activated()), this, SLOT(RenameDisplay()));
+  QShortcut * add_display_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_N), this);
+  connect(add_display_shortcut, SIGNAL(activated()), this, SLOT(SelectNewDisplay()));
 }
 
 Mapviz::~Mapviz()

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -237,6 +237,8 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
   /* connect(edit_display_name_shortcut, SIGNAL(activated()), this, SLOT()); */
   QShortcut * remove_display_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_X), this);
   connect(remove_display_shortcut, SIGNAL(activated()), this, SLOT(RemoveDisplay()));
+  QShortcut * rename_display_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_R), this);
+  connect(rename_display_shortcut, SIGNAL(activated()), this, SLOT(RenameDisplay()));
 }
 
 Mapviz::~Mapviz()
@@ -1452,6 +1454,20 @@ void Mapviz::RemoveDisplay(QListWidgetItem* item)
     plugins_.erase(item);
 
     delete item;
+  }
+}
+
+void Mapviz::RenameDisplay()
+{
+  QListWidgetItem* item = ui_.configs->currentItem();
+  RenameDisplay(item);
+}
+
+void Mapviz::RenameDisplay(QListWidgetItem* item)
+{
+  if (item) {
+    ConfigItem* config_item = static_cast<ConfigItem*>(ui_.configs->itemWidget(item));
+    config_item->EditName();
   }
 }
 

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -231,6 +231,12 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
 
   ui_.bg_color->setColor(background_);
   canvas_->SetBackground(background_);
+
+  // Keyboard shortcuts for the main window
+  /* QShortcut * edit_display_name_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_R), this); */
+  /* connect(edit_display_name_shortcut, SIGNAL(activated()), this, SLOT()); */
+  QShortcut * remove_display_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_X), this);
+  connect(remove_display_shortcut, SIGNAL(activated()), this, SLOT(RemoveDisplay()));
 }
 
 Mapviz::~Mapviz()

--- a/mapviz/ui/mapviz.ui
+++ b/mapviz/ui/mapviz.ui
@@ -311,7 +311,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Add a new display</string>
+           <string>Add a new display (Ctrl + N)</string>
           </property>
           <property name="text">
            <string>Add</string>
@@ -327,7 +327,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Remove the selected display</string>
+           <string>Remove the selected display (Ctrl + X)</string>
           </property>
           <property name="text">
            <string>Remove</string>


### PR DESCRIPTION
Implementation for #803 in the ROS 2 version. No reason this couldn't be backported to also work in ROS 1.

Added:
- Ctrl + R to rename select plugin
- Ctrl + N to add a new plugin
- Ctrl + X to remove the select plugin