### PR TITLE
Adjust UI element size properties to work for higher resolutions/scaling

### DIFF
--- a/mapviz/ui/mapviz.ui
+++ b/mapviz/ui/mapviz.ui
@@ -119,11 +119,11 @@
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
          <widget class="QLabel" name="label">
-          <property name="maximumSize">
-           <size>
-            <width>85</width>
-            <height>16777215</height>
-           </size>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="font">
            <font>
@@ -138,11 +138,11 @@
         </item>
         <item row="1" column="0" rowspan="2">
          <widget class="QLabel" name="label_2">
-          <property name="maximumSize">
-           <size>
-            <width>85</width>
-            <height>16777215</height>
-           </size>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="font">
            <font>
@@ -157,11 +157,11 @@
         </item>
         <item row="5" column="0">
          <widget class="QLabel" name="label_3">
-          <property name="maximumSize">
-           <size>
-            <width>85</width>
-            <height>16777215</height>
-           </size>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="font">
            <font>
@@ -173,6 +173,19 @@
            <string>Background:</string>
           </property>
          </widget>
+        </item>
+        <item row="5" column="2">
+         <spacer name="horizontalSpacer_bg">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item row="5" column="1">
          <widget class="mapviz::ColorButton" name="bg_color">
@@ -304,12 +317,6 @@
         </property>
         <item>
          <widget class="QPushButton" name="addbutton">
-          <property name="maximumSize">
-           <size>
-            <width>80</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="toolTip">
            <string>Add a new display (Ctrl + N)</string>
           </property>
@@ -320,12 +327,6 @@
         </item>
         <item>
          <widget class="QPushButton" name="removebutton">
-          <property name="maximumSize">
-           <size>
-            <width>80</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="toolTip">
            <string>Remove the selected display (Ctrl + X)</string>
           </property>

--- a/mapviz_plugins/ui/attitude_indicator_config.ui
+++ b/mapviz_plugins/ui/attitude_indicator_config.ui
@@ -85,6 +85,12 @@
    </item>
    <item row="2" column="2">
     <widget class="QPushButton" name="selecttopic">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="acceptDrops">
       <bool>false</bool>
      </property>

--- a/mapviz_plugins/ui/coordinate_picker_config.ui
+++ b/mapviz_plugins/ui/coordinate_picker_config.ui
@@ -86,6 +86,12 @@
    </item>
    <item row="0" column="3">
     <widget class="QPushButton" name="selectframe">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Select</string>
      </property>
@@ -100,6 +106,12 @@
    </item>
    <item row="2" column="3">
     <widget class="QPushButton" name="clearListButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Clear List</string>
      </property>

--- a/mapviz_plugins/ui/disparity_config.ui
+++ b/mapviz_plugins/ui/disparity_config.ui
@@ -38,11 +38,11 @@
    </item>
    <item row="2" column="2">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>

--- a/mapviz_plugins/ui/draw_polygon_config.ui
+++ b/mapviz_plugins/ui/draw_polygon_config.ui
@@ -66,6 +66,12 @@
    </item>
    <item row="8" column="2">
     <widget class="QPushButton" name="publish">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Publish Polygon</string>
      </property>
@@ -83,6 +89,12 @@
    </item>
    <item row="5" column="2">
     <widget class="QPushButton" name="clear">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Clear</string>
      </property>
@@ -126,6 +138,12 @@
    </item>
    <item row="0" column="3">
     <widget class="QPushButton" name="selectframe">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Select</string>
      </property>

--- a/mapviz_plugins/ui/float_config.ui
+++ b/mapviz_plugins/ui/float_config.ui
@@ -47,11 +47,11 @@
    </item>
    <item row="2" column="2">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -105,6 +105,12 @@
    </item>
    <item row="3" column="1">
     <widget class="QPushButton" name="font_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>

--- a/mapviz_plugins/ui/gps_config.ui
+++ b/mapviz_plugins/ui/gps_config.ui
@@ -42,11 +42,11 @@
    </item>
    <item row="1" column="1">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -237,11 +237,11 @@
      </item>
      <item>
       <widget class="QPushButton" name="buttonResetBuffer">
-       <property name="maximumSize">
-        <size>
-         <width>55</width>
-         <height>16777215</height>
-        </size>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="text">
         <string>Clear</string>

--- a/mapviz_plugins/ui/grid_config.ui
+++ b/mapviz_plugins/ui/grid_config.ui
@@ -180,6 +180,12 @@
    </item>
    <item row="2" column="2">
     <widget class="QPushButton" name="select_frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="font">
       <font>
        <pointsize>8</pointsize>

--- a/mapviz_plugins/ui/image_config.ui
+++ b/mapviz_plugins/ui/image_config.ui
@@ -350,11 +350,11 @@
    </item>
    <item row="0" column="2">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>

--- a/mapviz_plugins/ui/laserscan_config.ui
+++ b/mapviz_plugins/ui/laserscan_config.ui
@@ -66,11 +66,11 @@
    </item>
    <item row="2" column="4">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>

--- a/mapviz_plugins/ui/marker_config.ui
+++ b/mapviz_plugins/ui/marker_config.ui
@@ -76,11 +76,11 @@
    </item>
    <item row="2" column="4">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -111,8 +111,14 @@
    </item>
    <item row="3" column="3">
     <widget class="QPushButton" name="clear">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string> Clear All Markers</string>
+      <string>Clear All Markers</string>
      </property>
     </widget>
    </item>

--- a/mapviz_plugins/ui/measuring_config.ui
+++ b/mapviz_plugins/ui/measuring_config.ui
@@ -24,12 +24,6 @@
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
     <widget class="QLabel" name="label_3">
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
-      </size>
-     </property>
      <property name="text">
       <string>Distance:</string>
      </property>
@@ -47,12 +41,6 @@
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_5">
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
-      </size>
-     </property>
      <property name="text">
       <string>Total Distance:</string>
      </property>
@@ -121,13 +109,18 @@
      </property>
     </widget>
    </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_clear_spacer">
+     <property name="text"><string/></property>
+    </widget>
+   </item>
    <item row="8" column="1">
     <widget class="QPushButton" name="clear">
-     <property name="maximumSize">
-      <size>
-       <width>140</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="text">
       <string>Clear</string>
@@ -189,12 +182,6 @@
    </item>
    <item row="6" column="1">
     <widget class="QSpinBox" name="font_size">
-     <property name="maximumSize">
-      <size>
-       <width>48</width>
-       <height>16777215</height>
-      </size>
-     </property>
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
      </property>
@@ -218,12 +205,6 @@
    </item>
    <item row="7" column="1">
     <widget class="QDoubleSpinBox" name="alpha">
-     <property name="maximumSize">
-      <size>
-       <width>48</width>
-       <height>16777215</height>
-      </size>
-     </property>
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
      </property>

--- a/mapviz_plugins/ui/measuring_config.ui
+++ b/mapviz_plugins/ui/measuring_config.ui
@@ -182,6 +182,12 @@
    </item>
    <item row="6" column="1">
     <widget class="QSpinBox" name="font_size">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
      </property>
@@ -205,6 +211,12 @@
    </item>
    <item row="7" column="1">
     <widget class="QDoubleSpinBox" name="alpha">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::PlusMinus</enum>
      </property>

--- a/mapviz_plugins/ui/move_base_config.ui
+++ b/mapviz_plugins/ui/move_base_config.ui
@@ -24,16 +24,16 @@
      </property>
      <item>
       <widget class="QPushButton" name="pushButtonAbort">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>65</width>
          <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>65</width>
-         <height>16777215</height>
         </size>
        </property>
        <property name="font">
@@ -55,16 +55,16 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonInitialPose">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>100</width>
          <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>110</width>
-         <height>16777215</height>
         </size>
        </property>
        <property name="font">
@@ -89,16 +89,16 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonGoalPose">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>100</width>
          <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>100</width>
-         <height>16777215</height>
         </size>
        </property>
        <property name="font">

--- a/mapviz_plugins/ui/navsat_config.ui
+++ b/mapviz_plugins/ui/navsat_config.ui
@@ -102,11 +102,11 @@
    </item>
    <item row="6" column="2">
     <widget class="QPushButton" name="buttonResetBuffer">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="text">
       <string>Clear</string>
@@ -115,11 +115,11 @@
    </item>
    <item row="2" column="2">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>

--- a/mapviz_plugins/ui/occupancy_grid_config.ui
+++ b/mapviz_plugins/ui/occupancy_grid_config.ui
@@ -34,12 +34,6 @@
    </property>
    <item row="4" column="1">
     <widget class="QDoubleSpinBox" name="alpha">
-     <property name="maximumSize">
-      <size>
-       <width>50</width>
-       <height>16777215</height>
-      </size>
-     </property>
      <property name="decimals">
       <number>1</number>
      </property>
@@ -119,11 +113,11 @@
    </item>
    <item row="2" column="0">
     <widget class="QPushButton" name="select_grid">
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -149,12 +143,6 @@
    </item>
    <item row="5" column="1">
     <widget class="QComboBox" name="color_scheme">
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
-      </size>
-     </property>
      <item>
       <property name="text">
        <string>map</string>

--- a/mapviz_plugins/ui/occupancy_grid_config.ui
+++ b/mapviz_plugins/ui/occupancy_grid_config.ui
@@ -34,6 +34,12 @@
    </property>
    <item row="4" column="1">
     <widget class="QDoubleSpinBox" name="alpha">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="decimals">
       <number>1</number>
      </property>
@@ -143,6 +149,12 @@
    </item>
    <item row="5" column="1">
     <widget class="QComboBox" name="color_scheme">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <item>
       <property name="text">
        <string>map</string>

--- a/mapviz_plugins/ui/odometry_config.ui
+++ b/mapviz_plugins/ui/odometry_config.ui
@@ -139,11 +139,11 @@
    </item>
    <item row="0" column="2">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -184,11 +184,11 @@
    </item>
    <item row="8" column="2">
     <widget class="QPushButton" name="buttonResetBuffer">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="text">
       <string>Clear</string>

--- a/mapviz_plugins/ui/path_config.ui
+++ b/mapviz_plugins/ui/path_config.ui
@@ -69,11 +69,11 @@
    </item>
    <item row="2" column="3">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>

--- a/mapviz_plugins/ui/plan_route_config.ui
+++ b/mapviz_plugins/ui/plan_route_config.ui
@@ -107,6 +107,12 @@
    </item>
    <item row="10" column="2">
     <widget class="QPushButton" name="publish">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Publish Route</string>
      </property>
@@ -152,6 +158,12 @@
    </item>
    <item row="7" column="2">
     <widget class="QPushButton" name="clear">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Clear</string>
      </property>

--- a/mapviz_plugins/ui/pointcloud2_config.ui
+++ b/mapviz_plugins/ui/pointcloud2_config.ui
@@ -34,11 +34,11 @@
    </property>
    <item row="2" column="3">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -444,11 +444,11 @@
    </item>
    <item row="3" column="3">
     <widget class="QPushButton" name="buttonResetBuffer">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="text">
       <string>Clear</string>

--- a/mapviz_plugins/ui/pose_config.ui
+++ b/mapviz_plugins/ui/pose_config.ui
@@ -42,11 +42,11 @@
    </item>
    <item row="1" column="1">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -237,11 +237,11 @@
      </item>
      <item>
       <widget class="QPushButton" name="buttonResetBuffer">
-       <property name="maximumSize">
-        <size>
-         <width>55</width>
-         <height>16777215</height>
-        </size>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="text">
         <string>Clear</string>

--- a/mapviz_plugins/ui/robot_image_config.ui
+++ b/mapviz_plugins/ui/robot_image_config.ui
@@ -32,11 +32,11 @@
    </item>
    <item row="0" column="3">
     <widget class="QPushButton" name="browse">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -77,11 +77,11 @@
    </item>
    <item row="2" column="3">
     <widget class="QPushButton" name="selectframe">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>

--- a/mapviz_plugins/ui/route_config.ui
+++ b/mapviz_plugins/ui/route_config.ui
@@ -124,11 +124,11 @@
    </item>
    <item row="2" column="3">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -206,14 +206,14 @@
    </item>
    <item row="7" column="3">
     <widget class="QPushButton" name="selectpositiontopic">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="enabled">
       <bool>true</bool>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
      </property>
      <property name="font">
       <font>

--- a/mapviz_plugins/ui/string_config.ui
+++ b/mapviz_plugins/ui/string_config.ui
@@ -47,11 +47,11 @@
    </item>
    <item row="2" column="2">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -105,6 +105,12 @@
    </item>
    <item row="3" column="1">
     <widget class="QPushButton" name="font_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>

--- a/mapviz_plugins/ui/textured_marker_config.ui
+++ b/mapviz_plugins/ui/textured_marker_config.ui
@@ -76,11 +76,11 @@
    </item>
    <item row="2" column="2">
     <widget class="QPushButton" name="selecttopic">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -111,8 +111,14 @@
    </item>
    <item row="4" column="1">
     <widget class="QPushButton" name="clear">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string> Clear All Markers</string>
+      <string>Clear All Markers</string>
      </property>
     </widget>
    </item>

--- a/mapviz_plugins/ui/tf_frame_config.ui
+++ b/mapviz_plugins/ui/tf_frame_config.ui
@@ -95,11 +95,11 @@
    </item>
    <item row="0" column="2">
     <widget class="QPushButton" name="selectframe">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -136,11 +136,11 @@
    </item>
    <item row="5" column="2">
     <widget class="QPushButton" name="buttonResetBuffer">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="text">
       <string>Clear</string>

--- a/multires_image/src/multires_config.ui
+++ b/multires_image/src/multires_config.ui
@@ -66,11 +66,11 @@
    </item>
    <item row="2" column="3">
     <widget class="QPushButton" name="browse">
-     <property name="maximumSize">
-      <size>
-       <width>55</width>
-       <height>16777215</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>

--- a/tile_map/src/tile_map_config.ui
+++ b/tile_map/src/tile_map_config.ui
@@ -83,6 +83,12 @@
    </item>
    <item row="5" column="3">
     <widget class="QPushButton" name="reset_cache_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Reset Cache</string>
      </property>
@@ -153,6 +159,12 @@
    </item>
    <item row="4" column="3">
     <widget class="QPushButton" name="delete_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -163,6 +175,12 @@
    </item>
    <item row="4" column="2">
     <widget class="QPushButton" name="save_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -194,12 +212,6 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>50</width>
-       <height>16777215</height>
-      </size>
      </property>
      <property name="value">
       <number>15</number>


### PR DESCRIPTION
I'm usually using a high resolution display with scaling and a lot of the .ui defaults look less polished with this setup. I was working on a custom plugin for another project and realized it would be fast to take a quick pass through all the plugins to make them look better for hopefully more resolutions and scaling. I also looked at the changes at 1080p to confirm that nothing regressed for the standard resolution, but I'd like some feedback if any of these changes hurt that experience. I'm sure I missed a few things, but this is all that I quickly noticed on my setup. The changes are mostly just removing pixel size constraints in favor of size policies.

Examples:

| Before | After |
| ---------- | ------- |
| <img width="486" height="178" alt="Screenshot_2026-06-19_01-25-06" src="https://github.com/user-attachments/assets/d1228937-29e6-4955-9721-31c0202e5c8f" /> | <img width="500" height="211" alt="Screenshot_2026-06-19_01-30-24" src="https://github.com/user-attachments/assets/47f5bc1c-d5dc-4c3d-b804-cdad33796aab" /> |
| <img width="425" height="120" alt="Screenshot_2026-06-19_01-25-29" src="https://github.com/user-attachments/assets/ebe68df5-616f-4864-b8be-a609dfe42713" /> | <img width="493" height="115" alt="Screenshot_2026-06-19_01-30-34" src="https://github.com/user-attachments/assets/bc0f5767-7bc5-4452-b368-d5fae4c6fed4" /> |
| <img width="489" height="523" alt="Screenshot_2026-06-19_01-26-05" src="https://github.com/user-attachments/assets/78484ef0-9fdc-4b9e-a687-1399be0f361f" /> | <img width="516" height="526" alt="Screenshot_2026-06-19_01-48-22" src="https://github.com/user-attachments/assets/4331481b-9102-402b-ab47-59ddba6d7cca" /> |