### PR TITLE
Added image rotation option for image_plugin

### DIFF
--- a/mapviz_plugins/include/mapviz_plugins/image_plugin.h
+++ b/mapviz_plugins/include/mapviz_plugins/image_plugin.h
@@ -117,6 +117,7 @@ protected Q_SLOTS:
   void SetSubscription(bool visible);
   void SetTransport(const QString& transport);
   void KeepRatioChanged(bool checked);
+  void SetRotation(QString rotation);
 
 private:
   Ui::image_config ui_;
@@ -131,6 +132,7 @@ private:
   double width_;
   double height_;
   std::string transport_;
+  int rotation_;
 
   bool force_resubscribe_;
   bool has_image_;

--- a/mapviz_plugins/ui/image_config.ui
+++ b/mapviz_plugins/ui/image_config.ui
@@ -130,6 +130,55 @@
      </property>
     </widget>
    </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Rotation:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1" colspan="2">
+    <widget class="QComboBox" name="rotation">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>9</pointsize>
+      </font>
+     </property>
+     <item>
+      <property name="text">
+       <string>0</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>90</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>180</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>270</string>
+      </property>
+     </item>
+    </widget>
+   </item>
    <item row="11" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
@@ -201,7 +250,7 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
+   <item row="12" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
This adds the ability to rotate image (increments of 90 degrees) in the image_plugin directly inside mapviz.