### PR TITLE
Plugin panel eliding

### DIFF
--- a/mapviz/include/mapviz/config_item.hpp
+++ b/mapviz/include/mapviz/config_item.hpp
@@ -38,6 +38,7 @@
 #include <QWidget>
 #include <QLabel>
 #include <QMouseEvent>
+#include <QResizeEvent>
 #include <QListWidgetItem>
 
 // C++ standard libraries
@@ -82,11 +83,14 @@ public Q_SLOTS:
 
 private:
   void contextMenuEvent(QContextMenuEvent *event) override;
+  void resizeEvent(QResizeEvent* event) override;
+  void updateNameLabel();
 
 protected:
   QListWidgetItem* item_;
   QString name_;
   QString type_;
+  QString full_label_text_;
   QAction* edit_name_action_;
   QAction* duplicate_item_action_;
   QAction* remove_item_action_;

--- a/mapviz/src/config_item.cpp
+++ b/mapviz/src/config_item.cpp
@@ -30,6 +30,7 @@
 #include <mapviz/config_item.hpp>
 #include <QMenu>
 #include <QAction>
+#include <QFontMetrics>
 #include <QInputDialog>
 
 namespace mapviz
@@ -78,13 +79,31 @@ namespace mapviz
   void ConfigItem::SetName(QString name)
   {
     name_ = name;
-    ui_.namelabel->setText(type_ + " (" + name_ + ")");
+    full_label_text_ = type_ + " (" + name_ + ")";
+    updateNameLabel();
   }
 
   void ConfigItem::SetType(QString type)
   {
     type_ = type;
-    ui_.namelabel->setText(type_ + " (" + name_ + ")");
+    full_label_text_ = type_ + " (" + name_ + ")";
+    updateNameLabel();
+  }
+
+  void ConfigItem::resizeEvent(QResizeEvent* event)
+  {
+    QWidget::resizeEvent(event);
+    updateNameLabel();
+  }
+
+  void ConfigItem::updateNameLabel()
+  {
+    if (ui_.namelabel->width() <= 0) {
+      return;
+    }
+    QFontMetrics fm(ui_.namelabel->font());
+    ui_.namelabel->setText(
+        fm.elidedText(full_label_text_, Qt::ElideRight, ui_.namelabel->width()));
   }
 
   void ConfigItem::SetWidget(QWidget* widget)

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -1258,7 +1258,7 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
   config_item->SetType(pretty_type);
   QListWidgetItem* item = new PluginConfigListItem();
   config_item->SetListItem(item);
-  item->setSizeHint(config_item->sizeHint());
+  item->setSizeHint(QSize(0, config_item->sizeHint().height()));
   connect(config_item, SIGNAL(UpdateSizeHint()), this, SLOT(UpdateSizeHints()));
   connect(
     config_item,
@@ -1584,7 +1584,7 @@ void Mapviz::UpdateSizeHints()
       // Make sure the ConfigItem in the QListWidgetItem we're getting really
       // exists; if this method is called before it's been initialized, it would
       // cause a crash.
-      item->setSizeHint(widget->sizeHint());
+      item->setSizeHint(QSize(0, widget->sizeHint().height()));
     }
   }
 }

--- a/mapviz/ui/configitem.ui
+++ b/mapviz/ui/configitem.ui
@@ -619,6 +619,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="font">
          <font>
           <family>Ubuntu</family>


### PR DESCRIPTION
Elides the plugin title text so that the enable checkboxes are always visible and easier to use on a narrow panel.

| Before | After |
| ---------- | ------- |
| <img width="367" height="539" alt="Screenshot_2026-06-19_02-11-43" src="https://github.com/user-attachments/assets/09b6b6ac-0f15-40b5-b1a5-dbcfb6e5e031" /> | <img width="367" height="539" alt="Screenshot_2026-06-19_02-10-53" src="https://github.com/user-attachments/assets/72f610fb-bea3-48e1-8e42-8ac6aee0dc9b" /> |
