### PR TITLE
Dual Support for Qt5 and Qt6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,13 @@ jobs:
   industrial_ci:
     strategy:
       matrix:
-        env:       
+        env: 
+          - {ROS_DISTRO: humble, ROS_REPO: testing}
+          - {ROS_DISTRO: humble, ROS_REPO: main}
+          - {ROS_DISTRO: jazzy, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
+          - {ROS_DISTRO: jazzy, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}
+          - {ROS_DISTRO: kilted, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
+          - {ROS_DISTRO: kilted, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}       
           - {ROS_DISTRO: rolling, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
           - {ROS_DISTRO: rolling, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,15 +6,9 @@ jobs:
   industrial_ci:
     strategy:
       matrix:
-        env: 
-          - {ROS_DISTRO: humble, ROS_REPO: testing}
-          - {ROS_DISTRO: humble, ROS_REPO: main}
-          - {ROS_DISTRO: jazzy, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
-          - {ROS_DISTRO: jazzy, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}
-          - {ROS_DISTRO: kilted, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
-          - {ROS_DISTRO: kilted, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}       
-          - {ROS_DISTRO: rolling, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
-          - {ROS_DISTRO: rolling, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}
+        env:    
+          - {ROS_DISTRO: lyrical, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
+          - {ROS_DISTRO: lyrical, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
         env:    
           - {ROS_DISTRO: lyrical, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
           - {ROS_DISTRO: lyrical, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -50,6 +50,19 @@ set(MAPVIZ_AUTOGEN_UI_INCLUDE_DIR
   ${MAPVIZ_AUTOGEN_INCLUDE_DIR}/ui)
 
 find_package(ament_cmake REQUIRED)
+
+# Find Qt6 early before any dependencies that use it (like rqt_gui_cpp)
+# to avoid target conflict issues
+find_package(Qt6
+  REQUIRED
+  COMPONENTS
+    Concurrent
+    Core
+    Gui
+    OpenGL
+    OpenGLWidgets
+    Widgets)
+
 find_package(geometry_msgs REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(mapviz_interfaces REQUIRED)
@@ -62,16 +75,6 @@ find_package(swri_transform_util REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
-
-find_package(Qt6
-  REQUIRED
-  COMPONENTS
-    Concurrent
-    Core
-    Gui
-    OpenGL
-    OpenGLWidgets
-    Widgets)
 
 find_package(OpenCV QUIET CONFIG COMPONENTS core highgui imgcodecs imgproc videoio)
 if(NOT OpenCV_FOUND)

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -50,24 +50,32 @@ set(MAPVIZ_AUTOGEN_UI_INCLUDE_DIR
   ${MAPVIZ_AUTOGEN_INCLUDE_DIR}/ui)
 
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
 
-# Find Qt6 early before any dependencies that use it (like rqt_gui_cpp)
-# to avoid target conflict issues
-find_package(Qt6
+find_package(qt_gui_cpp REQUIRED)
+set(QT_VERSION_MAJOR "${qt_gui_cpp_USE_QT_MAJOR_VERSION}")
+find_package(Qt${qt_gui_cpp_USE_QT_MAJOR_VERSION}
   REQUIRED
   COMPONENTS
     Concurrent
     Core
     Gui
     OpenGL
-    OpenGLWidgets
-    Widgets)
+    Widgets
+)
+
+if(QT_VERSION_MAJOR EQUAL 6)
+  find_package(Qt6
+    REQUIRED
+    COMPONENTS
+      OpenGLWidgets
+  )
+endif()
 
 find_package(geometry_msgs REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(mapviz_interfaces REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(rclcpp REQUIRED)
 find_package(rqt_gui_cpp REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(swri_math_util REQUIRED)
@@ -131,21 +139,27 @@ set(SRC_FILES
 )
 
 set(MAPVIZ_QT_LIBRARIES
-  Qt6::Concurrent
-  Qt6::Core
-  Qt6::Gui
-  Qt6::OpenGL
-  Qt6::Widgets
+  Qt${QT_VERSION_MAJOR}::Concurrent
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Gui
+  Qt${QT_VERSION_MAJOR}::OpenGL
+  Qt${QT_VERSION_MAJOR}::Widgets
 )
 
-list(APPEND MAPVIZ_QT_LIBRARIES Qt6::OpenGLWidgets)
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND MAPVIZ_QT_LIBRARIES Qt${QT_VERSION_MAJOR}::OpenGLWidgets)
+endif()
+
 set(MAPVIZ_QT_EXPORT_DEPENDENCIES
-  Qt6Concurrent
-  Qt6Core
-  Qt6Gui
-  Qt6OpenGL
-  Qt6OpenGLWidgets
-  Qt6Widgets)
+  Qt${QT_VERSION_MAJOR}Concurrent
+  Qt${QT_VERSION_MAJOR}Core
+  Qt${QT_VERSION_MAJOR}Gui
+  Qt${QT_VERSION_MAJOR}OpenGL
+  Qt${QT_VERSION_MAJOR}Widgets)
+
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND MAPVIZ_QT_EXPORT_DEPENDENCIES Qt${QT_VERSION_MAJOR}OpenGLWidgets)
+endif()
 
 ### Build mapviz core library ###
 add_library(${PROJECT_NAME}_core SHARED

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -193,7 +193,7 @@ set_target_properties(${PROJECT_NAME}_core PROPERTIES
   AUTOUIC ON
   AUTORCC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/ui"
-  QT_MAJOR_VERSION 6)
+)
 
 ### Build rqt plugin (thin wrapper, loaded dynamically by rqt) ###
 add_library(rqt_${PROJECT_NAME} SHARED
@@ -206,7 +206,7 @@ target_link_libraries(rqt_${PROJECT_NAME} PUBLIC
 )
 set_target_properties(rqt_${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
-  QT_MAJOR_VERSION 6)
+)
 
 ### Build mapviz as a standalone executable ###
 add_executable(${PROJECT_NAME}

--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -63,21 +63,15 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-find_package(Qt5 QUIET COMPONENTS Concurrent Core Gui OpenGL Widgets)
-if(Qt5_FOUND)
-  set(MAPVIZ_QT_VERSION_MAJOR 5)
-else()
-  find_package(Qt6
-    REQUIRED
-    COMPONENTS
-      Concurrent
-      Core
-      Gui
-      OpenGL
-      OpenGLWidgets
-      Widgets)
-  set(MAPVIZ_QT_VERSION_MAJOR 6)
-endif()
+find_package(Qt6
+  REQUIRED
+  COMPONENTS
+    Concurrent
+    Core
+    Gui
+    OpenGL
+    OpenGLWidgets
+    Widgets)
 
 find_package(OpenCV QUIET CONFIG COMPONENTS core highgui imgcodecs imgproc videoio)
 if(NOT OpenCV_FOUND)
@@ -134,30 +128,21 @@ set(SRC_FILES
 )
 
 set(MAPVIZ_QT_LIBRARIES
-  Qt${MAPVIZ_QT_VERSION_MAJOR}::Concurrent
-  Qt${MAPVIZ_QT_VERSION_MAJOR}::Core
-  Qt${MAPVIZ_QT_VERSION_MAJOR}::Gui
-  Qt${MAPVIZ_QT_VERSION_MAJOR}::OpenGL
-  Qt${MAPVIZ_QT_VERSION_MAJOR}::Widgets
+  Qt6::Concurrent
+  Qt6::Core
+  Qt6::Gui
+  Qt6::OpenGL
+  Qt6::Widgets
 )
 
-if(MAPVIZ_QT_VERSION_MAJOR EQUAL 6)
-  list(APPEND MAPVIZ_QT_LIBRARIES Qt6::OpenGLWidgets)
-  set(MAPVIZ_QT_EXPORT_DEPENDENCIES
-    Qt6Concurrent
-    Qt6Core
-    Qt6Gui
-    Qt6OpenGL
-    Qt6OpenGLWidgets
-    Qt6Widgets)
-else()
-  set(MAPVIZ_QT_EXPORT_DEPENDENCIES
-    Qt5Concurrent
-    Qt5Core
-    Qt5Gui
-    Qt5OpenGL
-    Qt5Widgets)
-endif()
+list(APPEND MAPVIZ_QT_LIBRARIES Qt6::OpenGLWidgets)
+set(MAPVIZ_QT_EXPORT_DEPENDENCIES
+  Qt6Concurrent
+  Qt6Core
+  Qt6Gui
+  Qt6OpenGL
+  Qt6OpenGLWidgets
+  Qt6Widgets)
 
 ### Build mapviz core library ###
 add_library(${PROJECT_NAME}_core SHARED
@@ -205,7 +190,7 @@ set_target_properties(${PROJECT_NAME}_core PROPERTIES
   AUTOUIC ON
   AUTORCC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/ui"
-  QT_MAJOR_VERSION ${MAPVIZ_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 
 ### Build rqt plugin (thin wrapper, loaded dynamically by rqt) ###
 add_library(rqt_${PROJECT_NAME} SHARED
@@ -218,7 +203,7 @@ target_link_libraries(rqt_${PROJECT_NAME} PUBLIC
 )
 set_target_properties(rqt_${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
-  QT_MAJOR_VERSION ${MAPVIZ_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 
 ### Build mapviz as a standalone executable ###
 add_executable(${PROJECT_NAME}

--- a/mapviz/include/mapviz/map_canvas.hpp
+++ b/mapviz/include/mapviz/map_canvas.hpp
@@ -42,7 +42,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/transform_datatypes.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/transform_listener.hpp>
 
 #include <mapviz/mapviz_plugin.hpp>
 

--- a/mapviz/include/mapviz/mapviz.hpp
+++ b/mapviz/include/mapviz/mapviz.hpp
@@ -56,8 +56,8 @@
 // ROS libraries
 #include <rclcpp/rclcpp.hpp>
 #include <pluginlib/class_loader.hpp>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_listener.hpp>
 #include <yaml-cpp/yaml.h>
 #include <std_srvs/srv/empty.hpp>
 

--- a/mapviz/include/mapviz/mapviz_plugin.hpp
+++ b/mapviz/include/mapviz/mapviz_plugin.hpp
@@ -35,8 +35,8 @@
 #include <swri_transform_util/transform_manager.h>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/transform_datatypes.hpp>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 #include <mapviz/widgets.hpp>
 #include <yaml-cpp/yaml.h>

--- a/mapviz/include/mapviz/qt_mouse_event_compat.hpp
+++ b/mapviz/include/mapviz/qt_mouse_event_compat.hpp
@@ -27,61 +27,23 @@
 //
 // *****************************************************************************
 
+#ifndef MAPVIZ__QT_MOUSE_EVENT_COMPAT_HPP_
+#define MAPVIZ__QT_MOUSE_EVENT_COMPAT_HPP_
+
 #include <QMouseEvent>
-#include <QLineF>
-#include <QDateTime>
+#include <QPointF>
+#include <QtGlobal>
 
-#include <mapviz/qt_mouse_event_compat.hpp>
-
-#include "mapviz_plugins/canvas_click_filter.hpp"
-
-namespace mapviz_plugins
+namespace mapviz
 {
-  CanvasClickFilter::CanvasClickFilter()
-  : QObject()
-  , is_mouse_down_(false)
-  , max_ms_(Q_INT64_C(500))
-  , max_distance_(2.0)
-  { }
+inline QPointF MouseEventPosition(const QMouseEvent* event)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  return event->position();
+#else
+  return QPointF(event->x(), event->y());
+#endif
+}
+}  // namespace mapviz
 
-  void CanvasClickFilter::setMaxClickTime(qint64 max_ms)
-  {
-    max_ms_ = max_ms;
-  }
-
-  void CanvasClickFilter::setMaxClickMovement(qreal max_distance)
-  {
-    max_distance_ = max_distance;
-  }
-
-  bool CanvasClickFilter::eventFilter(QObject* object, QEvent* event)
-  {
-    if (event->type() == QEvent::MouseButtonPress)
-    {
-      is_mouse_down_ = true;
-      QMouseEvent* me = dynamic_cast<QMouseEvent*>(event);
-      mouse_down_pos_ = mapviz::MouseEventPosition(me);
-      mouse_down_time_ = QDateTime::currentMSecsSinceEpoch();
-    } else if (event->type() == QEvent::MouseButtonRelease) {
-      if (is_mouse_down_)
-      {
-        QMouseEvent* me = dynamic_cast<QMouseEvent*>(event);
-        const QPointF mouse_position = mapviz::MouseEventPosition(me);
-
-        qreal distance = QLineF(mouse_down_pos_, mouse_position).length();
-        qint64 msecsDiff = QDateTime::currentMSecsSinceEpoch() - mouse_down_time_;
-
-        // Only fire the event if the mouse has moved less than the maximum distance
-        // and was held for shorter than the maximum time..  This prevents click
-        // events from being fired if the user is dragging the mouse across the map
-        // or just holding the cursor in place.
-        if (msecsDiff < max_ms_ && distance <= max_distance_)
-        {
-          Q_EMIT pointClicked(mouse_position);
-        }
-      }
-      is_mouse_down_ = false;
-    }
-    return false;
-  }
-}   // namespace mapviz_plugins
+#endif  // MAPVIZ__QT_MOUSE_EVENT_COMPAT_HPP_

--- a/mapviz/include/mapviz/select_frame_dialog.hpp
+++ b/mapviz/include/mapviz/select_frame_dialog.hpp
@@ -29,7 +29,7 @@
 #ifndef MAPVIZ__SELECT_FRAME_DIALOG_HPP_
 #define MAPVIZ__SELECT_FRAME_DIALOG_HPP_
 
-#include <tf2_ros/buffer.h>
+#include <tf2_ros/buffer.hpp>
 
 #include <QDialog>
 

--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -12,10 +12,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
-  <buildtool_depend>qt6-qmake</buildtool_depend>
 
-  <depend>libqt6-core</depend>
-  <build_depend>libqt6-opengl-dev</build_depend>
+  <build_depend>qt-base-dev</build_depend>
+
+  <build_export_depend>qt-base-dev</build_export_depend>
 
   <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
@@ -35,7 +35,9 @@
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
 
-  <exec_depend>libqt6-opengl</exec_depend>
+  <exec_depend>libqtcore</exec_depend>
+  <exec_depend>libqtgui</exec_depend>
+  <exec_depend>libqtopengl</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -16,7 +16,6 @@
 
   <depend>libqt6-core</depend>
   <build_depend>libqt6-opengl-dev</build_depend>
-  <build_depend>ros_environment</build_depend>
 
   <depend>geometry_msgs</depend>
   <depend>image_transport</depend>

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -33,6 +33,7 @@
 #include <QSurfaceFormat>
 
 #include <mapviz/map_canvas.hpp>
+#include <mapviz/qt_mouse_event_compat.hpp>
 
 #include <geometry_msgs/msg/point.h>
 #include <swri_math_util/constants.h>
@@ -352,8 +353,9 @@ void MapCanvas::Zoom(float factor)
 
 void MapCanvas::mousePressEvent(QMouseEvent* e)
 {
-  mouse_x_ = e->position().x();
-  mouse_y_ = e->position().y();
+  const QPointF mouse_position = MouseEventPosition(e);
+  mouse_x_ = mouse_position.x();
+  mouse_y_ = mouse_position.y();
   mouse_previous_y_ = mouse_y_;
   drag_x_ = 0;
   drag_y_ = 0;
@@ -392,22 +394,24 @@ void MapCanvas::mouseReleaseEvent(QMouseEvent* e)
 
 void MapCanvas::mouseMoveEvent(QMouseEvent* e)
 {
+  const QPointF mouse_position = MouseEventPosition(e);
+
   if (mouse_pressed_ && canvas_able_to_move_) {
     int diff;
     switch (mouse_button_) {
       case Qt::LeftButton:
       case Qt::MiddleButton:
-        if (((mouse_x_ - e->position().x()) != 0 || (mouse_y_ - e->position().y()) != 0)) {
-          drag_x_ = -((mouse_x_ - e->position().x()) * view_scale_);
-          drag_y_ = ((mouse_y_ - e->position().y()) * view_scale_);
+        if (((mouse_x_ - mouse_position.x()) != 0 || (mouse_y_ - mouse_position.y()) != 0)) {
+          drag_x_ = -((mouse_x_ - mouse_position.x()) * view_scale_);
+          drag_y_ = ((mouse_y_ - mouse_position.y()) * view_scale_);
         }
         break;
       case Qt::RightButton:
-        diff = e->position().y() - mouse_previous_y_;
+        diff = mouse_position.y() - mouse_previous_y_;
         if (diff != 0) {
           Zoom((static_cast<float>(diff)) / 10.0f);
         }
-        mouse_previous_y_ = e->position().y();
+        mouse_previous_y_ = mouse_position.y();
         break;
       default:
         // Unexpected mouse button
@@ -417,8 +421,8 @@ void MapCanvas::mouseMoveEvent(QMouseEvent* e)
 
   double center_x = -offset_x_ - drag_x_;
   double center_y = -offset_y_ - drag_y_;
-  double x = center_x + (e->position().x() - width() / 2.0) * view_scale_;
-  double y = center_y + (height() / 2.0 - e->position().y()) * view_scale_;
+  double x = center_x + (mouse_position.x() - width() / 2.0) * view_scale_;
+  double y = center_y + (height() / 2.0 - mouse_position.y()) * view_scale_;
 
   geometry_msgs::msg::PointStamped point_in = make_point_stamped(x, y, 0.0);
   geometry_msgs::msg::PointStamped point_out;
@@ -427,8 +431,8 @@ void MapCanvas::mouseMoveEvent(QMouseEvent* e)
   tf2::doTransform(point_in, point_out, tfm_temp);
 
   mouse_hovering_ = true;
-  mouse_hover_x_ = e->position().x();
-  mouse_hover_y_ = e->position().y();
+  mouse_hover_x_ = mouse_position.x();
+  mouse_hover_y_ = mouse_position.y();
 
   Q_EMIT Hover(point_out.point.x, point_out.point.y, view_scale_);
 }

--- a/mapviz/src/map_canvas.cpp
+++ b/mapviz/src/map_canvas.cpp
@@ -352,8 +352,8 @@ void MapCanvas::Zoom(float factor)
 
 void MapCanvas::mousePressEvent(QMouseEvent* e)
 {
-  mouse_x_ = e->x();
-  mouse_y_ = e->y();
+  mouse_x_ = e->position().x();
+  mouse_y_ = e->position().y();
   mouse_previous_y_ = mouse_y_;
   drag_x_ = 0;
   drag_y_ = 0;
@@ -397,17 +397,17 @@ void MapCanvas::mouseMoveEvent(QMouseEvent* e)
     switch (mouse_button_) {
       case Qt::LeftButton:
       case Qt::MiddleButton:
-        if (((mouse_x_ - e->x()) != 0 || (mouse_y_ - e->y()) != 0)) {
-          drag_x_ = -((mouse_x_ - e->x()) * view_scale_);
-          drag_y_ = ((mouse_y_ - e->y()) * view_scale_);
+        if (((mouse_x_ - e->position().x()) != 0 || (mouse_y_ - e->position().y()) != 0)) {
+          drag_x_ = -((mouse_x_ - e->position().x()) * view_scale_);
+          drag_y_ = ((mouse_y_ - e->position().y()) * view_scale_);
         }
         break;
       case Qt::RightButton:
-        diff = e->y() - mouse_previous_y_;
+        diff = e->position().y() - mouse_previous_y_;
         if (diff != 0) {
           Zoom((static_cast<float>(diff)) / 10.0f);
         }
-        mouse_previous_y_ = e->y();
+        mouse_previous_y_ = e->position().y();
         break;
       default:
         // Unexpected mouse button
@@ -417,8 +417,8 @@ void MapCanvas::mouseMoveEvent(QMouseEvent* e)
 
   double center_x = -offset_x_ - drag_x_;
   double center_y = -offset_y_ - drag_y_;
-  double x = center_x + (e->x() - width() / 2.0) * view_scale_;
-  double y = center_y + (height() / 2.0 - e->y()) * view_scale_;
+  double x = center_x + (e->position().x() - width() / 2.0) * view_scale_;
+  double y = center_y + (height() / 2.0 - e->position().y()) * view_scale_;
 
   geometry_msgs::msg::PointStamped point_in = make_point_stamped(x, y, 0.0);
   geometry_msgs::msg::PointStamped point_out;
@@ -427,8 +427,8 @@ void MapCanvas::mouseMoveEvent(QMouseEvent* e)
   tf2::doTransform(point_in, point_out, tfm_temp);
 
   mouse_hovering_ = true;
-  mouse_hover_x_ = e->x();
-  mouse_hover_y_ = e->y();
+  mouse_hover_x_ = e->position().x();
+  mouse_hover_y_ = e->position().y();
 
   Q_EMIT Hover(point_out.point.x, point_out.point.y, view_scale_);
 }

--- a/mapviz/src/select_frame_dialog.cpp
+++ b/mapviz/src/select_frame_dialog.cpp
@@ -28,7 +28,7 @@
 // *****************************************************************************
 #include <mapviz/select_frame_dialog.hpp>
 
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/transform_listener.hpp>
 
 #include <QListWidget>
 #include <QLineEdit>

--- a/mapviz_plugins/CMakeLists.txt
+++ b/mapviz_plugins/CMakeLists.txt
@@ -65,6 +65,7 @@ find_package(std_srvs REQUIRED)
 find_package(stereo_msgs REQUIRED)
 find_package(swri_image_util REQUIRED)
 find_package(swri_math_util REQUIRED)
+find_package(qt_gui_cpp REQUIRED)
 find_package(swri_route_util REQUIRED)
 find_package(swri_transform_util REQUIRED)
 find_package(tf2 REQUIRED)
@@ -74,7 +75,12 @@ find_package(urdf REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 ### QT ###
-find_package(Qt6 REQUIRED COMPONENTS Core Gui OpenGL OpenGLWidgets Widgets)
+set(QT_VERSION_MAJOR "${qt_gui_cpp_USE_QT_MAJOR_VERSION}")
+set(MAPVIZ_PLUGINS_QT_COMPONENTS Core Gui OpenGL Widgets)
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND MAPVIZ_PLUGINS_QT_COMPONENTS OpenGLWidgets)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${MAPVIZ_PLUGINS_QT_COMPONENTS})
 
 find_package(OpenCV QUIET CONFIG COMPONENTS core imgproc highgui)
 if(NOT OpenCV_FOUND)
@@ -181,19 +187,24 @@ set(HEADER_FILES
   include/${PROJECT_NAME}/topic_select.hpp)
 
 set(MAPVIZ_PLUGINS_QT_LIBRARIES
-  Qt6::Core
-  Qt6::Gui
-  Qt6::OpenGL
-  Qt6::Widgets
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Gui
+  Qt${QT_VERSION_MAJOR}::OpenGL
+  Qt${QT_VERSION_MAJOR}::Widgets
 )
 
-list(APPEND MAPVIZ_PLUGINS_QT_LIBRARIES Qt6::OpenGLWidgets)
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND MAPVIZ_PLUGINS_QT_LIBRARIES Qt${QT_VERSION_MAJOR}::OpenGLWidgets)
+endif()
 set(MAPVIZ_PLUGINS_QT_EXPORT_DEPENDENCIES
-  Qt6Core
-  Qt6Gui
-  Qt6OpenGL
-  Qt6OpenGLWidgets
-  Qt6Widgets)
+  Qt${QT_VERSION_MAJOR}Core
+  Qt${QT_VERSION_MAJOR}Gui
+  Qt${QT_VERSION_MAJOR}OpenGL
+  Qt${QT_VERSION_MAJOR}Widgets)
+
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND MAPVIZ_PLUGINS_QT_EXPORT_DEPENDENCIES Qt${QT_VERSION_MAJOR}OpenGLWidgets)
+endif()
 
 add_library(${PROJECT_NAME} SHARED
     ${HEADER_FILES}
@@ -204,7 +215,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/ui"
-  QT_MAJOR_VERSION 6)
+  QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/mapviz_plugins/CMakeLists.txt
+++ b/mapviz_plugins/CMakeLists.txt
@@ -72,16 +72,7 @@ find_package(tf2_ros REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 ### QT ###
-find_package(Qt5 QUIET COMPONENTS Core Gui OpenGL Widgets)
-if(Qt5_FOUND)
-  set(MAPVIZ_PLUGINS_QT_VERSION_MAJOR 5)
-else()
-  find_package(Qt6 REQUIRED COMPONENTS Core Gui OpenGL Widgets)
-  set(MAPVIZ_PLUGINS_QT_VERSION_MAJOR 6)
-endif()
-if(MAPVIZ_PLUGINS_QT_VERSION_MAJOR EQUAL 6)
-  find_package(Qt6 REQUIRED COMPONENTS OpenGLWidgets)
-endif()
+find_package(Qt6 REQUIRED COMPONENTS Core Gui OpenGL OpenGLWidgets Widgets)
 
 find_package(OpenCV QUIET CONFIG COMPONENTS core imgproc highgui)
 if(NOT OpenCV_FOUND)
@@ -185,27 +176,19 @@ set(HEADER_FILES
   include/${PROJECT_NAME}/topic_select.hpp)
 
 set(MAPVIZ_PLUGINS_QT_LIBRARIES
-  Qt${MAPVIZ_PLUGINS_QT_VERSION_MAJOR}::Core
-  Qt${MAPVIZ_PLUGINS_QT_VERSION_MAJOR}::Gui
-  Qt${MAPVIZ_PLUGINS_QT_VERSION_MAJOR}::OpenGL
-  Qt${MAPVIZ_PLUGINS_QT_VERSION_MAJOR}::Widgets
+  Qt6::Core
+  Qt6::Gui
+  Qt6::OpenGL
+  Qt6::Widgets
 )
 
-if(MAPVIZ_PLUGINS_QT_VERSION_MAJOR EQUAL 6)
-  list(APPEND MAPVIZ_PLUGINS_QT_LIBRARIES Qt6::OpenGLWidgets)
-  set(MAPVIZ_PLUGINS_QT_EXPORT_DEPENDENCIES
-    Qt6Core
-    Qt6Gui
-    Qt6OpenGL
-    Qt6OpenGLWidgets
-    Qt6Widgets)
-else()
-  set(MAPVIZ_PLUGINS_QT_EXPORT_DEPENDENCIES
-    Qt5Core
-    Qt5Gui
-    Qt5OpenGL
-    Qt5Widgets)
-endif()
+list(APPEND MAPVIZ_PLUGINS_QT_LIBRARIES Qt6::OpenGLWidgets)
+set(MAPVIZ_PLUGINS_QT_EXPORT_DEPENDENCIES
+  Qt6Core
+  Qt6Gui
+  Qt6OpenGL
+  Qt6OpenGLWidgets
+  Qt6Widgets)
 
 add_library(${PROJECT_NAME} SHARED
     ${HEADER_FILES}
@@ -216,7 +199,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/ui"
-  QT_MAJOR_VERSION ${MAPVIZ_PLUGINS_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/mapviz_plugins/include/mapviz_plugins/robot_model_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/robot_model_plugin.hpp
@@ -41,8 +41,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/string.hpp>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <array>
 #include <atomic>

--- a/mapviz_plugins/package.xml
+++ b/mapviz_plugins/package.xml
@@ -13,10 +13,10 @@
   <url>https://github.com/swri-robotics/mapviz</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>qt5-qmake</buildtool_depend>
+  <buildtool_depend>qt6-qmake</buildtool_depend>
 
-  <depend>libqt5-core</depend>
-  <build_depend>libqt5-opengl-dev</build_depend>
+  <depend>libqt6-core</depend>
+  <build_depend>libqt6-opengl-dev</build_depend>
   <build_depend>ros_environment</build_depend>
 
   <depend>ament_index_cpp</depend>
@@ -48,7 +48,7 @@
   <depend>tf2</depend>
   <depend>visualization_msgs</depend>
   
-  <exec_depend>libqt5-opengl</exec_depend>
+  <exec_depend>libqt6-opengl</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mapviz_plugins/package.xml
+++ b/mapviz_plugins/package.xml
@@ -13,10 +13,8 @@
   <url>https://github.com/swri-robotics/mapviz</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>qt6-qmake</buildtool_depend>
-
-  <depend>libqt6-core</depend>
-  <build_depend>libqt6-opengl-dev</build_depend>
+  <build_depend>qt-base-dev</build_depend>
+  <build_export_depend>qt-base-dev</build_export_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>assimp</depend>
@@ -33,6 +31,7 @@
   <depend>marti_visualization_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
+  <depend>qt_gui_cpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
@@ -47,7 +46,9 @@
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
   
-  <exec_depend>libqt6-opengl</exec_depend>
+  <exec_depend>libqtcore</exec_depend>
+  <exec_depend>libqtgui</exec_depend>
+  <exec_depend>libqtopengl</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mapviz_plugins/package.xml
+++ b/mapviz_plugins/package.xml
@@ -17,7 +17,6 @@
 
   <depend>libqt6-core</depend>
   <build_depend>libqt6-opengl-dev</build_depend>
-  <build_depend>ros_environment</build_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>cv_bridge</depend>

--- a/mapviz_plugins/src/canvas_click_filter.cpp
+++ b/mapviz_plugins/src/canvas_click_filter.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2014, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2026, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -57,14 +57,14 @@ namespace mapviz_plugins
     {
       is_mouse_down_ = true;
       QMouseEvent* me = dynamic_cast<QMouseEvent*>(event);
-      mouse_down_pos_ = me->localPos();
+      mouse_down_pos_ = me->position();
       mouse_down_time_ = QDateTime::currentMSecsSinceEpoch();
     } else if (event->type() == QEvent::MouseButtonRelease) {
       if (is_mouse_down_)
       {
         QMouseEvent* me = dynamic_cast<QMouseEvent*>(event);
 
-        qreal distance = QLineF(mouse_down_pos_, me->localPos()).length();
+        qreal distance = QLineF(mouse_down_pos_, me->position()).length();
         qint64 msecsDiff = QDateTime::currentMSecsSinceEpoch() - mouse_down_time_;
 
         // Only fire the event if the mouse has moved less than the maximum distance
@@ -73,7 +73,7 @@ namespace mapviz_plugins
         // or just holding the cursor in place.
         if (msecsDiff < max_ms_ && distance <= max_distance_)
         {
-          Q_EMIT pointClicked(me->localPos());
+          Q_EMIT pointClicked(me->position());
         }
       }
       is_mouse_down_ = false;

--- a/mapviz_plugins/src/coordinate_picker_plugin.cpp
+++ b/mapviz_plugins/src/coordinate_picker_plugin.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2018, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2026, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -129,7 +129,7 @@ bool CoordinatePickerPlugin::eventFilter(QObject* object, QEvent* event)
 
 bool CoordinatePickerPlugin::handleMousePress(QMouseEvent* event)
 {
-  QPointF point = event->localPos();
+  QPointF point = event->position();
   RCLCPP_DEBUG(node_->get_logger(), "Map point: %f %f", point.x(), point.y());
 
   swri_transform_util::Transform transform;

--- a/mapviz_plugins/src/coordinate_picker_plugin.cpp
+++ b/mapviz_plugins/src/coordinate_picker_plugin.cpp
@@ -29,6 +29,7 @@
 
 #include <mapviz_plugins/coordinate_picker_plugin.hpp>
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz/qt_mouse_event_compat.hpp>
 
 #include <QClipboard>
 #include <QMouseEvent>
@@ -129,7 +130,7 @@ bool CoordinatePickerPlugin::eventFilter(QObject* object, QEvent* event)
 
 bool CoordinatePickerPlugin::handleMousePress(QMouseEvent* event)
 {
-  QPointF point = event->position();
+  QPointF point = mapviz::MouseEventPosition(event);
   RCLCPP_DEBUG(node_->get_logger(), "Map point: %f %f", point.x(), point.y());
 
   swri_transform_util::Transform transform;

--- a/mapviz_plugins/src/draw_polygon_plugin.cpp
+++ b/mapviz_plugins/src/draw_polygon_plugin.cpp
@@ -39,6 +39,7 @@
 #include <geometry_msgs/msg/point32.hpp>
 #include <geometry_msgs/msg/polygon_stamped.hpp>
 #include <mapviz/select_frame_dialog.hpp>
+#include <mapviz/qt_mouse_event_compat.hpp>
 
 // Declare plugin
 #include <pluginlib/class_list_macros.hpp>
@@ -211,7 +212,7 @@ namespace mapviz_plugins
     int closest_point = 0;
     double closest_distance = std::numeric_limits<double>::max();
 
-    QPointF point = event->position();
+    QPointF point = mapviz::MouseEventPosition(event);
     stu::Transform transform;
     std::string frame = ui_.frame->text().toStdString();
     if (tf_manager_->GetTransform(target_frame_, frame, transform))
@@ -241,7 +242,7 @@ namespace mapviz_plugins
         return true;
       } else {
         is_mouse_down_ = true;
-        mouse_down_pos_ = event->position();
+        mouse_down_pos_ = mapviz::MouseEventPosition(event);
         mouse_down_time_ = QDateTime::currentMSecsSinceEpoch();
         return false;
       }
@@ -262,7 +263,7 @@ namespace mapviz_plugins
     std::string frame = ui_.frame->text().toStdString();
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
     {
-      QPointF point = event->position();
+      QPointF point = mapviz::MouseEventPosition(event);
       stu::Transform transform;
       if (tf_manager_->GetTransform(frame, target_frame_, transform))
       {
@@ -276,7 +277,8 @@ namespace mapviz_plugins
       selected_point_ = -1;
       return true;
     } else if (is_mouse_down_) {
-      qreal distance = QLineF(mouse_down_pos_, event->position()).length();
+      const QPointF point = mapviz::MouseEventPosition(event);
+      qreal distance = QLineF(mouse_down_pos_, point).length();
       qint64 msecsDiff = QDateTime::currentMSecsSinceEpoch() - mouse_down_time_;
 
       // Only fire the event if the mouse has moved less than the maximum distance
@@ -285,8 +287,6 @@ namespace mapviz_plugins
       // or just holding the cursor in place.
       if (msecsDiff < max_ms_ && distance <= max_distance_)
       {
-        QPointF point = event->position();
-
         QPointF transformed = map_canvas_->MapGlCoordToFixedFrame(point);
         RCLCPP_INFO(
           node_->get_logger(),
@@ -322,7 +322,7 @@ namespace mapviz_plugins
   {
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
     {
-      QPointF point = event->position();
+      QPointF point = mapviz::MouseEventPosition(event);
       stu::Transform transform;
       std::string frame = ui_.frame->text().toStdString();
       if (tf_manager_->GetTransform(frame, target_frame_, transform))

--- a/mapviz_plugins/src/draw_polygon_plugin.cpp
+++ b/mapviz_plugins/src/draw_polygon_plugin.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2026, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -211,7 +211,7 @@ namespace mapviz_plugins
     int closest_point = 0;
     double closest_distance = std::numeric_limits<double>::max();
 
-    QPointF point = event->localPos();
+    QPointF point = event->position();
     stu::Transform transform;
     std::string frame = ui_.frame->text().toStdString();
     if (tf_manager_->GetTransform(target_frame_, frame, transform))
@@ -241,7 +241,7 @@ namespace mapviz_plugins
         return true;
       } else {
         is_mouse_down_ = true;
-        mouse_down_pos_ = event->localPos();
+        mouse_down_pos_ = event->position();
         mouse_down_time_ = QDateTime::currentMSecsSinceEpoch();
         return false;
       }
@@ -262,7 +262,7 @@ namespace mapviz_plugins
     std::string frame = ui_.frame->text().toStdString();
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
     {
-      QPointF point = event->localPos();
+      QPointF point = event->position();
       stu::Transform transform;
       if (tf_manager_->GetTransform(frame, target_frame_, transform))
       {
@@ -276,7 +276,7 @@ namespace mapviz_plugins
       selected_point_ = -1;
       return true;
     } else if (is_mouse_down_) {
-      qreal distance = QLineF(mouse_down_pos_, event->localPos()).length();
+      qreal distance = QLineF(mouse_down_pos_, event->position()).length();
       qint64 msecsDiff = QDateTime::currentMSecsSinceEpoch() - mouse_down_time_;
 
       // Only fire the event if the mouse has moved less than the maximum distance
@@ -285,7 +285,7 @@ namespace mapviz_plugins
       // or just holding the cursor in place.
       if (msecsDiff < max_ms_ && distance <= max_distance_)
       {
-        QPointF point = event->localPos();
+        QPointF point = event->position();
 
         QPointF transformed = map_canvas_->MapGlCoordToFixedFrame(point);
         RCLCPP_INFO(
@@ -322,7 +322,7 @@ namespace mapviz_plugins
   {
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
     {
-      QPointF point = event->localPos();
+      QPointF point = event->position();
       stu::Transform transform;
       std::string frame = ui_.frame->text().toStdString();
       if (tf_manager_->GetTransform(frame, target_frame_, transform))

--- a/mapviz_plugins/src/measuring_plugin.cpp
+++ b/mapviz_plugins/src/measuring_plugin.cpp
@@ -29,6 +29,7 @@
 
 #include <mapviz_plugins/measuring_plugin.hpp>
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz/qt_mouse_event_compat.hpp>
 
 // QT libraries
 #include <QDateTime>
@@ -153,7 +154,7 @@ bool MeasuringPlugin::handleMousePress(QMouseEvent* event)
   selected_point_ = -1;
   int closest_point = 0;
   double closest_distance = std::numeric_limits<double>::max();
-  QPointF point = event->position();
+  QPointF point = mapviz::MouseEventPosition(event);
   RCLCPP_DEBUG(node_->get_logger(), "Map point: %f %f", point.x(), point.y());
   for (size_t i = 0; i < vertices_.size(); i++)
   {
@@ -176,7 +177,7 @@ bool MeasuringPlugin::handleMousePress(QMouseEvent* event)
       return true;
     } else {
       is_mouse_down_ = true;
-      mouse_down_pos_ = event->position();
+      mouse_down_pos_ = mapviz::MouseEventPosition(event);
       mouse_down_time_ = QDateTime::currentMSecsSinceEpoch();
       return false;
     }
@@ -197,7 +198,7 @@ bool MeasuringPlugin::handleMouseRelease(QMouseEvent* event)
 {
   if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
   {
-    QPointF point = event->position();
+    QPointF point = mapviz::MouseEventPosition(event);
     QPointF transformed = map_canvas_->MapGlCoordToFixedFrame(point);
     tf2::Vector3 position(transformed.x(), transformed.y(), 0.0);
     vertices_[selected_point_].setX(position.x());
@@ -209,7 +210,8 @@ bool MeasuringPlugin::handleMouseRelease(QMouseEvent* event)
 
     return true;
   } else if (is_mouse_down_) {
-    qreal distance = QLineF(mouse_down_pos_, event->position()).length();
+    const QPointF point = mapviz::MouseEventPosition(event);
+    qreal distance = QLineF(mouse_down_pos_, point).length();
     qint64 msecsDiff = QDateTime::currentMSecsSinceEpoch() - mouse_down_time_;
 
     // Only fire the event if the mouse has moved less than the maximum distance
@@ -218,8 +220,6 @@ bool MeasuringPlugin::handleMouseRelease(QMouseEvent* event)
     // or just holding the cursor in place.
     if (msecsDiff < max_ms_ && distance <= max_distance_)
     {
-      QPointF point = event->position();
-
       QPointF transformed = map_canvas_->MapGlCoordToFixedFrame(point);
       tf2::Vector3 position(transformed.x(), transformed.y(), 0.0);
       vertices_.push_back(position);
@@ -277,7 +277,7 @@ bool MeasuringPlugin::handleMouseMove(QMouseEvent* event)
 {
   if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
   {
-    QPointF point = event->position();
+    QPointF point = mapviz::MouseEventPosition(event);
     std::string frame = target_frame_;
     QPointF transformed = map_canvas_->MapGlCoordToFixedFrame(point);
     tf2::Vector3 position(transformed.x(), transformed.y(), 0.0);

--- a/mapviz_plugins/src/measuring_plugin.cpp
+++ b/mapviz_plugins/src/measuring_plugin.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2018, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2026, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -153,7 +153,7 @@ bool MeasuringPlugin::handleMousePress(QMouseEvent* event)
   selected_point_ = -1;
   int closest_point = 0;
   double closest_distance = std::numeric_limits<double>::max();
-  QPointF point = event->localPos();
+  QPointF point = event->position();
   RCLCPP_DEBUG(node_->get_logger(), "Map point: %f %f", point.x(), point.y());
   for (size_t i = 0; i < vertices_.size(); i++)
   {
@@ -176,7 +176,7 @@ bool MeasuringPlugin::handleMousePress(QMouseEvent* event)
       return true;
     } else {
       is_mouse_down_ = true;
-      mouse_down_pos_ = event->localPos();
+      mouse_down_pos_ = event->position();
       mouse_down_time_ = QDateTime::currentMSecsSinceEpoch();
       return false;
     }
@@ -197,7 +197,7 @@ bool MeasuringPlugin::handleMouseRelease(QMouseEvent* event)
 {
   if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
   {
-    QPointF point = event->localPos();
+    QPointF point = event->position();
     QPointF transformed = map_canvas_->MapGlCoordToFixedFrame(point);
     tf2::Vector3 position(transformed.x(), transformed.y(), 0.0);
     vertices_[selected_point_].setX(position.x());
@@ -209,7 +209,7 @@ bool MeasuringPlugin::handleMouseRelease(QMouseEvent* event)
 
     return true;
   } else if (is_mouse_down_) {
-    qreal distance = QLineF(mouse_down_pos_, event->localPos()).length();
+    qreal distance = QLineF(mouse_down_pos_, event->position()).length();
     qint64 msecsDiff = QDateTime::currentMSecsSinceEpoch() - mouse_down_time_;
 
     // Only fire the event if the mouse has moved less than the maximum distance
@@ -218,7 +218,7 @@ bool MeasuringPlugin::handleMouseRelease(QMouseEvent* event)
     // or just holding the cursor in place.
     if (msecsDiff < max_ms_ && distance <= max_distance_)
     {
-      QPointF point = event->localPos();
+      QPointF point = event->position();
 
       QPointF transformed = map_canvas_->MapGlCoordToFixedFrame(point);
       tf2::Vector3 position(transformed.x(), transformed.y(), 0.0);
@@ -277,7 +277,7 @@ bool MeasuringPlugin::handleMouseMove(QMouseEvent* event)
 {
   if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
   {
-    QPointF point = event->localPos();
+    QPointF point = event->position();
     std::string frame = target_frame_;
     QPointF transformed = map_canvas_->MapGlCoordToFixedFrame(point);
     tf2::Vector3 position(transformed.x(), transformed.y(), 0.0);

--- a/mapviz_plugins/src/move_base_plugin.cpp
+++ b/mapviz_plugins/src/move_base_plugin.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2026, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -209,7 +209,7 @@ bool MoveBasePlugin::handleMousePress(QMouseEvent* event)
         is_mouse_down_ = true;
         arrow_angle_ = 0;
 #if QT_VERSION >= 0x050000
-      arrow_tail_position_= map_canvas_->MapGlCoordToFixedFrame( event->localPos() );
+      arrow_tail_position_= map_canvas_->MapGlCoordToFixedFrame( event->position() );
 #else
       arrow_tail_position_= map_canvas_->MapGlCoordToFixedFrame( event->posF() );
 #endif
@@ -223,7 +223,7 @@ bool MoveBasePlugin::handleMouseMove(QMouseEvent* event)
     if (is_mouse_down_)
     {
 #if QT_VERSION >= 0x050000
-        QPointF head_pos = map_canvas_->MapGlCoordToFixedFrame( event->localPos() );
+        QPointF head_pos = map_canvas_->MapGlCoordToFixedFrame(event->position());
 #else
         QPointF head_pos = map_canvas_->MapGlCoordToFixedFrame( event->posF() );
 #endif

--- a/mapviz_plugins/src/move_base_plugin.cpp
+++ b/mapviz_plugins/src/move_base_plugin.cpp
@@ -28,6 +28,7 @@
 // *****************************************************************************
 
 #include <mapviz_plugins/move_base_plugin.hpp>
+#include <mapviz/qt_mouse_event_compat.hpp>
 
 // C++ standard libraries
 #include <cstdio>
@@ -208,11 +209,7 @@ bool MoveBasePlugin::handleMousePress(QMouseEvent* event)
     {
         is_mouse_down_ = true;
         arrow_angle_ = 0;
-#if QT_VERSION >= 0x050000
-      arrow_tail_position_= map_canvas_->MapGlCoordToFixedFrame( event->position() );
-#else
-      arrow_tail_position_= map_canvas_->MapGlCoordToFixedFrame( event->posF() );
-#endif
+          arrow_tail_position_ = map_canvas_->MapGlCoordToFixedFrame(mapviz::MouseEventPosition(event));
         return true;
     }
     return false;
@@ -222,11 +219,7 @@ bool MoveBasePlugin::handleMouseMove(QMouseEvent* event)
 {
     if (is_mouse_down_)
     {
-#if QT_VERSION >= 0x050000
-        QPointF head_pos = map_canvas_->MapGlCoordToFixedFrame(event->position());
-#else
-        QPointF head_pos = map_canvas_->MapGlCoordToFixedFrame( event->posF() );
-#endif
+    QPointF head_pos = map_canvas_->MapGlCoordToFixedFrame(mapviz::MouseEventPosition(event));
         arrow_angle_ = atan2( head_pos.y() - arrow_tail_position_.y(),
                               head_pos.x() - arrow_tail_position_.x() );
     }

--- a/mapviz_plugins/src/placeable_window_proxy.cpp
+++ b/mapviz_plugins/src/placeable_window_proxy.cpp
@@ -28,6 +28,7 @@
 // *****************************************************************************
 
 #include <mapviz_plugins/placeable_window_proxy.hpp>
+#include <mapviz/qt_mouse_event_compat.hpp>
 
 #include <QApplication>
 #include <QCursor>
@@ -160,7 +161,7 @@ bool PlaceableWindowProxy::handleMousePress(QMouseEvent *event)
   {
     start_rect_ = rect_;
     start_point_ = event->pos();
-    state_ = getNextState(event->position());
+    state_ = getNextState(mapviz::MouseEventPosition(event));
     return true;
   }
 
@@ -200,7 +201,8 @@ bool PlaceableWindowProxy::handleMouseMove(QMouseEvent *event)
 
   if (state_ == INACTIVE)
   {
-    if (!rect_.contains(event->position()))
+    const QPointF mouse_position = mapviz::MouseEventPosition(event);
+    if (!rect_.contains(mouse_position))
     {
       if (has_cursor_)
       {
@@ -214,7 +216,7 @@ bool PlaceableWindowProxy::handleMouseMove(QMouseEvent *event)
     // cursor to indicate the state the user would enter by clicking.
 
     Qt::CursorShape shape;
-    switch(getNextState(event->position()))
+  switch(getNextState(mouse_position))
     {
     case MOVE_TOP_LEFT:
     case MOVE_BOTTOM_RIGHT:
@@ -239,7 +241,8 @@ bool PlaceableWindowProxy::handleMouseMove(QMouseEvent *event)
     return true;
   }
 
-  QPointF dp = event->position() - start_point_;
+  const QPointF mouse_position = mapviz::MouseEventPosition(event);
+  QPointF dp = mouse_position - start_point_;
 
   // todo: enforce minimum size & constrain aspect ratio for resizes.
   if (state_ == MOVE_ALL)
@@ -249,25 +252,25 @@ bool PlaceableWindowProxy::handleMouseMove(QMouseEvent *event)
     rect_ = resizeHelper(start_rect_,
                         start_rect_.bottomRight(),
                         start_rect_.topLeft(),
-                        event->position());
+                        mouse_position);
     rect_.moveBottomRight(start_rect_.bottomRight());
   } else if (state_ == MOVE_BOTTOM_LEFT) {
     rect_ = resizeHelper(start_rect_,
                         start_rect_.topRight(),
                         start_rect_.bottomLeft(),
-                        event->position());
+                        mouse_position);
     rect_.moveTopRight(start_rect_.topRight());
   } else if (state_ == MOVE_BOTTOM_RIGHT) {
     rect_ = resizeHelper(start_rect_,
                         start_rect_.topLeft(),
                         start_rect_.bottomRight(),
-                        event->position());
+                        mouse_position);
     rect_.moveTopLeft(start_rect_.topLeft());
   } else if (state_ == MOVE_TOP_RIGHT) {
     rect_ = resizeHelper(start_rect_,
                         start_rect_.bottomLeft(),
                         start_rect_.topRight(),
-                        event->position());
+                        mouse_position);
     rect_.moveBottomLeft(start_rect_.bottomLeft());
   } else {
     qWarning("Unhandled state in PlaceableWindowProxy: %d", state_);

--- a/mapviz_plugins/src/placeable_window_proxy.cpp
+++ b/mapviz_plugins/src/placeable_window_proxy.cpp
@@ -160,7 +160,7 @@ bool PlaceableWindowProxy::handleMousePress(QMouseEvent *event)
   {
     start_rect_ = rect_;
     start_point_ = event->pos();
-    state_ = getNextState(event->localPos());
+    state_ = getNextState(event->position());
     return true;
   }
 
@@ -200,7 +200,7 @@ bool PlaceableWindowProxy::handleMouseMove(QMouseEvent *event)
 
   if (state_ == INACTIVE)
   {
-    if (!rect_.contains(event->localPos()))
+    if (!rect_.contains(event->position()))
     {
       if (has_cursor_)
       {
@@ -214,7 +214,7 @@ bool PlaceableWindowProxy::handleMouseMove(QMouseEvent *event)
     // cursor to indicate the state the user would enter by clicking.
 
     Qt::CursorShape shape;
-    switch(getNextState(event->localPos()))
+    switch(getNextState(event->position()))
     {
     case MOVE_TOP_LEFT:
     case MOVE_BOTTOM_RIGHT:
@@ -239,7 +239,7 @@ bool PlaceableWindowProxy::handleMouseMove(QMouseEvent *event)
     return true;
   }
 
-  QPointF dp = event->localPos() - start_point_;
+  QPointF dp = event->position() - start_point_;
 
   // todo: enforce minimum size & constrain aspect ratio for resizes.
   if (state_ == MOVE_ALL)
@@ -249,25 +249,25 @@ bool PlaceableWindowProxy::handleMouseMove(QMouseEvent *event)
     rect_ = resizeHelper(start_rect_,
                         start_rect_.bottomRight(),
                         start_rect_.topLeft(),
-                        event->localPos());
+                        event->position());
     rect_.moveBottomRight(start_rect_.bottomRight());
   } else if (state_ == MOVE_BOTTOM_LEFT) {
     rect_ = resizeHelper(start_rect_,
                         start_rect_.topRight(),
                         start_rect_.bottomLeft(),
-                        event->localPos());
+                        event->position());
     rect_.moveTopRight(start_rect_.topRight());
   } else if (state_ == MOVE_BOTTOM_RIGHT) {
     rect_ = resizeHelper(start_rect_,
                         start_rect_.topLeft(),
                         start_rect_.bottomRight(),
-                        event->localPos());
+                        event->position());
     rect_.moveTopLeft(start_rect_.topLeft());
   } else if (state_ == MOVE_TOP_RIGHT) {
     rect_ = resizeHelper(start_rect_,
                         start_rect_.bottomLeft(),
                         start_rect_.topRight(),
-                        event->localPos());
+                        event->position());
     rect_.moveBottomLeft(start_rect_.bottomLeft());
   } else {
     qWarning("Unhandled state in PlaceableWindowProxy: %d", state_);

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -28,6 +28,7 @@
 // *****************************************************************************
 
 #include <mapviz_plugins/plan_route_plugin.hpp>
+#include <mapviz/qt_mouse_event_compat.hpp>
 
 // QT libraries
 #include <QDateTime>
@@ -265,7 +266,7 @@ namespace mapviz_plugins
     int closest_point = 0;
     double closest_distance = std::numeric_limits<double>::max();
 
-    QPointF point = event->position();
+    QPointF point = mapviz::MouseEventPosition(event);
     stu::Transform transform;
     if (tf_manager_->GetTransform(target_frame_, stu::_wgs84_frame, transform))
     {
@@ -298,7 +299,7 @@ namespace mapviz_plugins
         return true;
       } else {
         is_mouse_down_ = true;
-        mouse_down_pos_ = event->position();
+        mouse_down_pos_ = mapviz::MouseEventPosition(event);
         mouse_down_time_ = QDateTime::currentMSecsSinceEpoch();
         return false;
       }
@@ -316,7 +317,7 @@ namespace mapviz_plugins
 
   bool PlanRoutePlugin::handleMouseRelease(QMouseEvent* event)
   {
-    QPointF point = event->position();
+    QPointF point = mapviz::MouseEventPosition(event);
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < waypoints_.size())
     {
       stu::Transform transform;
@@ -367,7 +368,7 @@ namespace mapviz_plugins
   {
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < waypoints_.size())
     {
-      QPointF point = event->position();
+      QPointF point = mapviz::MouseEventPosition(event);
       stu::Transform transform;
       if (tf_manager_->GetTransform(stu::_wgs84_frame, target_frame_, transform))
       {

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2014, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2026, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -265,7 +265,7 @@ namespace mapviz_plugins
     int closest_point = 0;
     double closest_distance = std::numeric_limits<double>::max();
 
-    QPointF point = event->localPos();
+    QPointF point = event->position();
     stu::Transform transform;
     if (tf_manager_->GetTransform(target_frame_, stu::_wgs84_frame, transform))
     {
@@ -298,7 +298,7 @@ namespace mapviz_plugins
         return true;
       } else {
         is_mouse_down_ = true;
-        mouse_down_pos_ = event->localPos();
+        mouse_down_pos_ = event->position();
         mouse_down_time_ = QDateTime::currentMSecsSinceEpoch();
         return false;
       }
@@ -316,7 +316,7 @@ namespace mapviz_plugins
 
   bool PlanRoutePlugin::handleMouseRelease(QMouseEvent* event)
   {
-    QPointF point = event->localPos();
+    QPointF point = event->position();
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < waypoints_.size())
     {
       stu::Transform transform;
@@ -367,7 +367,7 @@ namespace mapviz_plugins
   {
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < waypoints_.size())
     {
-      QPointF point = event->localPos();
+      QPointF point = event->position();
       stu::Transform transform;
       if (tf_manager_->GetTransform(stu::_wgs84_frame, target_frame_, transform))
       {

--- a/multires_image/CMakeLists.txt
+++ b/multires_image/CMakeLists.txt
@@ -21,19 +21,26 @@ set(MULTIRES_PLUGIN_AUTOGEN_INCLUDE_DIR
 find_package(ament_cmake REQUIRED)
 find_package(mapviz REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(qt_gui_cpp REQUIRED)
 find_package(rclcpp  REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(swri_transform_util  REQUIRED)
 find_package(swri_math_util REQUIRED)
 
-find_package(Qt6
+set(QT_VERSION_MAJOR "${qt_gui_cpp_USE_QT_MAJOR_VERSION}")
+set(MULTIRES_IMAGE_QT_COMPONENTS
+  Core
+  Gui
+  OpenGL
+  Widgets)
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND MULTIRES_IMAGE_QT_COMPONENTS OpenGLWidgets)
+endif()
+
+find_package(Qt${QT_VERSION_MAJOR}
   REQUIRED
   COMPONENTS
-    Core
-    Gui
-    OpenGL
-    OpenGLWidgets
-    Widgets)
+    ${MULTIRES_IMAGE_QT_COMPONENTS})
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -41,19 +48,24 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 set(MULTIRES_IMAGE_QT_LIBRARIES
-  Qt6::Core
-  Qt6::Gui
-  Qt6::OpenGL
-  Qt6::Widgets
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Gui
+  Qt${QT_VERSION_MAJOR}::OpenGL
+  Qt${QT_VERSION_MAJOR}::Widgets
 )
 
-list(APPEND MULTIRES_IMAGE_QT_LIBRARIES Qt6::OpenGLWidgets)
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND MULTIRES_IMAGE_QT_LIBRARIES Qt${QT_VERSION_MAJOR}::OpenGLWidgets)
+endif()
 set(MULTIRES_IMAGE_QT_EXPORT_DEPENDENCIES
-  Qt6Core
-  Qt6Gui
-  Qt6OpenGL
-  Qt6OpenGLWidgets
-  Qt6Widgets)
+  Qt${QT_VERSION_MAJOR}Core
+  Qt${QT_VERSION_MAJOR}Gui
+  Qt${QT_VERSION_MAJOR}OpenGL
+  Qt${QT_VERSION_MAJOR}Widgets)
+
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND MULTIRES_IMAGE_QT_EXPORT_DEPENDENCIES Qt${QT_VERSION_MAJOR}OpenGLWidgets)
+endif()
 
 # Build libtile_cache
 set(TILE_SRC_FILES
@@ -73,7 +85,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION 6)
+  QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC
@@ -116,7 +128,7 @@ set_target_properties(multires_widget PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION 6)
+  QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
 target_include_directories(multires_widget
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -145,7 +157,7 @@ set_target_properties(multires_view_node PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION 6)
+  QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
 target_link_libraries(multires_view_node PUBLIC
   multires_widget
   rclcpp::rclcpp
@@ -172,7 +184,7 @@ set_target_properties(${PROJECT_NAME}_plugin PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION 6)
+  QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
 
 target_include_directories(${PROJECT_NAME}_plugin
   PUBLIC

--- a/multires_image/CMakeLists.txt
+++ b/multires_image/CMakeLists.txt
@@ -26,20 +26,14 @@ find_package(tf2 REQUIRED)
 find_package(swri_transform_util  REQUIRED)
 find_package(swri_math_util REQUIRED)
 
-find_package(Qt5 QUIET COMPONENTS Core Gui OpenGL Widgets)
-if(Qt5_FOUND)
-  set(MULTIRES_IMAGE_QT_VERSION_MAJOR 5)
-else()
-  find_package(Qt6
-    REQUIRED
-    COMPONENTS
-      Core
-      Gui
-      OpenGL
-      OpenGLWidgets
-      Widgets)
-  set(MULTIRES_IMAGE_QT_VERSION_MAJOR 6)
-endif()
+find_package(Qt6
+  REQUIRED
+  COMPONENTS
+    Core
+    Gui
+    OpenGL
+    OpenGLWidgets
+    Widgets)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -47,27 +41,19 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 set(MULTIRES_IMAGE_QT_LIBRARIES
-  Qt${MULTIRES_IMAGE_QT_VERSION_MAJOR}::Core
-  Qt${MULTIRES_IMAGE_QT_VERSION_MAJOR}::Gui
-  Qt${MULTIRES_IMAGE_QT_VERSION_MAJOR}::OpenGL
-  Qt${MULTIRES_IMAGE_QT_VERSION_MAJOR}::Widgets
+  Qt6::Core
+  Qt6::Gui
+  Qt6::OpenGL
+  Qt6::Widgets
 )
 
-if(MULTIRES_IMAGE_QT_VERSION_MAJOR EQUAL 6)
-  list(APPEND MULTIRES_IMAGE_QT_LIBRARIES Qt6::OpenGLWidgets)
-  set(MULTIRES_IMAGE_QT_EXPORT_DEPENDENCIES
-    Qt6Core
-    Qt6Gui
-    Qt6OpenGL
-    Qt6OpenGLWidgets
-    Qt6Widgets)
-else()
-  set(MULTIRES_IMAGE_QT_EXPORT_DEPENDENCIES
-    Qt5Core
-    Qt5Gui
-    Qt5OpenGL
-    Qt5Widgets)
-endif()
+list(APPEND MULTIRES_IMAGE_QT_LIBRARIES Qt6::OpenGLWidgets)
+set(MULTIRES_IMAGE_QT_EXPORT_DEPENDENCIES
+  Qt6Core
+  Qt6Gui
+  Qt6OpenGL
+  Qt6OpenGLWidgets
+  Qt6Widgets)
 
 # Build libtile_cache
 set(TILE_SRC_FILES
@@ -87,7 +73,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION ${MULTIRES_IMAGE_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC
@@ -130,7 +116,7 @@ set_target_properties(multires_widget PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION ${MULTIRES_IMAGE_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 target_include_directories(multires_widget
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -159,7 +145,7 @@ set_target_properties(multires_view_node PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION ${MULTIRES_IMAGE_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 target_link_libraries(multires_view_node PUBLIC
   multires_widget
   rclcpp::rclcpp
@@ -186,7 +172,7 @@ set_target_properties(${PROJECT_NAME}_plugin PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION ${MULTIRES_IMAGE_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 
 target_include_directories(${PROJECT_NAME}_plugin
   PUBLIC

--- a/multires_image/package.xml
+++ b/multires_image/package.xml
@@ -13,20 +13,21 @@
   <url>https://github.com/swri-robotics/mapviz</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>qt6-qmake</buildtool_depend>
-
-  <depend>libqt6-core</depend>
-  <build_depend>libqt6-opengl-dev</build_depend>
+  <build_depend>qt-base-dev</build_depend>
+  <build_export_depend>qt-base-dev</build_export_depend>
 
   <depend>geometry_msgs</depend>
   <depend>mapviz</depend>
   <depend>pluginlib</depend>
+  <depend>qt_gui_cpp</depend>
   <depend>rclcpp</depend>
   <depend>swri_math_util</depend>
   <depend>swri_transform_util</depend>
   <depend>tf2</depend>
 
-  <exec_depend>libqt6-opengl</exec_depend>
+  <exec_depend>libqtcore</exec_depend>
+  <exec_depend>libqtgui</exec_depend>
+  <exec_depend>libqtopengl</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <export>

--- a/multires_image/package.xml
+++ b/multires_image/package.xml
@@ -13,10 +13,10 @@
   <url>https://github.com/swri-robotics/mapviz</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>qt5-qmake</buildtool_depend>
+  <buildtool_depend>qt6-qmake</buildtool_depend>
 
-  <depend>libqt5-core</depend>
-  <build_depend>libqt5-opengl-dev</build_depend>
+  <depend>libqt6-core</depend>
+  <build_depend>libqt6-opengl-dev</build_depend>
 
   <depend>geometry_msgs</depend>
   <depend>mapviz</depend>
@@ -26,7 +26,7 @@
   <depend>swri_transform_util</depend>
   <depend>tf2</depend>
 
-  <exec_depend>libqt5-opengl</exec_depend>
+  <exec_depend>libqt6-opengl</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <export>

--- a/multires_image/src/QGLMap.cpp
+++ b/multires_image/src/QGLMap.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2014, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2026, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -185,8 +185,8 @@ void QGLMap::paintGL()
 
 void QGLMap::mousePressEvent(QMouseEvent* e)
 {
-  m_mouseDownX = e->x();
-  m_mouseDownY = e->y();
+  m_mouseDownX = e->position().x();
+  m_mouseDownY = e->position().y();
   m_mouseDown = true;
 
   update();
@@ -207,7 +207,7 @@ void QGLMap::mouseReleaseEvent(QMouseEvent* e)
 void QGLMap::mouseMoveEvent(QMouseEvent* e)
 {
   if (m_mouseDown)
-    MousePan(e->x(), e->y());
+    MousePan(e->position().x(), e->position().y());
 }
 
 void QGLMap::MousePan(int x, int y)

--- a/multires_image/src/QGLMap.cpp
+++ b/multires_image/src/QGLMap.cpp
@@ -29,6 +29,8 @@
 
 #include <multires_image/QGLMap.hpp>
 
+#include <mapviz/qt_mouse_event_compat.hpp>
+
 // C++ standard libraries
 #include <cmath>
 
@@ -185,8 +187,9 @@ void QGLMap::paintGL()
 
 void QGLMap::mousePressEvent(QMouseEvent* e)
 {
-  m_mouseDownX = e->position().x();
-  m_mouseDownY = e->position().y();
+  const QPointF mouse_position = mapviz::MouseEventPosition(e);
+  m_mouseDownX = mouse_position.x();
+  m_mouseDownY = mouse_position.y();
   m_mouseDown = true;
 
   update();
@@ -206,8 +209,10 @@ void QGLMap::mouseReleaseEvent(QMouseEvent* e)
 
 void QGLMap::mouseMoveEvent(QMouseEvent* e)
 {
-  if (m_mouseDown)
-    MousePan(e->position().x(), e->position().y());
+  if (m_mouseDown) {
+    const QPointF mouse_position = mapviz::MouseEventPosition(e);
+    MousePan(mouse_position.x(), mouse_position.y());
+  }
 }
 
 void QGLMap::MousePan(int x, int y)

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -32,14 +32,7 @@ find_package(swri_math_util REQUIRED)
 find_package(swri_transform_util REQUIRED)
 find_package(tf2 REQUIRED)
 
-find_package(Qt5 QUIET COMPONENTS Core Gui Network OpenGL Widgets)
-if(Qt5_FOUND)
-  set(TILE_MAP_QT_VERSION_MAJOR 5)
-else()
-  find_package(Qt6 REQUIRED COMPONENTS Core Gui Network OpenGL Widgets)
-  set(TILE_MAP_QT_VERSION_MAJOR 6)
-  find_package(Qt6 REQUIRED COMPONENTS OpenGLWidgets)
-endif()
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Network OpenGL OpenGLWidgets Widgets)
 
 find_package(jsoncpp QUIET CONFIG)
 if(NOT TARGET jsoncpp_lib)
@@ -83,37 +76,28 @@ set(QT_HEADERS
 )
 
 set(TILE_MAP_QT_LIBRARIES
-  Qt${TILE_MAP_QT_VERSION_MAJOR}::Network
-  Qt${TILE_MAP_QT_VERSION_MAJOR}::Core
-  Qt${TILE_MAP_QT_VERSION_MAJOR}::Gui
-  Qt${TILE_MAP_QT_VERSION_MAJOR}::OpenGL
-  Qt${TILE_MAP_QT_VERSION_MAJOR}::Widgets
+  Qt6::Network
+  Qt6::Core
+  Qt6::Gui
+  Qt6::OpenGL
+  Qt6::Widgets
 )
 
-if(TILE_MAP_QT_VERSION_MAJOR EQUAL 6)
-  list(APPEND TILE_MAP_QT_LIBRARIES Qt6::OpenGLWidgets)
-  set(TILE_MAP_QT_EXPORT_DEPENDENCIES
-    Qt6Network
-    Qt6Core
-    Qt6Gui
-    Qt6OpenGL
-    Qt6OpenGLWidgets
-    Qt6Widgets)
-else()
-  set(TILE_MAP_QT_EXPORT_DEPENDENCIES
-    Qt5Network
-    Qt5Core
-    Qt5Gui
-    Qt5OpenGL
-    Qt5Widgets)
-endif()
+list(APPEND TILE_MAP_QT_LIBRARIES Qt6::OpenGLWidgets)
+set(TILE_MAP_QT_EXPORT_DEPENDENCIES
+  Qt6Network
+  Qt6Core
+  Qt6Gui
+  Qt6OpenGL
+  Qt6OpenGLWidgets
+  Qt6Widgets)
 
 add_library(${PROJECT_NAME} ${TILE_SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION ${TILE_MAP_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -141,7 +125,7 @@ set_target_properties(${PROJECT_NAME}_plugin PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION ${TILE_MAP_QT_VERSION_MAJOR})
+  QT_MAJOR_VERSION 6)
 target_link_libraries(${PROJECT_NAME}_plugin ${PROJECT_NAME})
 
 install(DIRECTORY include/

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -27,12 +27,18 @@ endfunction()
 find_package(ament_cmake REQUIRED)
 find_package(mapviz REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(qt_gui_cpp REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(swri_math_util REQUIRED)
 find_package(swri_transform_util REQUIRED)
 find_package(tf2 REQUIRED)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Network OpenGL OpenGLWidgets Widgets)
+set(QT_VERSION_MAJOR "${qt_gui_cpp_USE_QT_MAJOR_VERSION}")
+set(TILE_MAP_QT_COMPONENTS Core Gui Network OpenGL Widgets)
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND TILE_MAP_QT_COMPONENTS OpenGLWidgets)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${TILE_MAP_QT_COMPONENTS})
 
 find_package(jsoncpp QUIET CONFIG)
 if(NOT TARGET jsoncpp_lib)
@@ -76,28 +82,33 @@ set(QT_HEADERS
 )
 
 set(TILE_MAP_QT_LIBRARIES
-  Qt6::Network
-  Qt6::Core
-  Qt6::Gui
-  Qt6::OpenGL
-  Qt6::Widgets
+  Qt${QT_VERSION_MAJOR}::Network
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Gui
+  Qt${QT_VERSION_MAJOR}::OpenGL
+  Qt${QT_VERSION_MAJOR}::Widgets
 )
 
-list(APPEND TILE_MAP_QT_LIBRARIES Qt6::OpenGLWidgets)
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND TILE_MAP_QT_LIBRARIES Qt${QT_VERSION_MAJOR}::OpenGLWidgets)
+endif()
 set(TILE_MAP_QT_EXPORT_DEPENDENCIES
-  Qt6Network
-  Qt6Core
-  Qt6Gui
-  Qt6OpenGL
-  Qt6OpenGLWidgets
-  Qt6Widgets)
+  Qt${QT_VERSION_MAJOR}Network
+  Qt${QT_VERSION_MAJOR}Core
+  Qt${QT_VERSION_MAJOR}Gui
+  Qt${QT_VERSION_MAJOR}OpenGL
+  Qt${QT_VERSION_MAJOR}Widgets)
+
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND TILE_MAP_QT_EXPORT_DEPENDENCIES Qt${QT_VERSION_MAJOR}OpenGLWidgets)
+endif()
 
 add_library(${PROJECT_NAME} SHARED ${TILE_SRC_FILES} ${QT_HEADERS})
 set_target_properties(${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION 6)
+  QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -125,7 +136,7 @@ set_target_properties(${PROJECT_NAME}_plugin PROPERTIES
   AUTOMOC ON
   AUTOUIC ON
   AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  QT_MAJOR_VERSION 6)
+  QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
 target_link_libraries(${PROJECT_NAME}_plugin ${PROJECT_NAME})
 
 install(DIRECTORY include/

--- a/tile_map/package.xml
+++ b/tile_map/package.xml
@@ -15,11 +15,11 @@
   <url>https://github.com/swri-robotics/mapviz</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>qt5-qmake</buildtool_depend>
+  <buildtool_depend>qt6-qmake</buildtool_depend>
 
   <build_depend>libjsoncpp-dev</build_depend>
-  <depend>libqt5-core</depend>
-  <build_depend>libqt5-opengl-dev</build_depend>
+  <depend>libqt6-core</depend>
+  <build_depend>libqt6-opengl-dev</build_depend>
 
   <depend>mapviz</depend>
   <depend>pluginlib</depend>
@@ -30,7 +30,7 @@
   <depend>yaml-cpp</depend>
 
   <exec_depend>libjsoncpp</exec_depend>
-  <exec_depend>libqt5-opengl</exec_depend>
+  <exec_depend>libqt6-opengl</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tile_map/package.xml
+++ b/tile_map/package.xml
@@ -15,14 +15,13 @@
   <url>https://github.com/swri-robotics/mapviz</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>qt6-qmake</buildtool_depend>
-
   <build_depend>libjsoncpp-dev</build_depend>
-  <depend>libqt6-core</depend>
-  <build_depend>libqt6-opengl-dev</build_depend>
+  <build_depend>qt-base-dev</build_depend>
+  <build_export_depend>qt-base-dev</build_export_depend>
 
   <depend>mapviz</depend>
   <depend>pluginlib</depend>
+  <depend>qt_gui_cpp</depend>
   <depend>rclcpp</depend>
   <depend>swri_math_util</depend>
   <depend>swri_transform_util</depend>
@@ -30,7 +29,9 @@
   <depend>yaml-cpp</depend>
 
   <exec_depend>libjsoncpp</exec_depend>
-  <exec_depend>libqt6-opengl</exec_depend>
+  <exec_depend>libqtcore</exec_depend>
+  <exec_depend>libqtgui</exec_depend>
+  <exec_depend>libqtopengl</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tile_map/src/bing_source.cpp
+++ b/tile_map/src/bing_source.cpp
@@ -30,7 +30,6 @@
 
 #include <tile_map/bing_source.hpp>
 
-#include <QRegExp>
 #include <QString>
 
 #include <random>


### PR DESCRIPTION
Adds support for Qt6 which is needed for releasing to Ubuntu 26.04 and ROS 2 Lyrical. Incidentally cleans up deprecated headers that were causing large numbers of build warnings.