### PR TITLE
Fix topic lists

### DIFF
--- a/mapviz_plugins/src/topic_select.cpp
+++ b/mapviz_plugins/src/topic_select.cpp
@@ -335,17 +335,19 @@ std::vector<std::string> SelectTopicDialog::filterTopics(
 void SelectTopicDialog::updateDisplayedTopics()
 {
   std::vector<std::string> next_displayed_topics = filterTopics(known_topics_);
-
   // It's a lot more work to keep track of the additions/removals like
   // this compared to resetting the QListWidget's items each time, but
   // it allows Qt to properly track the selection and current items
   // across updates, which results in much less frustration for the user.
 
+  displayed_topics_.clear();
   std::set<std::string> prev_names;
-  for (const auto & displayed_topic : displayed_topics_) {
-    prev_names.insert(displayed_topic);
-  }
 
+  for (int i = 0; i < ui_->topicList->count(); i++)
+  {
+    prev_names.insert(ui_->topicList->item(i)->text().toStdString());
+    displayed_topics_.push_back(ui_->topicList->item(i)->text().toStdString());
+  }
   std::set<std::string> next_names;
   for (const auto & next_displayed_topic : next_displayed_topics) {
     next_names.insert(next_displayed_topic);
@@ -375,6 +377,7 @@ void SelectTopicDialog::updateDisplayedTopics()
   }
 
   // Now we can add the new items.
+
   for (size_t i = 0; i < next_displayed_topics.size(); i++) {
     if (added_names.count(next_displayed_topics[i]) == 0) {
       continue;

--- a/mapviz_plugins/src/topic_select.cpp
+++ b/mapviz_plugins/src/topic_select.cpp
@@ -335,6 +335,7 @@ std::vector<std::string> SelectTopicDialog::filterTopics(
 void SelectTopicDialog::updateDisplayedTopics()
 {
   std::vector<std::string> next_displayed_topics = filterTopics(known_topics_);
+
   // It's a lot more work to keep track of the additions/removals like
   // this compared to resetting the QListWidget's items each time, but
   // it allows Qt to properly track the selection and current items
@@ -377,7 +378,6 @@ void SelectTopicDialog::updateDisplayedTopics()
   }
 
   // Now we can add the new items.
-
   for (size_t i = 0; i < next_displayed_topics.size(); i++) {
     if (added_names.count(next_displayed_topics[i]) == 0) {
       continue;


### PR DESCRIPTION
Not 100% sure why, but I was testing that last change I made and noticed sometimes the displayed topic list and the actual topics lost sync. So you it would display names that when clicked would result in different topics being selected. The names were also incorrect for the topics. This change just allows the update logic to check the actual displayed names and use those for the basis of the update instead of the purely internally tracked logic it was using previously.