### PR TITLE
Tilemap Plugin Peformance/Stability Improvements

### DIFF
--- a/tile_map/include/tile_map/image_cache.hpp
+++ b/tile_map/include/tile_map/image_cache.hpp
@@ -53,7 +53,7 @@ namespace tile_map
   class Image
   {
   public:
-    Image(const QString& uri, size_t uri_hash);
+    Image(const QString& uri, size_t uri_hash, uint64_t priority = 0);
     ~Image() = default;
 
     QString Uri() const { return uri_; }
@@ -67,14 +67,11 @@ namespace tile_map
     void AddFailure();
     bool Failed() const { return failed_; }
 
-    void SetBasePriority(int32_t priority) { base_priority_ = priority; }
-    int32_t BasePriority() const { return base_priority_; }
-
     void SetLastRequestedFrame(uint64_t frame) { last_requested_frame_ = frame; }
     uint64_t LastRequestedFrame() const { return last_requested_frame_; }
 
-    void SetLastRequestedTick(uint64_t tick) { last_requested_tick_ = tick; }
-    uint64_t LastRequestedTick() const { return last_requested_tick_; }
+    void SetPriority(uint64_t priority) { priority_ = priority; }
+    uint64_t Priority() const { return priority_; }
 
     bool Loading() const { return loading_; }
     void SetLoading(bool loading) { loading_ = loading; }
@@ -91,9 +88,8 @@ namespace tile_map
     bool loading_;
     int32_t failures_;
     bool failed_;
-    int32_t base_priority_ = 0;
     uint64_t last_requested_frame_ = 0;
-    uint64_t last_requested_tick_ = 0;
+    uint64_t priority_ = 0;
 
     mutable std::shared_ptr<QImage> image_;
     QByteArray pending_data_;

--- a/tile_map/include/tile_map/image_cache.hpp
+++ b/tile_map/include/tile_map/image_cache.hpp
@@ -31,10 +31,10 @@
 #define TILE_MAP_IMAGE_CACHE_HPP_
 
 #include <string>
-#include <limits>
 
 #include <rclcpp/logger.hpp>
 
+#include <QByteArray>
 #include <QCache>
 #include <QImage>
 #include <QMap>
@@ -53,7 +53,7 @@ namespace tile_map
   class Image
   {
   public:
-    Image(const QString& uri, size_t uri_hash, uint64_t priority = 0);
+    Image(const QString& uri, size_t uri_hash);
     ~Image() = default;
 
     QString Uri() const { return uri_; }
@@ -67,30 +67,37 @@ namespace tile_map
     void AddFailure();
     bool Failed() const { return failed_; }
 
-    void IncreasePriority()
-    {
-      if (priority_ < std::numeric_limits<uint64_t>::max())
-      {
-        priority_++;
-      }
-    }
-    void SetPriority(uint64_t priority) { priority_ = priority; }
-    uint64_t Priority() const { return priority_; }
+    void SetBasePriority(int32_t priority) { base_priority_ = priority; }
+    int32_t BasePriority() const { return base_priority_; }
+
+    void SetLastRequestedFrame(uint64_t frame) { last_requested_frame_ = frame; }
+    uint64_t LastRequestedFrame() const { return last_requested_frame_; }
+
+    void SetLastRequestedTick(uint64_t tick) { last_requested_tick_ = tick; }
+    uint64_t LastRequestedTick() const { return last_requested_tick_; }
 
     bool Loading() const { return loading_; }
     void SetLoading(bool loading) { loading_ = loading; }
 
+    void SetDecodedImage(std::shared_ptr<QImage> img) { image_ = img; }
+
+    bool HasPendingData() const { return has_pending_data_; }
+    void SetPendingData(const QByteArray& data);
+    QByteArray TakePendingData();
+
   private:
     QString uri_;
-
     size_t uri_hash_;
-
     bool loading_;
     int32_t failures_;
     bool failed_;
-    uint64_t priority_;
+    int32_t base_priority_ = 0;
+    uint64_t last_requested_frame_ = 0;
+    uint64_t last_requested_tick_ = 0;
 
     mutable std::shared_ptr<QImage> image_;
+    QByteArray pending_data_;
+    bool has_pending_data_ = false;
 
     static const int MAXIMUM_FAILURES;
   };
@@ -107,6 +114,8 @@ namespace tile_map
     ~ImageCache() override;
 
     ImagePtr GetImage(size_t uri_hash, const QString& uri, int32_t priority = 0);
+
+    void IncrementFrame();
 
     void SetLogger(rclcpp::Logger logger);
 
@@ -129,6 +138,7 @@ namespace tile_map
     QMutex unprocessed_mutex_;
     bool exit_;
 
+    uint64_t frame_;
     uint64_t tick_;
 
     CacheThread* cache_thread_;
@@ -157,7 +167,7 @@ namespace tile_map
 
     private:
       ImageCache* image_cache_;
-      QMutex waiting_mutex_;
+      QSemaphore waiting_semaphore_;
 
       static const int MAXIMUM_SEQUENTIAL_REQUESTS;
   };

--- a/tile_map/include/tile_map/texture_cache.hpp
+++ b/tile_map/include/tile_map/texture_cache.hpp
@@ -65,6 +65,8 @@ namespace tile_map
     TexturePtr GetTexture(size_t url_hash, const QString& url, bool& failed, int priority);
     void AddTexture(const TexturePtr& texture);
 
+    void IncrementFrame();
+
     void SetLogger(rclcpp::Logger logger);
 
     void Clear();

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -134,8 +134,10 @@ namespace tile_map
 
   void ImageCache::IncrementFrame()
   {
+    // As the user scrolls through many viewports, thousands of tile requests can accumulate.
     // Remove any unprocessed tile requests that aren't visible in the
-    // current viewport frame request
+    // current viewport frame request (unless we've already received a server reply and are actively
+    // decoding the image)
     unprocessed_mutex_.lock();
     for (auto it = unprocessed_.begin(); it != unprocessed_.end(); ) {
       if (!it.value()->Loading() && !it.value()->HasPendingData() &&
@@ -388,10 +390,7 @@ namespace tile_map
 
         ImagePtr image = images.front();
         image_cache_->unprocessed_mutex_.lock();
-        // As the user scrolls through many viewports, thousands of tile requests can accumulate.
-        // We're assuming only the current frame is really important to cache and anything unprocessed
-        // outside of that can be dropped (unless we've already received a server reply and are actively
-        // decoding the image)
+        // Request images only if they aren't currently pending, loading, or previously failed
         if (!image->Loading() && !image->Failed() && !image->HasPendingData() &&
             image_cache_->unprocessed_.value(image->UriHash()) == image)
         {

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -43,18 +43,18 @@ namespace tile_map
 {
   bool ComparePriority(const ImagePtr left, const ImagePtr right)
   {
-    return (static_cast<uint64_t>(left->BasePriority()) + left->LastRequestedTick()) >
-           (static_cast<uint64_t>(right->BasePriority()) + right->LastRequestedTick());
+    return left->Priority() > right->Priority();
   }
 
   const int Image::MAXIMUM_FAILURES = 5;
 
-  Image::Image(const QString& uri, size_t uri_hash) :
+  Image::Image(const QString& uri, size_t uri_hash, uint64_t priority) :
     uri_(uri),
     uri_hash_(uri_hash),
     loading_(false),
     failures_(0),
-    failed_(false)
+    failed_(false),
+    priority_(priority)
   {
   }
 
@@ -196,21 +196,16 @@ namespace tile_map
       {
         if (!unprocessed_.contains(uri_hash))
         {
-          image->SetBasePriority(priority);
           image->SetLastRequestedFrame(frame_);
-          image->SetLastRequestedTick(tick_++);
+          image->SetPriority(tick_++);
           unprocessed_[uri_hash] = image;
           uri_to_hash_map_[uri] = uri_hash;
           cache_thread_->notify();
         }
         else
         {
-          // Tile has been re-requested but still not processed.
-          // Update priority (in case it changes), and increase tick count to increase the
-          // overall priority of this tile (sum of base priority and ticks).
-          image->SetBasePriority(priority);
           image->SetLastRequestedFrame(frame_);
-          image->SetLastRequestedTick(tick_++);
+          image->SetPriority(tick_++);
         }
       }
       else

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -43,24 +43,38 @@ namespace tile_map
 {
   bool ComparePriority(const ImagePtr left, const ImagePtr right)
   {
-    return left->Priority() > right->Priority();
+    return (static_cast<uint64_t>(left->BasePriority()) + left->LastRequestedTick()) >
+           (static_cast<uint64_t>(right->BasePriority()) + right->LastRequestedTick());
   }
 
   const int Image::MAXIMUM_FAILURES = 5;
 
-  Image::Image(const QString& uri, size_t uri_hash, uint64_t priority) :
+  Image::Image(const QString& uri, size_t uri_hash) :
     uri_(uri),
     uri_hash_(uri_hash),
     loading_(false),
     failures_(0),
-    failed_(false),
-    priority_(priority)
+    failed_(false)
   {
   }
 
   void Image::InitializeImage()
   {
     image_ = std::make_shared<QImage>();
+  }
+
+  void Image::SetPendingData(const QByteArray& data)
+  {
+    pending_data_ = data;
+    has_pending_data_ = true;
+  }
+
+  QByteArray Image::TakePendingData()
+  {
+    QByteArray result;
+    std::swap(result, pending_data_);
+    has_pending_data_ = false;
+    return result;
   }
 
   void Image::ClearImage()
@@ -83,6 +97,7 @@ namespace tile_map
     cache_dir_(cache_dir),
     cache_(size),
     exit_(false),
+    frame_(0),
     tick_(0),
     cache_thread_(new CacheThread(this)),
     network_request_semaphore_(MAXIMUM_NETWORK_REQUESTS),
@@ -96,18 +111,41 @@ namespace tile_map
     connect(cache_thread_, SIGNAL(RequestImage(QString)), this, SLOT(ProcessRequest(QString)));
 
     cache_thread_->start();
-    cache_thread_->setPriority(QThread::NormalPriority);
+    cache_thread_->setPriority(QThread::LowPriority);
   }
 
   ImageCache::~ImageCache()
   {
-    // After setting our exit flag to true, release any conditions the cache thread
-    // might be waiting on so that it will exit.
+    // Disconnect signals before touching the thread or network manager in
+    // case of any cleanup race conditions
+    disconnect(&network_manager_, SIGNAL(finished(QNetworkReply*)),
+        this, SLOT(ProcessReply(QNetworkReply*)));
+    disconnect(cache_thread_, SIGNAL(RequestImage(QString)),
+        this, SLOT(ProcessRequest(QString)));
+
     exit_ = true;
     cache_thread_->notify();
     network_request_semaphore_.release(MAXIMUM_NETWORK_REQUESTS);
     cache_thread_->wait();
     delete cache_thread_;
+  }
+
+  void ImageCache::IncrementFrame()
+  {
+    // Remove any unprocessed tile requests that aren't visible in the
+    // current viewport frame request
+    unprocessed_mutex_.lock();
+    for (auto it = unprocessed_.begin(); it != unprocessed_.end(); ) {
+      if (!it.value()->Loading() && !it.value()->HasPendingData() &&
+          it.value()->LastRequestedFrame() < frame_) {
+        uri_to_hash_map_.remove(it.value()->Uri());
+        it = unprocessed_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    unprocessed_mutex_.unlock();
+    frame_++;
   }
 
   void ImageCache::Clear()
@@ -158,22 +196,21 @@ namespace tile_map
       {
         if (!unprocessed_.contains(uri_hash))
         {
-          // Set an image's starting priority so that it's higher than the
-          // starting priority of every other image we've requested so
-          // far; that ensures that, all other things being equal, the
-          // most recently requested images will be loaded first.
-          image->SetPriority(priority + tick_++);
+          image->SetBasePriority(priority);
+          image->SetLastRequestedFrame(frame_);
+          image->SetLastRequestedTick(tick_++);
           unprocessed_[uri_hash] = image;
           uri_to_hash_map_[uri] = uri_hash;
           cache_thread_->notify();
         }
         else
         {
-          // Every time an image is requested but hasn't been loaded yet,
-          // increase its priority.  Tiles within the visible area will
-          // be requested more frequently, so this will make them load faster
-          // than tiles the user can't see.
-          image->SetPriority(priority + tick_++);
+          // Tile has been re-requested but still not processed.
+          // Update priority (in case it changes), and increase tick count to increase the
+          // overall priority of this tile (sum of base priority and ticks).
+          image->SetBasePriority(priority);
+          image->SetLastRequestedFrame(frame_);
+          image->SetLastRequestedTick(tick_++);
         }
       }
       else
@@ -211,40 +248,50 @@ namespace tile_map
   {
     QString url = reply->url().toString();
 
-    ImagePtr image;
+    // Store raw bytes under the mutex
+    // CacheThread decodes instead of the higher priority main thread.
     unprocessed_mutex_.lock();
 
-    size_t hash = uri_to_hash_map_[url];
-    image = unprocessed_[hash];
+    size_t hash = uri_to_hash_map_.value(url, 0);
+    ImagePtr image;
+    if (uri_to_hash_map_.contains(url)) {
+      image = unprocessed_.value(hash);
+    }
+
+    bool keep_in_queue = false;
     if (image)
     {
       if (reply->error() == QNetworkReply::NoError)
       {
-        QByteArray data = reply->readAll();
-        image->InitializeImage();
-        if (!image->GetImage()->loadFromData(data))
-        {
-          image->ClearImage();
-          image->AddFailure();
-        }
+        image->SetPendingData(reply->readAll());
+        keep_in_queue = true;  // CacheThread will decode then remove
       }
       else
       {
         auto steady_clock = rclcpp::Clock();
-        RCLCPP_ERROR_THROTTLE(logger_, steady_clock, 1.0, "NETWORK ERROR: %s", reply->errorString().toStdString().c_str());
+        RCLCPP_ERROR_THROTTLE(logger_, steady_clock, 1000,
+          "tile_map: network error for %s: %s",
+          url.toStdString().c_str(), reply->errorString().toStdString().c_str());
         image->AddFailure();
       }
-    }
-
-    unprocessed_.remove(hash);
-    uri_to_hash_map_.remove(url);
-    if (image)
-    {
       image->SetLoading(false);
     }
+    else
+    {
+      RCLCPP_WARN(logger_, "tile_map: reply for unknown URL (already evicted?): %s",
+        url.toStdString().c_str());
+    }
+
+    if (!keep_in_queue && uri_to_hash_map_.contains(url)) {
+      unprocessed_.remove(hash);
+      uri_to_hash_map_.remove(url);
+    }
+
     network_request_semaphore_.release();
 
     unprocessed_mutex_.unlock();
+
+    cache_thread_->notify();
 
     reply->deleteLater();
   }
@@ -253,14 +300,18 @@ namespace tile_map
 
   CacheThread::CacheThread(ImageCache* parent) :
     image_cache_(parent),
-    waiting_mutex_()
+    waiting_semaphore_(0)
   {
-    waiting_mutex_.lock();
   }
 
   void CacheThread::notify()
   {
-    waiting_mutex_.unlock();
+    // Using a semaphore here to safely call release from any thread. There is a race
+    // here where multiple threads can see available as 0, but this just causes extra
+    // wakeups and is effectively harmless
+    if (waiting_semaphore_.available() == 0) {
+      waiting_semaphore_.release();
+    }
   }
 
   void CacheThread::run()
@@ -268,14 +319,55 @@ namespace tile_map
     while (!image_cache_->exit_)
     {
       // Wait until we're told there are images we need to request.
-      waiting_mutex_.lock();
+      waiting_semaphore_.acquire();
+
+      // Decode any tiles whose network bytes have arrived (set by ProcessReply).
+      // This keeps JPEG/PNG decode off the main thread so it cannot block the
+      // Qt event loop and delay render frames.
+      while (!image_cache_->exit_)
+      {
+        image_cache_->unprocessed_mutex_.lock();
+        ImagePtr to_decode;
+        for (auto& img : image_cache_->unprocessed_) {
+          if (img->HasPendingData()) { to_decode = img; break; }
+        }
+        QByteArray raw_data;
+        if (to_decode) {
+          raw_data = to_decode->TakePendingData();
+        }
+        image_cache_->unprocessed_mutex_.unlock();
+
+        if (!to_decode) { break; }
+
+        auto decoded = std::make_shared<QImage>();
+        if (!decoded->loadFromData(raw_data))
+        {
+          decoded.reset();
+          RCLCPP_WARN(image_cache_->logger_, "tile_map: failed to decode image from %s",
+            to_decode->Uri().toStdString().c_str());
+        }
+
+        image_cache_->unprocessed_mutex_.lock();
+        if (image_cache_->unprocessed_.value(to_decode->UriHash()) == to_decode)
+        {
+          if (decoded) {
+            to_decode->SetDecodedImage(decoded);
+          } else {
+            to_decode->AddFailure();
+          }
+          image_cache_->unprocessed_.remove(to_decode->UriHash());
+          image_cache_->uri_to_hash_map_.remove(to_decode->Uri());
+        }
+        image_cache_->unprocessed_mutex_.unlock();
+      }
 
       // Next, get all of them and sort them by priority.
+      // Sort under the mutex guard to prevent seg faults from occurring
+      // during comparisons in other threads
       image_cache_->unprocessed_mutex_.lock();
       QList<ImagePtr> images = image_cache_->unprocessed_.values();
-      image_cache_->unprocessed_mutex_.unlock();
-
       std::sort(images.begin(), images.end(), ComparePriority);
+      image_cache_->unprocessed_mutex_.unlock();
 
       // Go through all of them and request them.  Qt's network manager will
       // only handle six simultaneous requests at once, so we use a semaphore
@@ -291,14 +383,19 @@ namespace tile_map
 
         ImagePtr image = images.front();
         image_cache_->unprocessed_mutex_.lock();
-        if (!image->Loading() && !image->Failed())
+        // As the user scrolls through many viewports, thousands of tile requests can accumulate.
+        // We're assuming only the current frame is really important to cache and anything unprocessed
+        // outside of that can be dropped (unless we've already received a server reply and are actively
+        // decoding the image)
+        if (!image->Loading() && !image->Failed() && !image->HasPendingData() &&
+            image_cache_->unprocessed_.value(image->UriHash()) == image)
         {
           count++;
           image->SetLoading(true);
           images.pop_front();
 
           QString uri = image->Uri();
-          size_t hash = image_cache_->uri_to_hash_map_[uri];
+          size_t hash = image_cache_->uri_to_hash_map_.value(uri);
           if (uri.startsWith(QString("file:///")))
           {
             image->InitializeImage();
@@ -313,6 +410,7 @@ namespace tile_map
             image_cache_->uri_to_hash_map_.remove(uri);
             image->SetLoading(false);
             image_cache_->network_request_semaphore_.release();
+            image_cache_->cache_thread_->notify();
           }
           else
           {
@@ -322,13 +420,9 @@ namespace tile_map
         else
         {
           images.pop_front();
+          image_cache_->network_request_semaphore_.release();
         }
         image_cache_->unprocessed_mutex_.unlock();
-
-      }
-      if (!images.empty())
-      {
-        waiting_mutex_.unlock();
       }
     }
   }

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -123,6 +123,8 @@ namespace tile_map
     disconnect(cache_thread_, SIGNAL(RequestImage(QString)),
         this, SLOT(ProcessRequest(QString)));
 
+    // After setting our exit flag to true, release any conditions the cache thread
+    // might be waiting on so that it will exit.
     exit_ = true;
     cache_thread_->notify();
     network_request_semaphore_.release(MAXIMUM_NETWORK_REQUESTS);

--- a/tile_map/src/image_cache.cpp
+++ b/tile_map/src/image_cache.cpp
@@ -196,16 +196,24 @@ namespace tile_map
       {
         if (!unprocessed_.contains(uri_hash))
         {
+          // Set an image's starting priority so that it's higher than the
+          // starting priority of every other image we've requested so
+          // far; that ensures that, all other things being equal, the
+          // most recently requested images will be loaded first.
           image->SetLastRequestedFrame(frame_);
-          image->SetPriority(tick_++);
+          image->SetPriority(priority + tick_++);
           unprocessed_[uri_hash] = image;
           uri_to_hash_map_[uri] = uri_hash;
           cache_thread_->notify();
         }
         else
         {
+          // Every time an image is requested but hasn't been loaded yet,
+          // increase its priority.  Tiles within the visible area will
+          // be requested more frequently, so this will make them load faster
+          // than tiles the user can't see.
           image->SetLastRequestedFrame(frame_);
-          image->SetPriority(tick_++);
+          image->SetPriority(priority + tick_++);
         }
       }
       else

--- a/tile_map/src/texture_cache.cpp
+++ b/tile_map/src/texture_cache.cpp
@@ -131,6 +131,11 @@ namespace tile_map
     }
   }
 
+  void TextureCache::IncrementFrame()
+  {
+    image_cache_->IncrementFrame();
+  }
+
   void TextureCache::SetLogger(rclcpp::Logger logger)
   {
     logger_ = logger;

--- a/tile_map/src/tile_map_view.cpp
+++ b/tile_map/src/tile_map_view.cpp
@@ -218,6 +218,8 @@ namespace tile_map
           }
         }
       }
+
+      tile_cache_->IncrementFrame();
     }
   }
 


### PR DESCRIPTION
I've been having more and more issues with mapviz crashing as I've been using it for more simulation intensive (especially GPU) based projects. Most of my issues went away when disabling the tile_map plugin so this PR is an attempt to address the problems I was running into. The main issues I'm addressing (both occurring only when tile_map plugin was enabled):

-  Mapviz crashes
- Temporarily unresponsive Mapviz window

Summary of Changes:
- **Fixed seg fault causing mapviz to crash**: The most important fix was moving `std::sort(images.begin(), images.end(), ComparePriority);` inside the mutex check. Without that mapviz would crash on me pretty consistently when under heavy load. This is because there was a comparison check in another thread that was accessing out of bounds memory if checking the unprocessed queue while it was being sorted.
- Lowered the priority of the cache thread. I'm not sure how much performance improvement I got from doing this, but it at least should prioritize the main thread and prevent it from getting starved and freezing the mapviz window. If you're having performance issues, you would probably rather the image cache thread get starved instead of the main thread.
- Moved image decode entirely off the main thread into CacheThread. Similar to above, it seemed better to handle decoding in the cache thread so the main thread isn't tied up doing this
- Added step to remove unprocessed requests that aren't visible in the current frame (or at least requested by pre-cache). This shouldn't affect pre-cache as it gets requested with each SetView change. But it does reduce the backlog of requests that queue up as a user pans around. With aggressive panning and zooming, a user can create a queue of 5,000 + requests. In the old code the priority naturally works out such that the currently visible tiles get priority, but this still seemed wasteful to me. Instead I set it to remove any unprocessed tiles from the queue that aren't a part of the current SetView frame. This significantly reduces how much backlog can accumulate. The sideffect is that image tiles seem to load more quickly (slightly), but at the cost that the intermediate tiles when panning around don't get queued (i.e. if a user scrolls out a lot, only the previous view and the current zoomed out view will likely get fetched; all tiles in-between likely won't be fetched until you zoom back in to the intermediate layer). If this is not desirable behavior I can remove it.