### PR TITLE
revert config save/load whitespace trimming behavior

### DIFF
--- a/mapviz/include/mapviz/mapviz_plugin.h
+++ b/mapviz/include/mapviz/mapviz_plugin.h
@@ -349,6 +349,31 @@ protected:
     emitter << YAML::Key << prefix + "qos_durability" << YAML::Value << qos.durability;
   }
 
+  // Dealing with YAML frequently requires trimming whitespace from strings
+  inline std::string TrimString(const std::string& str)
+  {
+    auto begin = str.begin();
+    auto end = str.end();
+
+    // Trim leading whitespace
+    while (begin != end && std::isspace(*begin))
+    {
+      ++begin;
+    }
+
+    // Trim trailing whitespace
+    if (begin != end)
+    {
+      do
+      {
+        --end;
+      } while (std::isspace(*end));
+      ++end;
+    }
+
+    return std::string(begin, end);
+  }
+
 private:
   // Collect basic profiling info to know how much time each plugin
   // spends in Transform(), Paint(), and Draw().
@@ -357,31 +382,6 @@ private:
   Stopwatch meas_draw_;
 };
 typedef std::shared_ptr<MapvizPlugin> MapvizPluginPtr;
-
-// Dealing with YAML frequently requires trimming whitespace from strings
-inline std::string TrimString(const std::string& str)
-{
-  auto begin = str.begin();
-  auto end = str.end();
-
-  // Trim leading whitespace
-  while (begin != end && std::isspace(*begin))
-  {
-    ++begin;
-  }
-
-  // Trim trailing whitespace
-  if (begin != end)
-  {
-    do
-    {
-      --end;
-    } while (std::isspace(*end));
-    ++end;
-  }
-
-  return std::string(begin, end);
-}
 
 // Implementation
 inline void MapvizPlugin::PrintErrorHelper(QLabel *status_label, const std::string &message,

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -540,9 +540,7 @@ namespace mapviz_plugins
     LoadQosConfig(node, qos_);
     if (node["topic"])
     {
-      std::string topic = node["topic"].as<std::string>();
-      std::string trimmed = topic;
-      trimmed.erase(std::remove_if(trimmed.begin(), trimmed.end(), ::isspace), trimmed.end());
+      std::string trimmed = TrimString(node["topic"].as<std::string>());
       ui_.topic->setText(trimmed.c_str());
       TopicEdited();
     }
@@ -666,8 +664,7 @@ namespace mapviz_plugins
   void LaserScanPlugin::SaveConfig(YAML::Emitter& emitter,
       const std::string& path)
   {
-    std::string trimmed = ui_.topic->text().toStdString();
-    trimmed.erase(std::remove_if(trimmed.begin(), trimmed.end(), ::isspace), trimmed.end());
+    std::string trimmed = TrimString(ui_.topic->text().toStdString());
 
     emitter << YAML::Key << "topic" <<
                YAML::Value << trimmed;

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -698,8 +698,7 @@ namespace mapviz_plugins
     LoadQosConfig(node, qos_);
     if (node["topic"])
     {
-      std::string topic = node["topic"].as<std::string>();
-      topic.erase(std::remove_if(topic.begin(), topic.end(), ::isspace), topic.end());
+      std::string topic = TrimString(node["topic"].as<std::string>());
       ui_.topic->setText(topic.c_str());
 
       TopicEdited();
@@ -708,8 +707,7 @@ namespace mapviz_plugins
 
   void MarkerPlugin::SaveConfig(YAML::Emitter& emitter, const std::string& path)
   {
-    std::string trimmed = ui_.topic->text().toStdString();
-    trimmed.erase(std::remove_if(trimmed.begin(), trimmed.end(), ::isspace), trimmed.end());
+    std::string trimmed = TrimString(ui_.topic->text().toStdString());
     emitter << YAML::Key
       << "topic"
       << YAML::Value

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -738,8 +738,7 @@ namespace mapviz_plugins
 
     if (node["topic"])
     {
-      std::string topic = node["topic"].as<std::string>();
-      topic.erase(std::remove_if(topic.begin(), topic.end(), ::isspace), topic.end());
+      std::string topic = TrimString(node["topic"].as<std::string>());
       ui_.topic->setText(topic.c_str());
       TopicEdited();
     }
@@ -864,8 +863,7 @@ namespace mapviz_plugins
   void PointCloud2Plugin::SaveConfig(YAML::Emitter& emitter,
                                      const std::string& path)
   {
-    std::string topic = ui_.topic->text().toStdString();
-    topic.erase(std::remove_if(topic.begin(), topic.end(), ::isspace), topic.end());
+    std::string topic = TrimString(ui_.topic->text().toStdString());
     emitter << YAML::Key << "topic" <<
       YAML::Value << topic;
     emitter << YAML::Key << "size" <<

--- a/mapviz_plugins/src/textured_marker_plugin.cpp
+++ b/mapviz_plugins/src/textured_marker_plugin.cpp
@@ -531,8 +531,7 @@ void TexturedMarkerPlugin::LoadConfig(const YAML::Node & node, const std::string
 {
   LoadQosConfig(node, qos_);
   if (node["topic"]) {
-    std::string topic = node["topic"].as<std::string>();
-    topic.erase(std::remove_if(topic.begin(), topic.end(), ::isspace), topic.end());
+    std::string topic = TrimString(node["topic"].as<std::string>());
     ui_.topic->setText(topic.c_str());
   }
 
@@ -541,8 +540,7 @@ void TexturedMarkerPlugin::LoadConfig(const YAML::Node & node, const std::string
 
 void TexturedMarkerPlugin::SaveConfig(YAML::Emitter & emitter, const std::string & path)
 {
-  std::string topic = ui_.topic->text().toStdString();
-    topic.erase(std::remove_if(topic.begin(), topic.end(), ::isspace), topic.end());
+  std::string topic = TrimString(ui_.topic->text().toStdString());
   emitter << YAML::Key << "topic" << YAML::Value << topic;
 
   SaveQosConfig(emitter, qos_);

--- a/tile_map/src/tile_map_plugin.cpp
+++ b/tile_map/src/tile_map_plugin.cpp
@@ -27,6 +27,7 @@
 //
 // *****************************************************************************
 
+#include <mapviz/mapviz_plugin.h>
 #include <tile_map/tile_map_plugin.h>
 #include <tile_map/tile_source.h>
 #include <tile_map/bing_source.h>
@@ -399,6 +400,19 @@ namespace tile_map
     }
   }
 
+  std::string trim_whitespace(const std::string& in)
+  {
+    std::string out;
+    const char* whitespace = " \t";
+    auto begin = in.find_first_not_of(whitespace);
+    if (begin == std::string::npos)
+    {
+      return in;
+    }
+    auto end = in.find_last_not_of(whitespace);
+    return in.substr(begin, (end - begin + 1));
+  }
+
   void TileMapPlugin::SaveConfig(YAML::Emitter& emitter, const std::string&)
   {
     emitter << YAML::Key << CUSTOM_SOURCES_KEY << YAML::Value << YAML::BeginSeq;
@@ -417,15 +431,12 @@ namespace tile_map
       }
     }
     emitter << YAML::EndSeq;
-
     
     BingSource* bing_source = dynamic_cast<BingSource*>(tile_sources_[BING_NAME].get());
-    std::string bing_key = bing_source->GetApiKey().toStdString();
-    bing_key.erase(std::remove_if(bing_key.begin(), bing_key.end(), ::isspace), bing_key.end());
+    std::string bing_key = TrimString(bing_source->GetApiKey().toStdString());
     emitter << YAML::Key << BING_API_KEY << YAML::Value << bing_key;
 
-    std::string combo_str = ui_.source_combo->currentText().toStdString();
-    combo_str.erase(std::remove_if(combo_str.begin(), combo_str.end(), ::isspace), combo_str.end());
+    std::string combo_str = TrimString(ui_.source_combo->currentText().toStdString());
     emitter << YAML::Key << SOURCE_KEY << YAML::Value << combo_str; 
   }
 


### PR DESCRIPTION
- moved MapvizPlugin::TrimString to protected from private
- make plugins use TrimString instead of remove_if with std::isspace