### PR TITLE
Improved tf handling

### DIFF
--- a/mapviz/include/mapviz/mapviz.hpp
+++ b/mapviz/include/mapviz/mapviz.hpp
@@ -55,6 +55,7 @@
 
 // ROS libraries
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/executors/single_threaded_executor.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -62,7 +63,9 @@
 #include <std_srvs/srv/empty.hpp>
 
 // C++ standard libraries
+#include <atomic>
 #include <string>
+#include <thread>
 #include <vector>
 #include <map>
 #include <memory>
@@ -178,8 +181,11 @@ protected:
   QMenu* image_transport_menu_;
 
   QTimer frame_timer_;
-  QTimer spin_timer_;
+  QTimer spin_timer_;  // unused in standalone mode; kept for rqt embedding
   QTimer save_timer_;
+  rclcpp::executors::SingleThreadedExecutor::UniquePtr spin_executor_;
+  std::thread spin_thread_;
+  std::atomic<bool> spin_thread_running_{false};
   QTimer record_timer_;
   QTimer profile_timer_;
 

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -329,6 +329,11 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
 
 Mapviz::~Mapviz()
 {
+  if (spin_thread_running_) {
+    spin_executor_->cancel();
+    spin_thread_running_ = false;
+    if (spin_thread_.joinable()) spin_thread_.join();
+  }
   video_thread_.quit();
   video_thread_.wait();
 }
@@ -359,8 +364,16 @@ void Mapviz::Initialize()
 {
   if (!initialized_) {
     if (is_standalone_) {
-      spin_timer_.start(30);
-      connect(&spin_timer_, SIGNAL(timeout()), this, SLOT(SpinOnce()));
+      spin_executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+      spin_executor_->add_node(node_);
+      spin_thread_running_ = true;
+      spin_thread_ = std::thread([this]() {
+        spin_executor_->spin();
+        spin_thread_running_ = false;
+        if (!rclcpp::ok()) {
+          QApplication::exit();
+        }
+      });
     }
 
     // Create a sub-menu that lists all available Image Transports


### PR DESCRIPTION
I kept noticing that when I set the target_frame to base_link that the mapviz canvas stuttered a lot. Putting the whole mapviz node in its own spin thread seemed to fix all these issues I was having.

For this PR I used Claude to diagnose and fix the problem, and I haven't had a chance to scrutinize it. I'm going to go ahead and open it for others to look at if I don't get back to it first.