### PR TITLE
HiDPI Resolution Issues

### DIFF
--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -592,7 +592,7 @@ void MapCanvas::UpdateView()
   if (initialized_) {
     Recenter();
 
-    glViewport(0, 0, width(), height());
+    glViewport(0, 0, width() * devicePixelRatio(), height() * devicePixelRatio());
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glOrtho(view_left_, view_right_, view_top_, view_bottom_, -0.5f, 0.5f);


### PR DESCRIPTION
I tend to run on 200% resolution since the way 4k renders on my monitors makes the text too small
<img width="698" height="497" alt="Screenshot from 2025-12-15 13-43-13" src="https://github.com/user-attachments/assets/a391a960-d337-403b-a386-4029a5a96dc4" />

This results in Mapviz only rendering in the bottom corner
<img width="1869" height="1059" alt="Screenshot from 2025-12-15 13-40-32" src="https://github.com/user-attachments/assets/40d0e326-2822-481b-9c4e-29d66ae16333" />

It's apparently a known issue when people run monitors with a >100% scaling factor that the QT render only renders in the bottom left corner  

https://qt-project.atlassian.net/browse/QTBUG-59956
https://doc.qt.io/archives/qt-5.15/highdpi.html

With the update line it now renders properly. I tested in both 100 and 200% resolution
<img width="1869" height="1059" alt="Screenshot from 2025-12-15 13-39-03" src="https://github.com/user-attachments/assets/35999ba3-999e-4f03-9b5b-4fb00e2405b6" />