### PR TITLE
Fixed bad initial path import for multires image plugin

### DIFF
--- a/multires_image/src/multires_image_plugin.cpp
+++ b/multires_image/src/multires_image_plugin.cpp
@@ -323,17 +323,20 @@ namespace mapviz_plugins
     {
       std::string path_string = node["path"].as<std::string>();
 
-      std::filesystem::path image_path(path_string);
-      if (!image_path.is_absolute())
+      if (!path_string.empty())
       {
-        std::filesystem::path base_path(path);
-        path_string =
-          (path / image_path.relative_path()).lexically_normal().string();
+        std::filesystem::path image_path(path_string);
+        if (!image_path.is_absolute())
+        {
+          std::filesystem::path base_path(path);
+          path_string =
+            (path / image_path.relative_path()).lexically_normal().string();
+        }
+
+        ui_.path->setText(path_string.c_str());
+
+        AcceptConfiguration();
       }
-
-      ui_.path->setText(path_string.c_str());
-
-      AcceptConfiguration();
     }
 
     if (node["offset_x"])


### PR DESCRIPTION
If you add the multires image plugin and save your config (or just allow mapviz to restore the last config) it fails to load because the default path is an empty string. This fixes that to basically just ignore the empty path.