### PR TITLE
Fix plugin export

### DIFF
--- a/mapviz/CMakeLists.txt
+++ b/mapviz/CMakeLists.txt
@@ -268,6 +268,8 @@ install(FILES plugin.xml
   DESTINATION share/${PROJECT_NAME} 
 )
 
+pluginlib_export_plugin_description_file(rqt_gui "plugin.xml")
+
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   geometry_msgs

--- a/mapviz/plugin.xml
+++ b/mapviz/plugin.xml
@@ -1,4 +1,4 @@
-<library path="lib/librqt_mapviz">
+<library path="rqt_mapviz">
     <class name="mapviz/rqt_mapviz" type="mapviz::RqtMapviz" base_class_type="rqt_gui_cpp::Plugin">
         <description>
             Mapviz is a ROS based visualization tool with a plug-in system similar to RVIZ focused on visualizing 2D data.

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
     Qt5Widgets)
 endif()
 
-add_library(${PROJECT_NAME} ${TILE_SRC_FILES})
+add_library(${PROJECT_NAME} SHARED ${TILE_SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
   AUTOUIC ON

--- a/tile_map/CMakeLists.txt
+++ b/tile_map/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
     Qt5Widgets)
 endif()
 
-add_library(${PROJECT_NAME} SHARED ${TILE_SRC_FILES})
+add_library(${PROJECT_NAME} SHARED ${TILE_SRC_FILES} ${QT_HEADERS})
 set_target_properties(${PROJECT_NAME} PROPERTIES
   AUTOMOC ON
   AUTOUIC ON

--- a/tile_map/include/tile_map/stadia_source.hpp
+++ b/tile_map/include/tile_map/stadia_source.hpp
@@ -31,7 +31,7 @@
 #ifndef TILE_MAP_STADIA_SOURCE_H
 #define TILE_MAP_STADIA_SOURCE_H
 
-#include "tile_source.hpp"
+#include <tile_map/tile_source.hpp>
 
 #include <string>
 


### PR DESCRIPTION
Fixed rqt_gui plugin export, so that rqt_gui can load mapviz as a Visualization plugin once again.

Fixed tile_map error that caused the plugin not to load due to missing Qt build steps.