### PR TITLE
Adding conditional include

### DIFF
--- a/mapviz/include/mapviz/rqt_mapviz.h
+++ b/mapviz/include/mapviz/rqt_mapviz.h
@@ -39,7 +39,11 @@
  */
 #define slots
 #define signals
+#if __has_include(<rqt_gui_cpp/plugin.h>)
 #include <rqt_gui_cpp/plugin.h>
+#else
+#include <rqt_gui_cpp/plugin.hpp>
+#endif
 #undef slots
 #undef signals
 


### PR DESCRIPTION
Adding check to conditionally include either the .h or .hpp version of an RQT include. Fixes https://github.com/swri-robotics/mapviz/issues/868.