### PR TITLE
Fix incorrect GLUT library reference

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -146,7 +146,7 @@ add_executable(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
   rqt_${PROJECT_NAME}
-  ${GLUT_LIBRARY}
+  ${GLUT_LIBRARIES}
   ${swri_transform_util_TARGETS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
   image_transport::image_transport


### PR DESCRIPTION
The documented variable here is `GLUT_LIBRARIES`, which is actually already used correctly earlier in this file.

https://cmake.org/cmake/help/latest/module/FindGLUT.html

This is the (sole) cause of the RHEL 9 build failures on build.ros2.org.

Previously changed by #854.