### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -124,7 +124,7 @@ target_include_directories(rqt_${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-target_link_libraries(rqt_${PROJECT_NAME}
+target_link_libraries(rqt_${PROJECT_NAME} PUBLIC
   OpenGL::GL
   ${GLUT_LIBRARIES}
   GLEW::GLEW
@@ -139,22 +139,20 @@ target_link_libraries(rqt_${PROJECT_NAME}
   Qt5::Gui
   Qt5::OpenGL
   Qt5::Widgets
-  PUBLIC
-  ament_cmake
-  cv_bridge
-  geometry_msgs
-  image_transport
-  mapviz_interfaces
-  marti_common_msgs
-  pluginlib
-  rclcpp
-  rqt_gui_cpp
-  std_srvs
-  swri_math_util
-  swri_transform_util
-  tf2
-  tf2_geometry_msgs
-  tf2_ros
+  ${geometry_msgs_TARGETS}
+  ${mapviz_interfaces_TARGETS}
+  ${marti_common_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+  cv_bridge::cv_bridge
+  image_transport::image_transport
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rqt_gui_cpp::rqt_gui_cpp
+  swri_math_util::swri_math_util
+  swri_transform_util::swri_transform_util
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
 )
 set_target_properties(rqt_${PROJECT_NAME} PROPERTIES
   COMPILE_FLAGS "-D__STDC_FORMAT_MACROS"
@@ -164,13 +162,12 @@ set_target_properties(rqt_${PROJECT_NAME} PROPERTIES
 add_executable(${PROJECT_NAME}
   src/${PROJECT_NAME}_main.cpp
 )
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   rqt_${PROJECT_NAME}
   ${Boost_LIBRARIES}
   ${GLU_LIBRARY}
-  PUBLIC
-  swri_math_util
-  swri_transform_util
+  swri_math_util::swri_math_util
+  swri_transform_util::swri_transform_util
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES
   COMPILE_FLAGS "-D__STDC_FORMAT_MACROS"

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -140,7 +140,7 @@ target_link_libraries(rqt_${PROJECT_NAME}
   Qt5::OpenGL
   Qt5::Widgets
 )
-ament_target_dependencies(rqt_${PROJECT_NAME}
+target_link_libraries(rqt_${PROJECT_NAME} PUBLIC
   ament_cmake
   cv_bridge
   geometry_msgs
@@ -170,7 +170,7 @@ target_link_libraries(${PROJECT_NAME}
   ${Boost_LIBRARIES}
   ${GLU_LIBRARY}
 )
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   swri_math_util
   swri_transform_util
 )

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -139,8 +139,7 @@ target_link_libraries(rqt_${PROJECT_NAME}
   Qt5::Gui
   Qt5::OpenGL
   Qt5::Widgets
-)
-target_link_libraries(rqt_${PROJECT_NAME} PUBLIC
+  PUBLIC
   ament_cmake
   cv_bridge
   geometry_msgs
@@ -169,8 +168,7 @@ target_link_libraries(${PROJECT_NAME}
   rqt_${PROJECT_NAME}
   ${Boost_LIBRARIES}
   ${GLU_LIBRARY}
-)
-target_link_libraries(${PROJECT_NAME} PUBLIC
+  PUBLIC
   swri_math_util
   swri_transform_util
 )

--- a/mapviz_plugins/CMakeLists.txt
+++ b/mapviz_plugins/CMakeLists.txt
@@ -179,33 +179,7 @@ if ("$ENV{ROS_DISTRO}" STRLESS "iron")
   target_compile_definitions(${PROJECT_NAME} PRIVATE "-DUSE_CVBRIDGE_H_FILES")
 endif()
 
-target_link_libraries(${PROJECT_NAME} PUBLIC
-    ament_cmake
-    ament_index_cpp
-    cv_bridge
-    gps_msgs
-    image_transport
-    map_msgs
-    mapviz
-    marti_common_msgs
-    marti_nav_msgs
-    marti_sensor_msgs
-    marti_visualization_msgs
-    # move_base_msgs
-    nav_msgs
-    pluginlib
-    rclcpp
-    sensor_msgs
-    std_msgs
-    stereo_msgs
-    swri_image_util
-    swri_math_util
-    swri_route_util
-    swri_transform_util
-    tf2
-    tf2_geometry_msgs
-    tf2_ros
-    visualization_msgs
+target_link_libraries(${PROJECT_NAME}
     Qt5::Core
     Qt5::Gui
     Qt5::OpenGL
@@ -215,6 +189,27 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
     opencv_core
     opencv_imgproc
     opencv_highgui
+PUBLIC
+    ${gps_msgs_TARGETS}
+    ${map_msgs_TARGETS}
+    ${marti_common_msgs_TARGETS}
+    ${marti_nav_msgs_TARGETS}
+    ${marti_sensor_msgs_TARGETS}
+    ${marti_visualization_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${stereo_msgs_TARGETS}
+    ${visualization_msgs_TARGETS}
+    ament_index_cpp::ament_index_cpp
+    cv_bridge::cv_bridge
+    image_transport::image_transport
+    pluginlib::pluginlib
+    rclcpp::rclcpp
+    sensor_msgs::sensor_msgs_library
+    tf2::tf2
+    tf2_geometry_msgs::tf2_geometry_msgs
+    tf2_ros::tf2_ros
 )
 
 ### Install the plugins ###

--- a/mapviz_plugins/CMakeLists.txt
+++ b/mapviz_plugins/CMakeLists.txt
@@ -206,8 +206,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
     tf2_geometry_msgs
     tf2_ros
     visualization_msgs
-)
-target_link_libraries(${PROJECT_NAME}
     Qt5::Core
     Qt5::Gui
     Qt5::OpenGL

--- a/mapviz_plugins/CMakeLists.txt
+++ b/mapviz_plugins/CMakeLists.txt
@@ -179,7 +179,7 @@ if ("$ENV{ROS_DISTRO}" STRLESS "iron")
   target_compile_definitions(${PROJECT_NAME} PRIVATE "-DUSE_CVBRIDGE_H_FILES")
 endif()
 
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
     ament_cmake
     ament_index_cpp
     cv_bridge

--- a/multires_image/CMakeLists.txt
+++ b/multires_image/CMakeLists.txt
@@ -72,8 +72,7 @@ target_link_libraries(${PROJECT_NAME}
   Qt5::Gui
   Qt5::OpenGL
   Qt5::Widgets
-)
-target_link_libraries(${PROJECT_NAME} PUBLIC
+  PUBLIC
   ament_cmake
   cv_bridge
   gps_msgs
@@ -115,8 +114,7 @@ target_link_libraries(multires_view_node
   multires_widget
   Boost::filesystem
   Boost::thread
-)
-target_link_libraries(multires_view_node PUBLIC
+  PUBLIC
   ament_cmake
   rclcpp
   swri_transform_util

--- a/multires_image/CMakeLists.txt
+++ b/multires_image/CMakeLists.txt
@@ -73,15 +73,15 @@ target_link_libraries(${PROJECT_NAME}
   Qt5::OpenGL
   Qt5::Widgets
 )
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   ament_cmake
   cv_bridge
   gps_msgs
   mapviz
   pluginlib
-  rclcpp 
+  rclcpp
   tf2
-  swri_transform_util 
+  swri_transform_util
   swri_math_util
 )
 
@@ -116,7 +116,7 @@ target_link_libraries(multires_view_node
   Boost::filesystem
   Boost::thread
 )
-ament_target_dependencies(multires_view_node
+target_link_libraries(multires_view_node PUBLIC
   ament_cmake
   rclcpp
   swri_transform_util

--- a/multires_image/CMakeLists.txt
+++ b/multires_image/CMakeLists.txt
@@ -72,16 +72,12 @@ target_link_libraries(${PROJECT_NAME}
   Qt5::Gui
   Qt5::OpenGL
   Qt5::Widgets
-  PUBLIC
-  ament_cmake
-  cv_bridge
-  gps_msgs
-  mapviz
-  pluginlib
-  rclcpp
-  tf2
-  swri_transform_util
-  swri_math_util
+PUBLIC
+  ${gps_msgs_TARGETS}
+  cv_bridge::cv_bridge
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  tf2::tf2
 )
 
 # Build libmultires_widget
@@ -114,10 +110,8 @@ target_link_libraries(multires_view_node
   multires_widget
   Boost::filesystem
   Boost::thread
-  PUBLIC
-  ament_cmake
-  rclcpp
-  swri_transform_util
+PUBLIC
+  rclcpp::rclcpp
 )
 
 # Build mapviz plugin

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -84,14 +84,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM
     GLEW::GLEW
     ${JSONCPP_INCLUDE_DIRS}
     ${YamlCpp_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} PUBLIC
-  ament_cmake
-  mapviz
-  pluginlib
-  rclcpp
-  swri_math_util
-  swri_transform_util
-  tf2
+target_link_libraries(${PROJECT_NAME}
   ${GLU_LIBRARY}
   ${JSONCPP_LIBRARIES}
   ${YamlCpp_LIBRARIES}
@@ -100,6 +93,10 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   Qt5::Gui
   Qt5::OpenGL
   Qt5::Widgets
+PUBLIC
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  tf2::tf2
 )
 
 set(PLUGIN_SRC_FILES

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -84,7 +84,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM
     GLEW::GLEW
     ${JSONCPP_INCLUDE_DIRS}
     ${YamlCpp_INCLUDE_DIRS})
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   ament_cmake
   mapviz
   pluginlib

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -92,8 +92,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   swri_math_util
   swri_transform_util
   tf2
-)
-target_link_libraries(${PROJECT_NAME}
   ${GLU_LIBRARY}
   ${JSONCPP_LIBRARIES}
   ${YamlCpp_LIBRARIES}


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
