### PR TITLE
add error status for navsatfix uninitialized origin

### DIFF
--- a/docs/_plugins/navsat.md
+++ b/docs/_plugins/navsat.md
@@ -1,6 +1,6 @@
 ---
 title: "NavSat"
-description: "Projects [sensor_msgs::NavSatFix](https://docs.ros.org/jade/api/sensor_msgs/html/msg/NavSatFix.html) message data into the scene."
+description: "Projects [sensor_msgs::NavSatFix](https://docs.ros.org/jade/api/sensor_msgs/html/msg/NavSatFix.html) message data into the scene. Requires an initialized local_xy_origin."
 image: ""
 parameters:
   - name: "Topic"

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -130,6 +130,7 @@ namespace mapviz_plugins
   {
     if (!tf_manager_->LocalXyUtil()->Initialized())
     {
+      PrintError("No origin initalized; dropping messages");
       return;
     }
     if (!has_message_)


### PR DESCRIPTION
Make the NavSat plugin display when it is dropping messages due to an unitialized origin.

<img width="334" height="200" alt="image" src="https://github.com/user-attachments/assets/d603906d-cc23-4cc8-bc43-cc740cdca4df" />
 