### PR TITLE
Additional Tile Map Sources

### DIFF
--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TILE_SRC_FILES
   src/image_cache.cpp
   src/texture_cache.cpp
   src/bing_source.cpp
+  src/stadia_source.cpp
   src/tile_source.cpp
   src/wmts_source.cpp
   src/${PROJECT_NAME}_view.cpp
@@ -68,6 +69,7 @@ set(QT_HEADERS
   include/${PROJECT_NAME}/tile_source.h
   include/${PROJECT_NAME}/wmts_source.h
   include/${PROJECT_NAME}/bing_source.h
+  include/${PROJECT_NAME}/stadia_source.h
 )
 qt5_wrap_cpp(TILE_SRC_FILES ${QT_HEADERS})
 add_library(${PROJECT_NAME} ${TILE_SRC_FILES})

--- a/tile_map/include/tile_map/stadia_source.h
+++ b/tile_map/include/tile_map/stadia_source.h
@@ -1,0 +1,66 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015-2025, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef TILE_MAP_STADIA_SOURCE_H
+#define TILE_MAP_STADIA_SOURCE_H
+
+#include "tile_source.h"
+
+#include <string>
+
+#include <QString>
+
+namespace tile_map
+{
+  class StadiaSource : public TileSource
+  {
+  Q_OBJECT
+  public:
+    explicit StadiaSource(const QString& name,
+                          const QString& base_url,
+                          bool is_custom,
+                          int32_t max_zoom);
+
+    size_t GenerateTileHash(int32_t level, int64_t x, int64_t y) override;
+    QString GenerateTileUrl(int32_t level, int64_t x, int64_t y) override;
+    QString GetType() const override;
+
+    QString GetApiKey() const;
+    void SetApiKey(const QString& api_key);
+
+    static const QString STADIA_TYPE;
+
+  private:
+    std::hash<std::string> hash_;
+    QString api_key_;
+  };
+}
+
+#endif //TILE_MAP_STADIA_SOURCE_H

--- a/tile_map/include/tile_map/tile_map_plugin.h
+++ b/tile_map/include/tile_map/tile_map_plugin.h
@@ -108,15 +108,19 @@ namespace tile_map
 
     static std::string BASE_URL_KEY;
     static std::string BING_API_KEY;
+    static std::string STADIA_API_KEY;
     static std::string CUSTOM_SOURCES_KEY;
     static std::string MAX_ZOOM_KEY;
     static std::string NAME_KEY;
     static std::string SOURCE_KEY;
     static std::string TYPE_KEY;
     static QString BING_NAME;
+    static QString CARTO_NAME;
     static QString STAMEN_TERRAIN_NAME;
     static QString STAMEN_TONER_NAME;
     static QString STAMEN_WATERCOLOR_NAME;
+    static QString OSM_NAME;
+    static QString USGS_NAME;
   };
 }
 

--- a/tile_map/src/stadia_source.cpp
+++ b/tile_map/src/stadia_source.cpp
@@ -1,0 +1,84 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015-2025, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+
+#include <tile_map/stadia_source.h>
+
+namespace tile_map
+{
+  const QString StadiaSource::STADIA_TYPE = "stadia";
+
+  StadiaSource::StadiaSource(const QString& name,
+                             const QString& base_url,
+                             bool is_custom,
+                             int32_t max_zoom) :
+                             TileSource()
+  {
+    name_ = name;
+    base_url_ = base_url;
+    is_custom_ = is_custom;
+    max_zoom_ = max_zoom;
+    min_zoom_ = 1;
+  }
+
+  QString StadiaSource::GetType() const
+  {
+    return STADIA_TYPE;
+  }
+
+  QString StadiaSource::GetApiKey() const
+  {
+    return api_key_;
+  }
+
+  void StadiaSource::SetApiKey(const QString& api_key)
+  {
+    api_key_ = api_key.trimmed();
+  }
+
+  size_t StadiaSource::GenerateTileHash(int32_t level, int64_t x, int64_t y)
+  {
+    return hash_((base_url_ + api_key_ + GenerateTileUrl(level, x, y)).toStdString());
+  }
+
+  QString StadiaSource::GenerateTileUrl(int32_t level, int64_t x, int64_t y)
+  {
+    QString url(base_url_);
+    url.replace(QString::fromStdString("{level}"), QString::number(level));
+    url.replace(QString::fromStdString("{x}"), QString::number(x));
+    url.replace(QString::fromStdString("{y}"), QString::number(y));
+
+    if (!api_key_.isEmpty())
+    {
+      url += "?api_key=" + api_key_;
+    }
+
+    return url;
+  }
+}

--- a/tile_map/src/tile_map_config.ui
+++ b/tile_map/src/tile_map_config.ui
@@ -101,6 +101,11 @@
      </property>
      <item>
       <property name="text">
+       <string>Carto</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>Stamen (terrain)</string>
       </property>
      </item>
@@ -112,6 +117,16 @@
      <item>
       <property name="text">
        <string>Stamen (toner)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>OpenStreetMap</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>USGS Satellite</string>
       </property>
      </item>
      <item>

--- a/tile_map/src/tile_map_view.cpp
+++ b/tile_map/src/tile_map_view.cpp
@@ -75,6 +75,18 @@ namespace tile_map
   {
     tile_source_ = tile_source;
     level_ = -1;
+    // Clear existing tiles to avoid using stale textures from the old source
+    // which can cause segfaults when switching tile sources
+    for (auto & tile : tiles_)
+    {
+      tile_cache_->AddTexture(tile.texture);
+    }
+    tiles_.clear();
+    for (auto & tile : precache_)
+    {
+      tile_cache_->AddTexture(tile.texture);
+    }
+    precache_.clear();
   }
 
   void TileMapView::SetTransform(const swri_transform_util::Transform& transform)


### PR DESCRIPTION
Based on the comments attached to https://github.com/swri-robotics/mapviz/issues/851

I updated the tile map plugin to connect to stadia with an API key and added Carto, Open Street Maps, and USGS terrain data.

Stamen shots cropped to hide my API key

<img width="3840" height="2160" alt="Screenshot from 2025-12-15 14-56-20" src="https://github.com/user-attachments/assets/563fe34d-8dd6-4723-b9c7-d86682b73168" />
<img width="3840" height="2160" alt="Screenshot from 2025-12-15 14-54-53" src="https://github.com/user-attachments/assets/e0c6ffec-603c-41e8-a463-59fe565e24aa" />
<img width="3027" height="1962" alt="Screenshot from 2025-12-15 14-57-22" src="https://github.com/user-attachments/assets/38cec394-1280-471a-ab99-86ab7e3a32b0" />

<img width="3027" height="1962" alt="Screenshot from 2025-12-15 14-57-47" src="https://github.com/user-attachments/assets/fd5638a9-0c6c-4bc2-a2a6-19118c189797" />
<img width="3027" height="1962" alt="Screenshot from 2025-12-15 14-57-38" src="https://github.com/user-attachments/assets/ca1a9248-8bd4-4276-8094-5f33f3286b4f" />

