### PR TITLE
Separate ROS and UI Threads

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -10,5 +10,6 @@ has_children: true
 
 | Title | Description |
 |:- |:- |
+| [Writing a plugin]({{site.basurl}}/mapviz/guides/writing_a_plugin) | How to create a mapviz display plugin for your own data types in your own package, including the threading contract plugins must follow. |
 | [Local tile_map imagery]({{site.basurl}}/mapviz/guides/local_tile_map_imagery) | How to wrangle data to the correct format and direct mapviz's `tile_map` plugin to use it from local storage. |
 | [Geospatial Imagery From USGS Earth Explorer]({{site.basurl}}/mapviz/guides/imagery_usgs_earth_explorer) | An example of how to get imagery that could be used as a source for local `tile_map` imagery. Provided for reference only. |

--- a/docs/guides/writing_a_plugin.md
+++ b/docs/guides/writing_a_plugin.md
@@ -1,0 +1,183 @@
+---
+title: Writing a plugin
+parent: Guides
+has_children: false
+---
+
+# Writing a plugin
+{: .no_toc }
+
+Mapviz displays are plugins loaded at runtime through
+[pluginlib](https://github.com/ros/pluginlib). The core application knows
+nothing about the data types your plugin displays — it only speaks the
+abstract `mapviz::MapvizPlugin` interface — so you can add support for new
+message types in your own package without modifying mapviz itself. The
+`tile_map` and `multires_image` packages in this repository are examples of
+plugins that live outside the core.
+
+1. TOC
+{:toc}
+
+## Package setup
+
+Your plugin package depends on `mapviz` (the core, **not** `mapviz_plugins`),
+`pluginlib`, `rclcpp`, and whatever message packages it displays.
+
+Declare the plugin manifest in `package.xml` so mapviz can discover it:
+
+```xml
+<export>
+  <mapviz plugin="${prefix}/mapviz_plugins.xml" />
+</export>
+```
+
+The manifest (`mapviz_plugins.xml`) names each display class you export:
+
+```xml
+<library path="my_plugin_library">
+  <class name="my_package/my_display"
+         type="my_package::MyDisplayPlugin"
+         base_class_type="mapviz::MapvizPlugin">
+    <description>Displays MyMessage data.</description>
+  </class>
+</library>
+```
+
+In `CMakeLists.txt`, build your plugin as a shared library with `AUTOMOC`
+enabled (the plugin is a `QObject`), link it against mapviz and Qt, and
+register the manifest:
+
+```cmake
+find_package(mapviz REQUIRED)
+find_package(pluginlib REQUIRED)
+
+set(CMAKE_AUTOMOC ON)
+
+add_library(my_plugin_library SHARED src/my_display_plugin.cpp)
+target_link_libraries(my_plugin_library
+  ${mapviz_TARGETS}
+  pluginlib::pluginlib
+  # ... Qt5::Widgets, message packages, etc.
+)
+
+pluginlib_export_plugin_description_file(mapviz mapviz_plugins.xml)
+```
+
+Finally, export the class from your source file:
+
+```cpp
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(my_package::MyDisplayPlugin, mapviz::MapvizPlugin)
+```
+
+When mapviz starts it logs every discovered class
+(`Found mapviz plugin: my_package/my_display`), and the display appears in
+the *Add display* dialog.
+
+## The MapvizPlugin interface
+
+Subclass `mapviz::MapvizPlugin` (see `mapviz/mapviz_plugin.hpp`) and
+implement:
+
+| Method | Purpose |
+|:-|:-|
+| `Initialize(QOpenGLWidget* canvas)` | One-time setup; the canvas is provided for GL work. |
+| `Shutdown()` | Tear down anything not handled by the destructor. |
+| `Draw(x, y, scale)` | Render with OpenGL. Called every frame while visible; the GL context is already current. |
+| `Transform()` | Re-project stored data into the current target frame. Called before every draw and when the target frame changes. |
+| `LoadConfig(node, path)` / `SaveConfig(emitter, path)` | Persist settings to the mapviz config file (yaml-cpp). |
+| `GetConfigWidget(parent)` | Return the Qt widget shown in the config panel. |
+| `PrintError/PrintInfo/PrintWarning` | Status reporting; delegate to the `Print*Helper` base-class methods with your status `QLabel`. |
+
+Optionally override `Paint()` (and return `true` from `SupportsPainting()`)
+to draw with a `QPainter` on top of the GL scene, `DrawIcon()` to render the
+display-list icon, and `ClearHistory()` to drop buffered data.
+
+Use the base class `GetTransform(...)` to look up transforms, and the
+`LoadQosConfig`/`SaveQosConfig` helpers to persist subscription QoS.
+
+## Threading model
+
+This is the one contract you must follow. Mapviz services ROS on a
+background spin thread so that message traffic never stalls rendering, while
+rendering, widgets, the GL context, and the (not thread safe)
+`TransformManager` all belong to the GUI thread.
+
+**Subscription callbacks run on the spin thread and must not touch widgets,
+the GL context, `tf_manager_`/`GetTransform()`, or any state shared with the
+GUI thread.** A callback should do at most expensive, configuration-independent
+decoding on local data, then hand the result to the GUI thread with a queued
+signal. Everything else — `Draw()`, `Paint()`, `Transform()`, config-widget
+slots — runs on the GUI thread and needs no locking.
+
+The handoff uses an ordinary Qt signal/slot pair. Because the signal is
+emitted from a different thread than the one your plugin object lives on, Qt
+automatically delivers it as a queued event on the GUI thread:
+
+```cpp
+// my_display_plugin.hpp
+class MyDisplayPlugin : public mapviz::MapvizPlugin
+{
+  Q_OBJECT
+  // ...
+
+Q_SIGNALS:
+  // Emitted from the ROS spin thread; delivered as a queued connection to
+  // handleMessage() on the GUI thread, which owns all plugin state.
+  void MessageReceived(const my_msgs::msg::MyMessage::ConstSharedPtr msg);
+
+private Q_SLOTS:
+  void handleMessage(const my_msgs::msg::MyMessage::ConstSharedPtr msg);
+
+private:
+  void messageCallback(const my_msgs::msg::MyMessage::ConstSharedPtr msg);
+};
+
+// Required so the shared_ptr can be carried by a queued emission.
+Q_DECLARE_METATYPE(my_msgs::msg::MyMessage::ConstSharedPtr)
+```
+
+```cpp
+// my_display_plugin.cpp — in the constructor:
+qRegisterMetaType<my_msgs::msg::MyMessage::ConstSharedPtr>(
+    "my_msgs::msg::MyMessage::ConstSharedPtr");
+QObject::connect(this, &MyDisplayPlugin::MessageReceived,
+                 this, &MyDisplayPlugin::handleMessage);
+
+// The subscription callback: decode and emit, nothing else.
+void MyDisplayPlugin::messageCallback(
+    const my_msgs::msg::MyMessage::ConstSharedPtr msg)
+{
+  Q_EMIT MessageReceived(msg);
+}
+
+// The slot: runs on the GUI thread, free to use tf, widgets, and config.
+void MyDisplayPlugin::handleMessage(
+    const my_msgs::msg::MyMessage::ConstSharedPtr msg)
+{
+  // update buffers, call GetTransform(), touch ui_, etc.
+}
+```
+
+Emit `ConstSharedPtr`s (or a `shared_ptr` to your own decoded struct) so the
+queued copy is just a pointer. For a simple example see `OdometryPlugin`; for
+a plugin that does heavy per-message decoding in the callback before emitting
+see `PointCloud2Plugin`.
+
+Notes:
+
+- Declare metatypes for your **own** types in your own headers. If several
+  headers in one library share a type, put the declaration in one common
+  header (see `mapviz_plugins/ros_metatypes.hpp`) — `AUTOMOC` compiles a
+  library's moc files in a single translation unit, so a type declared in
+  two of its headers is a redefinition. Two *separate* plugin libraries
+  registering the same type is fine.
+- The `Print*Helper` methods are safe to call from either thread.
+- Queued connections do not apply backpressure: if your topic can outrun the
+  GUI, coalesce in the callback (e.g. store the latest message and emit a
+  lightweight notification) instead of emitting every message.
+- Timers: use a `QTimer` (fires on the GUI thread), not
+  `node_->create_wall_timer()` (fires on the spin thread) — see
+  `TfFramePlugin`.
+- Create and reset subscriptions from GUI code (topic-edited slots,
+  `LoadConfig`), as the built-in plugins do.

--- a/mapviz/include/mapviz/mapviz.hpp
+++ b/mapviz/include/mapviz/mapviz.hpp
@@ -66,6 +66,7 @@
 #include <atomic>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -222,11 +223,15 @@ protected:
   rclcpp::CallbackGroup::SharedPtr gui_callback_group_;
 
   // Spins everything else on the node (plugin subscriptions, tf, etc.) on a
-  // background thread so message processing doesn't block the GUI.  The
-  // spin loop holds MapvizPlugin::DataMutex() while dispatching callbacks.
+  // background thread so message waiting and decoding never block the GUI.
+  // Plugin callbacks hand their results to the GUI thread through queued
+  // signal connections, so no data locking is needed; the only
+  // synchronization is plugin_teardown_mutex_, which keeps a plugin from
+  // being destroyed while one of its callbacks is being dispatched.
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> ros_executor_;
   std::thread ros_spin_thread_;
   std::atomic_bool spinning_;
+  std::mutex plugin_teardown_mutex_;
 
   void StopSpinThread();
 

--- a/mapviz/include/mapviz/mapviz.hpp
+++ b/mapviz/include/mapviz/mapviz.hpp
@@ -55,6 +55,7 @@
 
 // ROS libraries
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/version.h>
 #include <pluginlib/class_loader.hpp>
 #include <tf2_ros/buffer.hpp>
 #include <tf2_ros/transform_listener.hpp>
@@ -62,10 +63,12 @@
 #include <std_srvs/srv/empty.hpp>
 
 // C++ standard libraries
-#include <string>
-#include <vector>
+#include <atomic>
 #include <map>
 #include <memory>
+#include <string>
+#include <thread>
+#include <vector>
 
 // Auto-generated UI files
 #include "ui/ui_mapviz.h"
@@ -211,7 +214,22 @@ protected:
   bool updating_frames_;
 
   std::shared_ptr<rclcpp::Node> node_;
+
+  // Spins only gui_callback_group_ (currently the add_mapviz_display
+  // service, which manipulates widgets); pumped from a QTimer on the GUI
+  // thread via SpinOnce().
   rclcpp::executors::SingleThreadedExecutor executor_;
+  rclcpp::CallbackGroup::SharedPtr gui_callback_group_;
+
+  // Spins everything else on the node (plugin subscriptions, tf, etc.) on a
+  // background thread so message processing doesn't block the GUI.  The
+  // spin loop holds MapvizPlugin::DataMutex() while dispatching callbacks.
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> ros_executor_;
+  std::thread ros_spin_thread_;
+  std::atomic_bool spinning_;
+
+  void StopSpinThread();
+
   rclcpp::Service<mapviz_interfaces::srv::AddMapvizDisplay>::SharedPtr add_display_srv_;
   std::shared_ptr<tf2_ros::Buffer> tf_buf_;
   std::shared_ptr<tf2_ros::TransformListener> tf_;

--- a/mapviz/include/mapviz/mapviz_plugin.hpp
+++ b/mapviz/include/mapviz/mapviz_plugin.hpp
@@ -64,19 +64,28 @@ public:
   ~MapvizPlugin() override = default;
 
   /**
-   * Mutex guarding state shared between the background ROS spin thread and
-   * the GUI thread.  The background executor holds it while dispatching
-   * message callbacks; the draw/paint/transform entry points hold it while
-   * rendering.  TransformManager is not thread safe, so any access to
-   * tf_manager_ outside a message callback or Draw()/Paint()/Transform()
-   * must also hold this mutex.  Recursive so nested entry points
-   * (e.g. GetTransform() inside Transform()) can lock freely.
+   * Threading model
+   *
+   * ROS message callbacks run on a background spin thread, while rendering,
+   * widgets, and the (not thread safe) TransformManager belong to the GUI
+   * thread.  Plugins bridge the two with queued signals: the subscription
+   * callback does any expensive, configuration-independent decoding on
+   * local data, then emits the result through a signal connected to a slot
+   * on this object.  Because the emitting thread differs from the receiving
+   * object's thread, Qt delivers it as a queued event on the GUI thread,
+   * where all plugin state may be used without locking.  Carry results in
+   * shared_ptrs (declared with Q_DECLARE_METATYPE and registered with
+   * qRegisterMetaType) so queued copies stay cheap.  See OdometryPlugin
+   * (simple handoff) and PointCloud2Plugin (heavy decode in the callback)
+   * for the pattern.
+   *
+   * The rules this imposes on plugin code:
+   *  - Subscription callbacks must not touch widgets, the GL context,
+   *    tf_manager_, or any state shared with the GUI thread; they decode
+   *    and emit.
+   *  - Everything else (Draw/Paint/Transform, config slots, GetTransform)
+   *    runs on the GUI thread and needs no synchronization.
    */
-  static std::recursive_mutex& DataMutex()
-  {
-    static std::recursive_mutex mutex;
-    return mutex;
-  }
 
   virtual bool Initialize(
       std::shared_ptr<tf2_ros::Buffer> tf_buffer,
@@ -142,8 +151,6 @@ public:
   void DrawPlugin(double x, double y, double scale)
   {
     if (visible_ && initialized_) {
-      std::lock_guard<std::recursive_mutex> lock(DataMutex());
-
       meas_transform_.start();
       Transform();
       meas_transform_.stop();
@@ -157,8 +164,6 @@ public:
   void PaintPlugin(QPainter* painter, double x, double y, double scale)
   {
     if (visible_ && initialized_) {
-      std::lock_guard<std::recursive_mutex> lock(DataMutex());
-
       meas_transform_.start();
       Transform();
       meas_transform_.stop();
@@ -172,8 +177,6 @@ public:
   void SetTargetFrame(const std::string& frame_id)
   {
     if (frame_id != target_frame_) {
-      std::lock_guard<std::recursive_mutex> lock(DataMutex());
-
       target_frame_ = frame_id;
 
       meas_transform_.start();
@@ -210,10 +213,6 @@ public:
     if (!initialized_) {
       return false;
     }
-
-    // TransformManager is not thread safe; this can be called from both the
-    // ROS spin thread (message callbacks) and the GUI thread.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
 
     tf2::TimePoint time;
     rclcpp::Time now = node_->now();

--- a/mapviz/include/mapviz/mapviz_plugin.hpp
+++ b/mapviz/include/mapviz/mapviz_plugin.hpp
@@ -45,9 +45,11 @@
 #include <QWidget>
 #include <QObject>
 #include <QOpenGLWidget>
+#include <QThread>
 
 // C++ standard libraries
 #include <memory>
+#include <mutex>
 #include <string>
 
 
@@ -60,6 +62,21 @@ class MapvizPlugin : public QObject
   Q_OBJECT
 public:
   ~MapvizPlugin() override = default;
+
+  /**
+   * Mutex guarding state shared between the background ROS spin thread and
+   * the GUI thread.  The background executor holds it while dispatching
+   * message callbacks; the draw/paint/transform entry points hold it while
+   * rendering.  TransformManager is not thread safe, so any access to
+   * tf_manager_ outside a message callback or Draw()/Paint()/Transform()
+   * must also hold this mutex.  Recursive so nested entry points
+   * (e.g. GetTransform() inside Transform()) can lock freely.
+   */
+  static std::recursive_mutex& DataMutex()
+  {
+    static std::recursive_mutex mutex;
+    return mutex;
+  }
 
   virtual bool Initialize(
       std::shared_ptr<tf2_ros::Buffer> tf_buffer,
@@ -125,6 +142,8 @@ public:
   void DrawPlugin(double x, double y, double scale)
   {
     if (visible_ && initialized_) {
+      std::lock_guard<std::recursive_mutex> lock(DataMutex());
+
       meas_transform_.start();
       Transform();
       meas_transform_.stop();
@@ -138,6 +157,8 @@ public:
   void PaintPlugin(QPainter* painter, double x, double y, double scale)
   {
     if (visible_ && initialized_) {
+      std::lock_guard<std::recursive_mutex> lock(DataMutex());
+
       meas_transform_.start();
       Transform();
       meas_transform_.stop();
@@ -151,6 +172,8 @@ public:
   void SetTargetFrame(const std::string& frame_id)
   {
     if (frame_id != target_frame_) {
+      std::lock_guard<std::recursive_mutex> lock(DataMutex());
+
       target_frame_ = frame_id;
 
       meas_transform_.start();
@@ -187,6 +210,10 @@ public:
     if (!initialized_) {
       return false;
     }
+
+    // TransformManager is not thread safe; this can be called from both the
+    // ROS spin thread (message callbacks) and the GUI thread.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
 
     tf2::TimePoint time;
     rclcpp::Time now = node_->now();
@@ -380,14 +407,36 @@ private:
   Stopwatch meas_transform_;
   Stopwatch meas_paint_;
   Stopwatch meas_draw_;
+
+  // Deduplicates status messages; the print helpers can be called from the
+  // ROS spin thread, so the label text can't be read there for comparison.
+  std::mutex status_mutex_;
+  std::string last_status_msg_;
+
+  // Returns true the first time each unique message is seen; used so the
+  // status label and log are only updated when the message changes.
+  bool StatusMessageChanged(const std::string& message)
+  {
+    std::lock_guard<std::mutex> lock(status_mutex_);
+    if (message == last_status_msg_) {
+      return false;
+    }
+    last_status_msg_ = message;
+    return true;
+  }
 };
 typedef std::shared_ptr<MapvizPlugin> MapvizPluginPtr;
 
 // Implementation
+//
+// The print helpers may be called from the ROS spin thread, but QLabel can
+// only be touched from the GUI thread, so the label update is posted to the
+// label's thread with a queued invocation when necessary.  The label is used
+// as the invocation context so pending updates are dropped if it is deleted.
 inline void MapvizPlugin::PrintErrorHelper(QLabel *status_label, const std::string &message,
                                             double throttle)
 {
-    if (message == status_label->text().toStdString()) {
+    if (!StatusMessageChanged(message)) {
       return;
     }
 
@@ -397,16 +446,23 @@ inline void MapvizPlugin::PrintErrorHelper(QLabel *status_label, const std::stri
     } else {
         RCLCPP_ERROR(logger, "%s", message.c_str());
     }
-    QPalette p(status_label->palette());
-    p.setColor(QPalette::Text, Qt::red);
-    status_label->setPalette(p);
-    status_label->setText(message.c_str());
+    auto update_label = [status_label, message]() {
+      QPalette p(status_label->palette());
+      p.setColor(QPalette::Text, Qt::red);
+      status_label->setPalette(p);
+      status_label->setText(message.c_str());
+    };
+    if (QThread::currentThread() == status_label->thread()) {
+      update_label();
+    } else {
+      QMetaObject::invokeMethod(status_label, update_label, Qt::QueuedConnection);
+    }
 }
 
 inline void MapvizPlugin::PrintInfoHelper(QLabel *status_label, const std::string &message,
                                           double throttle)
 {
-    if (message == status_label->text().toStdString()) {
+    if (!StatusMessageChanged(message)) {
       return;
     }
 
@@ -416,16 +472,23 @@ inline void MapvizPlugin::PrintInfoHelper(QLabel *status_label, const std::strin
     } else {
         RCLCPP_INFO(logger, "%s", message.c_str());
     }
-    QPalette p(status_label->palette());
-    p.setColor(QPalette::Text, Qt::darkGreen);
-    status_label->setPalette(p);
-    status_label->setText(message.c_str());
+    auto update_label = [status_label, message]() {
+      QPalette p(status_label->palette());
+      p.setColor(QPalette::Text, Qt::darkGreen);
+      status_label->setPalette(p);
+      status_label->setText(message.c_str());
+    };
+    if (QThread::currentThread() == status_label->thread()) {
+      update_label();
+    } else {
+      QMetaObject::invokeMethod(status_label, update_label, Qt::QueuedConnection);
+    }
 }
 
 inline void MapvizPlugin::PrintWarningHelper(QLabel *status_label, const std::string &message,
                                               double throttle)
 {
-    if (message == status_label->text().toStdString()) {
+    if (!StatusMessageChanged(message)) {
       return;
     }
 
@@ -435,10 +498,17 @@ inline void MapvizPlugin::PrintWarningHelper(QLabel *status_label, const std::st
     } else {
         RCLCPP_WARN(logger, "%s", message.c_str());
     }
-    QPalette p(status_label->palette());
-    p.setColor(QPalette::Text, Qt::darkYellow);
-    status_label->setPalette(p);
-    status_label->setText(message.c_str());
+    auto update_label = [status_label, message]() {
+      QPalette p(status_label->palette());
+      p.setColor(QPalette::Text, Qt::darkYellow);
+      status_label->setPalette(p);
+      status_label->setText(message.c_str());
+    };
+    if (QThread::currentThread() == status_label->thread()) {
+      update_label();
+    } else {
+      QMetaObject::invokeMethod(status_label, update_label, Qt::QueuedConnection);
+    }
 }
 
 }   // namespace mapviz

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -484,20 +484,17 @@ void Mapviz::Initialize()
                   // prevent other fields from obtaining focus at startup
 
     // Service ROS message callbacks on a background thread so that message
-    // processing never blocks the GUI.  The callbacks are dispatched while
-    // holding MapvizPlugin::DataMutex(), which is also held by the plugin
-    // draw/transform entry points on the GUI thread; that mutual exclusion
-    // is what makes the plugins' message buffers and the shared
-    // TransformManager safe to use from both threads.
+    // waiting and decoding never block the GUI.  Plugin callbacks only
+    // decode and emit queued signals, so no data lock is needed; the
+    // teardown mutex just keeps RemoveDisplay()/ClearDisplays() from
+    // destroying a plugin while one of its callbacks is being dispatched.
     spinning_ = true;
     ros_spin_thread_ = std::thread([this]() {
       while (spinning_ && rclcpp::ok()) {
         {
-          std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
+          std::lock_guard<std::mutex> lock(plugin_teardown_mutex_);
           ros_executor_->spin_some();
         }
-        // Sleep outside the lock so the GUI thread gets a chance to draw
-        // even under a constant stream of messages.
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
       }
     });
@@ -1096,9 +1093,6 @@ void Mapviz::SaveConfig()
 void Mapviz::ClearHistory()
 {
   RCLCPP_DEBUG(node_->get_logger(), "Mapviz::ClearHistory()");
-  // ClearHistory() mutates plugin message buffers that the spin thread
-  // may be appending to.
-  std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
   for (auto& plugin : plugins_) {
     plugin.second->ClearHistory();
   }
@@ -1243,9 +1237,6 @@ void Mapviz::Hover(double x, double y, double scale)
 
     swri_transform_util::Transform transform;
     std::string fixed_frame = ui_.fixedframe->currentText().toStdString();
-    // TransformManager is not thread safe and is also used by message
-    // callbacks on the spin thread.
-    std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
     if
     (
       fixed_frame.length() > 0 &&
@@ -1680,9 +1671,9 @@ void Mapviz::RemoveDisplay(QListWidgetItem* item)
   RCLCPP_INFO(rclcpp::get_logger("mapviz"), "Remove display ...");
 
   if (item) {
-    // Hold the data mutex so the plugin (and its subscriptions) can't be
+    // Hold the teardown mutex so the plugin (and its subscriptions) can't be
     // destroyed while the spin thread is dispatching one of its callbacks.
-    std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
+    std::lock_guard<std::mutex> lock(plugin_teardown_mutex_);
 
     canvas_->RemovePlugin(plugins_[item]);
     plugins_.erase(item);
@@ -1767,7 +1758,7 @@ void Mapviz::DuplicateDisplay(QListWidgetItem* item)
 void Mapviz::ClearDisplays()
 {
   // See RemoveDisplay(): plugins must not be destroyed mid-callback.
-  std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
+  std::lock_guard<std::mutex> lock(plugin_teardown_mutex_);
 
   while (ui_.configs->count() > 0) {
     RCLCPP_INFO(node_->get_logger(), "Remove display ...");

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -163,7 +163,19 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
   std::snprintf(buf, sizeof(buf), "_%llu", (unsigned long long)rclcpp::Clock().now().nanoseconds());
   name << buf;
   node_ = std::make_shared<rclcpp::Node>(name.str());
-  executor_.add_node(node_);
+
+  // Callbacks that must run on the GUI thread (the add_mapviz_display
+  // service creates widgets) go in this group, which is spun by executor_
+  // from a QTimer.  The rest of the node's callbacks are serviced by
+  // ros_executor_ on a background thread; see Initialize().
+  gui_callback_group_ = node_->create_callback_group(
+      rclcpp::CallbackGroupType::MutuallyExclusive,
+      false /* don't add to the executor that spins the node */);
+  executor_.add_callback_group(gui_callback_group_, node_->get_node_base_interface());
+
+  ros_executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  ros_executor_->add_node(node_);
+  spinning_ = false;
 
   QString default_path = GetDefaultConfigPath();
   node_->declare_parameter("config", default_path.toStdString());
@@ -330,6 +342,7 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
 
 Mapviz::~Mapviz()
 {
+  StopSpinThread();
   video_thread_.quit();
   video_thread_.wait();
 }
@@ -348,6 +361,9 @@ void Mapviz::closeEvent(QCloseEvent* event)
 {
   AutoSave();
 
+  // Stop servicing message callbacks before tearing the plugins down.
+  StopSpinThread();
+
   for (auto& display : plugins_) {
     MapvizPluginPtr plugin = display.second;
     canvas_->RemovePlugin(plugin);
@@ -359,10 +375,10 @@ void Mapviz::closeEvent(QCloseEvent* event)
 void Mapviz::Initialize()
 {
   if (!initialized_) {
-    if (is_standalone_) {
-      spin_timer_.start(30);
-      connect(&spin_timer_, SIGNAL(timeout()), this, SLOT(SpinOnce()));
-    }
+    // executor_ only services the GUI callback group; this timer runs in
+    // both standalone and rqt modes.
+    spin_timer_.start(30);
+    connect(&spin_timer_, SIGNAL(timeout()), this, SLOT(SpinOnce()));
 
     // Create a sub-menu that lists all available Image Transports
     // image_common < 6.4.0 (e.g. ROS Humble) exposes
@@ -419,12 +435,22 @@ void Mapviz::Initialize()
     canvas_->SetFixedFrame(ui_.fixedframe->currentText().toStdString());
     canvas_->SetTargetFrame(ui_.targetframe->currentText().toStdString());
 
+    // This service creates and configures widgets, so it must be handled on
+    // the GUI thread; the GUI callback group is spun there by SpinOnce().
     add_display_srv_ = node_->create_service<mapviz_interfaces::srv::AddMapvizDisplay>(
                                               "add_mapviz_display",
                                               std::bind(&Mapviz::AddDisplay,
                                                   this,
                                                   std::placeholders::_1,
-                                                  std::placeholders::_2));
+                                                  std::placeholders::_2),
+#if RCLCPP_VERSION_GTE(17, 0, 0)
+                                              // Iron and newer take rclcpp::QoS
+                                              rclcpp::ServicesQoS(),
+#else
+                                              // Humble takes rmw_qos_profile_t
+                                              rmw_qos_profile_services_default,
+#endif
+                                              gui_callback_group_);
 
     QString default_path = GetDefaultConfigPath();
 
@@ -457,7 +483,34 @@ void Mapviz::Initialize()
     setFocus();   // Set the main window as focused object,
                   // prevent other fields from obtaining focus at startup
 
+    // Service ROS message callbacks on a background thread so that message
+    // processing never blocks the GUI.  The callbacks are dispatched while
+    // holding MapvizPlugin::DataMutex(), which is also held by the plugin
+    // draw/transform entry points on the GUI thread; that mutual exclusion
+    // is what makes the plugins' message buffers and the shared
+    // TransformManager safe to use from both threads.
+    spinning_ = true;
+    ros_spin_thread_ = std::thread([this]() {
+      while (spinning_ && rclcpp::ok()) {
+        {
+          std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
+          ros_executor_->spin_some();
+        }
+        // Sleep outside the lock so the GUI thread gets a chance to draw
+        // even under a constant stream of messages.
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+      }
+    });
+
     initialized_ = true;
+  }
+}
+
+void Mapviz::StopSpinThread()
+{
+  spinning_ = false;
+  if (ros_spin_thread_.joinable()) {
+    ros_spin_thread_.join();
   }
 }
 
@@ -1043,6 +1096,9 @@ void Mapviz::SaveConfig()
 void Mapviz::ClearHistory()
 {
   RCLCPP_DEBUG(node_->get_logger(), "Mapviz::ClearHistory()");
+  // ClearHistory() mutates plugin message buffers that the spin thread
+  // may be appending to.
+  std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
   for (auto& plugin : plugins_) {
     plugin.second->ClearHistory();
   }
@@ -1187,6 +1243,9 @@ void Mapviz::Hover(double x, double y, double scale)
 
     swri_transform_util::Transform transform;
     std::string fixed_frame = ui_.fixedframe->currentText().toStdString();
+    // TransformManager is not thread safe and is also used by message
+    // callbacks on the spin thread.
+    std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
     if
     (
       fixed_frame.length() > 0 &&
@@ -1621,6 +1680,10 @@ void Mapviz::RemoveDisplay(QListWidgetItem* item)
   RCLCPP_INFO(rclcpp::get_logger("mapviz"), "Remove display ...");
 
   if (item) {
+    // Hold the data mutex so the plugin (and its subscriptions) can't be
+    // destroyed while the spin thread is dispatching one of its callbacks.
+    std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
+
     canvas_->RemovePlugin(plugins_[item]);
     plugins_.erase(item);
 
@@ -1703,6 +1766,9 @@ void Mapviz::DuplicateDisplay(QListWidgetItem* item)
 
 void Mapviz::ClearDisplays()
 {
+  // See RemoveDisplay(): plugins must not be destroyed mid-callback.
+  std::lock_guard<std::recursive_mutex> lock(MapvizPlugin::DataMutex());
+
   while (ui_.configs->count() > 0) {
     RCLCPP_INFO(node_->get_logger(), "Remove display ...");
 

--- a/mapviz_plugins/include/mapviz_plugins/attitude_indicator_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/attitude_indicator_plugin.hpp
@@ -32,6 +32,7 @@
 
 // Include mapviz_plugin.h first to ensure GL deps are included in the right order
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 // QT libraries
 #include <QColor>
@@ -96,6 +97,18 @@ class AttitudeIndicatorPlugin : public mapviz::MapvizPlugin,
    void SelectTopic();
    void TopicEdited();
 
+ Q_SIGNALS:
+   // Emitted from the ROS spin thread; delivered as queued connections to
+   // the handle*() slots on the GUI thread, which owns all plugin state.
+   void ImuReceived(const sensor_msgs::msg::Imu::ConstSharedPtr imu);
+   void OdometryReceived(const nav_msgs::msg::Odometry::ConstSharedPtr odometry);
+   void PoseReceived(const geometry_msgs::msg::Pose::ConstSharedPtr pose);
+
+ private Q_SLOTS:
+   void handleImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu);
+   void handleOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr odometry);
+   void handlePose(const geometry_msgs::msg::Pose::ConstSharedPtr pose);
+
  private:
   void AttitudeCallbackImu(sensor_msgs::msg::Imu::ConstSharedPtr imu);
   void AttitudeCallbackOdom(nav_msgs::msg::Odometry::ConstSharedPtr odometry);
@@ -117,4 +130,5 @@ class AttitudeIndicatorPlugin : public mapviz::MapvizPlugin,
   Ui::attitude_indicator_config ui_{};
 };  // class AttitudeIndicatorPlugin
 }  // namespace mapviz_plugins
+
 #endif  // MAPVIZ_PLUGINS__ATTITUDE_INDICATOR_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/disparity_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/disparity_plugin.hpp
@@ -32,6 +32,7 @@
 
 // Include mapviz_plugin.h first to ensure GL deps are included in the right order
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 // QT libraries
 #include <QColor>
@@ -111,6 +112,14 @@ protected Q_SLOTS:
   void SetHeight(int height);
   void SetSubscription(bool visible);
 
+Q_SIGNALS:
+  // Emitted from the ROS spin thread; delivered as queued connections to
+  // handleDisparity() on the GUI thread, which owns all plugin state.
+  void DisparityReceived(const stereo_msgs::msg::DisparityImage::ConstSharedPtr disparity);
+
+private Q_SLOTS:
+  void handleDisparity(const stereo_msgs::msg::DisparityImage::ConstSharedPtr disparity);
+
 private:
   void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
   Ui::disparity_config ui_;
@@ -138,7 +147,7 @@ private:
   cv::Mat_<cv::Vec3b> disparity_color_;
   cv::Mat scaled_image_;
 
-  void disparityCallback(const stereo_msgs::msg::DisparityImage::SharedPtr image);
+  void disparityCallback(const stereo_msgs::msg::DisparityImage::ConstSharedPtr image);
 
   void ScaleImage(double width, double height);
   void DrawIplImage(cv::Mat *image);
@@ -149,5 +158,6 @@ private:
   static const unsigned char COLOR_MAP[];
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__DISPARITY_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/float_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/float_plugin.hpp
@@ -117,6 +117,14 @@ namespace mapviz_plugins
     void SetOffsetY(int offset);
     void PostfixEdited();
 
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread; delivered as a queued connection to
+    // handleFloat() on the GUI thread, which owns all plugin state.
+    void FloatReceived(double value);
+
+  private Q_SLOTS:
+    void handleFloat(double value);
+
   private:
     Ui::float_config ui_;
     QWidget* config_widget_;

--- a/mapviz_plugins/include/mapviz_plugins/gps_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/gps_plugin.hpp
@@ -22,6 +22,7 @@
 
 // Include mapviz_plugin.h first to ensure GL deps are included in the right order
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 #include <mapviz/map_canvas.hpp>
 #include <mapviz_plugins/point_drawing_plugin.hpp>
@@ -74,6 +75,14 @@ class GpsPlugin : public mapviz_plugins::PointDrawingPlugin
     void SelectTopic();
     void TopicEdited();
 
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread; delivered as a queued connection to
+    // handleGpsFix() on the GUI thread, which owns all plugin state.
+    void GpsFixReceived(const gps_msgs::msg::GPSFix::ConstSharedPtr msg);
+
+  private Q_SLOTS:
+    void handleGpsFix(const gps_msgs::msg::GPSFix::ConstSharedPtr msg);
+
   private:
     Ui::gps_config ui_;
     QWidget* config_widget_;
@@ -85,9 +94,10 @@ class GpsPlugin : public mapviz_plugins::PointDrawingPlugin
     rclcpp::Subscription<gps_msgs::msg::GPSFix>::SharedPtr gps_sub_;
     bool has_message_;
 
-    void GPSFixCallback(const gps_msgs::msg::GPSFix::SharedPtr gps);
+    void GPSFixCallback(const gps_msgs::msg::GPSFix::ConstSharedPtr msg);
     void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__GPS_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/image_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/image_plugin.hpp
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS__IMAGE_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 // QT libraries
 #include <QOpenGLFunctions_1_1>
@@ -120,6 +121,14 @@ protected Q_SLOTS:
   void KeepRatioChanged(bool checked);
   void SetRotation(QString rotation);
 
+Q_SIGNALS:
+  // Emitted from the ROS spin thread; delivered as queued connections to
+  // handleImage() on the GUI thread, which owns all plugin state.
+  void ImageReceived(const sensor_msgs::msg::Image::ConstSharedPtr image);
+
+private Q_SLOTS:
+  void handleImage(const sensor_msgs::msg::Image::ConstSharedPtr image);
+
 private:
   Ui::image_config ui_;
   QWidget* config_widget_;
@@ -158,5 +167,6 @@ private:
   std::string UnitsToString(Units units);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__IMAGE_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/laserscan_plugin.hpp
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS__LASERSCAN_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 // QT libraries
 #include <QOpenGLFunctions_1_1>
@@ -101,6 +102,14 @@ class LaserScanPlugin : public mapviz::MapvizPlugin, protected QOpenGLFunctions_
     void DrawIcon() override;
     void ResetTransformedScans();
 
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread; delivered as queued connections to
+    // handleLaserScan() on the GUI thread, which owns all plugin state.
+    void LaserScanReceived(const sensor_msgs::msg::LaserScan::ConstSharedPtr scan);
+
+  private Q_SLOTS:
+    void handleLaserScan(const sensor_msgs::msg::LaserScan::ConstSharedPtr scan);
+
   private:
     struct StampedPoint
     {
@@ -121,10 +130,10 @@ class LaserScanPlugin : public mapviz::MapvizPlugin, protected QOpenGLFunctions_
       bool has_intensity;
     };
 
-    void laserScanCallback(const sensor_msgs::msg::LaserScan::SharedPtr scan);
+    void laserScanCallback(const sensor_msgs::msg::LaserScan::ConstSharedPtr scan);
     void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
     QColor CalculateColor(const StampedPoint& point, bool has_intensity);
-    void updatePreComputedTriginometic(const sensor_msgs::msg::LaserScan::SharedPtr msg);
+    void updatePreComputedTriginometic(const sensor_msgs::msg::LaserScan::ConstSharedPtr msg);
 
     Ui::laserscan_config ui_;
     QWidget* config_widget_;
@@ -152,5 +161,6 @@ class LaserScanPlugin : public mapviz::MapvizPlugin, protected QOpenGLFunctions_
     bool GetScanTransform(const Scan &scan, swri_transform_util::Transform& transform);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__LASERSCAN_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/marker_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/marker_plugin.hpp
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS__MARKER_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 // QT libraries
 #include <QOpenGLFunctions_1_1>
@@ -121,6 +122,17 @@ protected Q_SLOTS:
   void TopicEdited();
   void ClearHistory() override;
 
+Q_SIGNALS:
+  // Emitted from the ROS spin thread; delivered as queued connections to
+  // the handleMarker*() slots on the GUI thread, which owns all plugin
+  // state.
+  void MarkerReceived(const visualization_msgs::msg::Marker::ConstSharedPtr marker);
+  void MarkerArrayReceived(const visualization_msgs::msg::MarkerArray::ConstSharedPtr markers);
+
+private Q_SLOTS:
+  void handleMarker(const visualization_msgs::msg::Marker::ConstSharedPtr marker);
+  void handleMarkerArray(const visualization_msgs::msg::MarkerArray::ConstSharedPtr markers);
+
 private:
   struct Color
   {
@@ -177,13 +189,14 @@ private:
   std::unordered_map<MarkerId, MarkerData, MarkerIdHash> markers_;
   std::unordered_map<std::string, bool, MarkerNsHash> marker_visible_;
 
-  void handleMarker(visualization_msgs::msg::Marker::ConstSharedPtr marker);
-  void handleMarkerArray(visualization_msgs::msg::MarkerArray::ConstSharedPtr markers);
+  void markerCallback(const visualization_msgs::msg::Marker::ConstSharedPtr marker);
+  void markerArrayCallback(const visualization_msgs::msg::MarkerArray::ConstSharedPtr markers);
   void processMarker(const visualization_msgs::msg::Marker& marker);
   void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
   void transformArrow(MarkerData& markerData,
                       const swri_transform_util::Transform& transform);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__MARKER_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/navsat_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/navsat_plugin.hpp
@@ -21,6 +21,7 @@
 #define MAPVIZ_PLUGINS__NAVSAT_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 #include <mapviz/map_canvas.hpp>
 #include <mapviz_plugins/point_drawing_plugin.hpp>
 
@@ -72,6 +73,14 @@ class NavSatPlugin : public mapviz_plugins::PointDrawingPlugin
   void SelectTopic();
   void TopicEdited();
 
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread; delivered as a queued connection to
+    // handleNavSatFix() on the GUI thread, which owns all plugin state.
+    void NavSatFixReceived(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg);
+
+  private Q_SLOTS:
+    void handleNavSatFix(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg);
+
   private:
   Ui::navsat_config ui_;
   QWidget* config_widget_;
@@ -83,8 +92,9 @@ class NavSatPlugin : public mapviz_plugins::PointDrawingPlugin
   bool has_message_;
 
   void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
-  void NavSatFixCallback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr navsat);
+  void NavSatFixCallback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__NAVSAT_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/occupancy_grid_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/occupancy_grid_plugin.hpp
@@ -120,6 +120,13 @@ private:
   std::vector<uchar> color_buffer_;
   uint32_t texture_size_;
 
+  // Message callbacks run on the ROS spin thread, which must not touch the
+  // GL context or widgets; they fill color_buffer_, cache the widget-driven
+  // color scheme here, and set texture_stale_ so Draw() re-uploads the
+  // texture on the GUI thread.
+  std::string color_scheme_;
+  bool texture_stale_;
+
   Palette map_palette_;
   Palette costmap_palette_;
 
@@ -127,6 +134,7 @@ private:
   void Callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg);
   void CallbackUpdate(const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg);
   void updateTexture();
+  void rebuildTexture();
 };
 }   // namespace mapviz_plugins
 

--- a/mapviz_plugins/include/mapviz_plugins/occupancy_grid_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/occupancy_grid_plugin.hpp
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS__OCCUPANCY_GRID_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 // QT libraries
 #include <QOpenGLFunctions_1_1>
@@ -98,11 +99,22 @@ protected Q_SLOTS:
 
   void FrameChanged(std::string);
 
+Q_SIGNALS:
+  // Emitted from the ROS spin thread; delivered as queued connections to
+  // the handleGrid*() slots on the GUI thread, which owns all plugin
+  // state, the GL texture, and the color-scheme widget.
+  void GridReceived(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr grid);
+  void GridUpdateReceived(const map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
+
+private Q_SLOTS:
+  void handleGrid(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr grid);
+  void handleGridUpdate(const map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
+
 private:
   Ui::occupancy_grid_config ui_;
   QWidget* config_widget_;
 
-  nav_msgs::msg::OccupancyGrid::SharedPtr grid_;
+  nav_msgs::msg::OccupancyGrid::ConstSharedPtr grid_;
 
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr grid_sub_;
   rclcpp::Subscription<map_msgs::msg::OccupancyGridUpdate>::SharedPtr update_sub_;
@@ -120,22 +132,15 @@ private:
   std::vector<uchar> color_buffer_;
   uint32_t texture_size_;
 
-  // Message callbacks run on the ROS spin thread, which must not touch the
-  // GL context or widgets; they fill color_buffer_, cache the widget-driven
-  // color scheme here, and set texture_stale_ so Draw() re-uploads the
-  // texture on the GUI thread.
-  std::string color_scheme_;
-  bool texture_stale_;
-
   Palette map_palette_;
   Palette costmap_palette_;
 
   void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
-  void Callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg);
-  void CallbackUpdate(const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg);
+  void Callback(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg);
+  void CallbackUpdate(const map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr msg);
   void updateTexture();
-  void rebuildTexture();
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__OCCUPANCY_GRID_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/odometry_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/odometry_plugin.hpp
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS__ODOMETRY_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 #include <mapviz_plugins/point_drawing_plugin.hpp>
 // QT libraries
 #include <QOpenGLWidget>
@@ -86,6 +87,14 @@ class OdometryPlugin : public mapviz_plugins::PointDrawingPlugin
     void SelectTopic();
     void TopicEdited();
 
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread; delivered as a queued connection to
+    // handleOdometry() on the GUI thread, which owns all plugin state.
+    void OdometryReceived(nav_msgs::msg::Odometry::ConstSharedPtr odometry);
+
+  private Q_SLOTS:
+    void handleOdometry(nav_msgs::msg::Odometry::ConstSharedPtr odometry);
+
   private:
     Ui::odometry_config ui_;
     QWidget* config_widget_;
@@ -93,10 +102,11 @@ class OdometryPlugin : public mapviz_plugins::PointDrawingPlugin
     rmw_qos_profile_t qos_;
     rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odometry_sub_;
     bool has_message_;
-    void odometryCallback(const nav_msgs::msg::Odometry::SharedPtr odometry);
+    void odometryCallback(const nav_msgs::msg::Odometry::ConstSharedPtr odometry);
     void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__ODOMETRY_PLUGIN_HPP_
 

--- a/mapviz_plugins/include/mapviz_plugins/path_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/path_plugin.hpp
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS__PATH_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 // QT libraries
 #include <QOpenGLWidget>
@@ -81,6 +82,14 @@ class PathPlugin : public mapviz_plugins::PointDrawingPlugin
     void SelectTopic();
     void TopicEdited();
   
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread; delivered as a queued connection to
+    // handlePath() on the GUI thread, which owns all plugin state.
+    void PathReceived(const nav_msgs::msg::Path::ConstSharedPtr msg);
+
+  private Q_SLOTS:
+    void handlePath(const nav_msgs::msg::Path::ConstSharedPtr msg);
+
   private:
     Ui::path_config ui_;
     QWidget* config_widget_;
@@ -92,8 +101,9 @@ class PathPlugin : public mapviz_plugins::PointDrawingPlugin
     bool has_message_;
 
     void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
-    void pathCallback(const nav_msgs::msg::Path::SharedPtr path);
+    void pathCallback(const nav_msgs::msg::Path::ConstSharedPtr msg);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__PATH_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/plan_route_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/plan_route_plugin.hpp
@@ -101,6 +101,15 @@ class PlanRoutePlugin : public mapviz::MapvizPlugin, protected QOpenGLFunctions_
   void Clear();
   void VisibilityChanged(bool);
 
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread when the PlanRoute service responds;
+    // delivered as a queued connection to handlePlanRouteResponse() on the
+    // GUI thread, which owns all plugin state.
+    void PlanRouteCompleted(rclcpp::Client<marti_nav_msgs::srv::PlanRoute>::SharedFuture future);
+
+  private Q_SLOTS:
+    void handlePlanRouteResponse(rclcpp::Client<marti_nav_msgs::srv::PlanRoute>::SharedFuture future);
+
   private:
   // void Retry(const ros::TimerEvent& e);
   void Retry();
@@ -130,5 +139,8 @@ class PlanRoutePlugin : public mapviz::MapvizPlugin, protected QOpenGLFunctions_
   qreal max_distance_;
 };
 }   // namespace mapviz_plugins
+
+// Allows the service response future to be copied into a queued signal emission.
+Q_DECLARE_METATYPE(rclcpp::Client<marti_nav_msgs::srv::PlanRoute>::SharedFuture)
 
 #endif  // MAPVIZ_PLUGINS__PLAN_ROUTE_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/pointcloud2_plugin.hpp
@@ -37,7 +37,6 @@
 #include <QOpenGLFunctions_1_5>
 #include <QOpenGLWidget>
 #include <QColor>
-#include <QMutex>
 
 // ROS libraries
 #include <rclcpp/rclcpp.hpp>
@@ -70,6 +69,27 @@ public:
   {
     COLOR_FLAT = 0,
     COLOR_Z = 3
+  };
+
+  struct StampedPoint
+  {
+    tf2::Vector3 point;
+    std::vector<float> features;
+  };
+
+  // Public so a shared_ptr to a decoded scan can be carried by a queued
+  // signal from the ROS spin thread to the GUI thread.
+  struct Scan
+  {
+    rclcpp::Time stamp;
+    QColor color;
+    std::vector<StampedPoint> points;
+    std::string source_frame;
+    bool transformed;
+    std::map<std::string, FieldInfo> new_features;
+
+    std::vector<float> gl_point;
+    std::vector<uint8_t> gl_color;
   };
 
   PointCloud2Plugin();
@@ -111,29 +131,19 @@ protected Q_SLOTS:
   void ClearPointClouds();
   void SetSubscription(bool subscribe);
 
+Q_SIGNALS:
+  // Emitted from the ROS spin thread with a freshly decoded scan; delivered
+  // as a queued connection to handleScan() on the GUI thread, which owns
+  // scans_ and everything configuration-dependent.
+  void ScanProcessed(std::shared_ptr<mapviz_plugins::PointCloud2Plugin::Scan> scan);
+
+private Q_SLOTS:
+  void handleScan(std::shared_ptr<mapviz_plugins::PointCloud2Plugin::Scan> scan);
+
 private:
-  struct StampedPoint
-  {
-    tf2::Vector3 point;
-    std::vector<float> features;
-  };
-
-  struct Scan
-  {
-    rclcpp::Time stamp;
-    QColor color;
-    std::vector<StampedPoint> points;
-    std::string source_frame;
-    bool transformed;
-    std::map<std::string, FieldInfo> new_features;
-
-    std::vector<float> gl_point;
-    std::vector<uint8_t> gl_color;
-  };
-
   float PointFeature(const uint8_t*, const FieldInfo&);
   void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
-  void PointCloud2Callback(const sensor_msgs::msg::PointCloud2::SharedPtr scan);
+  void PointCloud2Callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr scan);
   QColor CalculateColor(const StampedPoint& point);
   void UpdateMinMaxWidgets();
 
@@ -147,7 +157,6 @@ private:
   double min_value_;
   size_t point_size_;
   size_t buffer_size_;
-  bool new_topic_;
   bool has_message_;
   size_t num_of_feats_;
   bool need_new_list_;
@@ -163,9 +172,10 @@ private:
 
   QOpenGLBuffer point_buffer_;
   QOpenGLBuffer color_buffer_;
-
-  QMutex scan_mutex_;
 };
 }   // namespace mapviz_plugins
+
+// Allows the decoded scan to be carried by a queued signal emission.
+Q_DECLARE_METATYPE(std::shared_ptr<mapviz_plugins::PointCloud2Plugin::Scan>)
 
 #endif  // MAPVIZ_PLUGINS__POINTCLOUD2_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/pose_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/pose_plugin.hpp
@@ -33,6 +33,7 @@
 
 // Include mapviz_plugin.h first to ensure GL deps are included in the right order
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 #include <mapviz/map_canvas.hpp>
 #include <mapviz_plugins/point_drawing_plugin.hpp>
@@ -85,6 +86,14 @@ class PosePlugin : public mapviz_plugins::PointDrawingPlugin
     void SelectTopic();
     void TopicEdited();
 
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread; delivered as a queued connection to
+    // handlePose() on the GUI thread, which owns all plugin state.
+    void PoseReceived(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg);
+
+  private Q_SLOTS:
+    void handlePose(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg);
+
   private:
     Ui::pose_config ui_;
     QWidget* config_widget_;
@@ -96,8 +105,9 @@ class PosePlugin : public mapviz_plugins::PointDrawingPlugin
     bool has_message_;
 
     void connectCallback(const std::string& topic, const rmw_qos_profile_t& qos);
-    void PoseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr pose);
+    void PoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__POSE_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/robot_model_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/robot_model_plugin.hpp
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS__ROBOT_MODEL_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 #include <QColor>
 #include <QObject>
@@ -113,6 +114,14 @@ class RobotModelPlugin : public mapviz::MapvizPlugin {
   void BrowseFile();
   void FileEdited();
 
+ Q_SIGNALS:
+   // Emitted from the ROS spin thread; delivered as queued connections to
+   // handleDescription() on the GUI thread, which owns all plugin state.
+   void DescriptionReceived(const std_msgs::msg::String::ConstSharedPtr description);
+
+ private Q_SLOTS:
+   void handleDescription(const std_msgs::msg::String::ConstSharedPtr description);
+
  private:
   struct BakeResult {
     GLuint texture{0};
@@ -124,7 +133,7 @@ class RobotModelPlugin : public mapviz::MapvizPlugin {
     bool ready{false};
   };
 
-  void robotDescriptionCallback(const std_msgs::msg::String::SharedPtr msg);
+  void robotDescriptionCallback(const std_msgs::msg::String::ConstSharedPtr msg);
   void parseUrdf(const std::string& xml);
   void rebakeRaster(const std::vector<LinkGeometry>& geoms, double scale,
                     int canvas_max_dim, bool off_screen);
@@ -164,5 +173,6 @@ class RobotModelPlugin : public mapviz::MapvizPlugin {
 };
 
 }  // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__ROBOT_MODEL_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/ros_metatypes.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/ros_metatypes.hpp
@@ -1,0 +1,79 @@
+// *****************************************************************************
+//
+// Copyright (c) 2026, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef MAPVIZ_PLUGINS__ROS_METATYPES_HPP_
+#define MAPVIZ_PLUGINS__ROS_METATYPES_HPP_
+
+// Qt metatype declarations for the ROS message shared_ptrs that plugins carry
+// through queued signal emissions (ROS spin thread -> GUI thread).  They are
+// centralized here because AUTOMOC compiles every moc file in a single
+// translation unit, so a type declared in two plugin headers would be a
+// redefinition.
+
+#include <QMetaType>
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <map_msgs/msg/occupancy_grid_update.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <stereo_msgs/msg/disparity_image.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <gps_msgs/msg/gps_fix.hpp>
+#include <marti_nav_msgs/msg/route.hpp>
+#include <marti_nav_msgs/msg/route_position.hpp>
+
+Q_DECLARE_METATYPE(geometry_msgs::msg::Pose::ConstSharedPtr)
+Q_DECLARE_METATYPE(geometry_msgs::msg::PoseStamped::ConstSharedPtr)
+Q_DECLARE_METATYPE(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr)
+Q_DECLARE_METATYPE(nav_msgs::msg::OccupancyGrid::ConstSharedPtr)
+Q_DECLARE_METATYPE(nav_msgs::msg::Odometry::ConstSharedPtr)
+Q_DECLARE_METATYPE(nav_msgs::msg::Path::ConstSharedPtr)
+Q_DECLARE_METATYPE(sensor_msgs::msg::Image::ConstSharedPtr)
+Q_DECLARE_METATYPE(sensor_msgs::msg::Imu::ConstSharedPtr)
+Q_DECLARE_METATYPE(sensor_msgs::msg::LaserScan::ConstSharedPtr)
+Q_DECLARE_METATYPE(sensor_msgs::msg::NavSatFix::ConstSharedPtr)
+Q_DECLARE_METATYPE(std_msgs::msg::String::ConstSharedPtr)
+Q_DECLARE_METATYPE(stereo_msgs::msg::DisparityImage::ConstSharedPtr)
+Q_DECLARE_METATYPE(visualization_msgs::msg::Marker::ConstSharedPtr)
+Q_DECLARE_METATYPE(visualization_msgs::msg::MarkerArray::ConstSharedPtr)
+
+Q_DECLARE_METATYPE(gps_msgs::msg::GPSFix::ConstSharedPtr)
+Q_DECLARE_METATYPE(marti_nav_msgs::msg::Route::ConstSharedPtr)
+Q_DECLARE_METATYPE(marti_nav_msgs::msg::RoutePosition::ConstSharedPtr)
+
+#endif  // MAPVIZ_PLUGINS__ROS_METATYPES_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/route_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/route_plugin.hpp
@@ -31,6 +31,7 @@
 #define MAPVIZ_PLUGINS__ROUTE_PLUGIN_HPP_
 
 #include <mapviz/mapviz_plugin.hpp>
+#include <mapviz_plugins/ros_metatypes.hpp>
 
 // QT libraries
 #include <QOpenGLFunctions_1_1>
@@ -97,6 +98,16 @@ class RoutePlugin : public mapviz::MapvizPlugin, protected QOpenGLFunctions_1_1
     void SetDrawStyle(QString style);
     void DrawIcon() override;
 
+  Q_SIGNALS:
+    // Emitted from the ROS spin thread; delivered as queued connections to
+    // the handle*() slots on the GUI thread, which owns all plugin state.
+    void RouteReceived(const marti_nav_msgs::msg::Route::ConstSharedPtr route);
+    void RoutePositionReceived(const marti_nav_msgs::msg::RoutePosition::ConstSharedPtr position);
+
+  private Q_SLOTS:
+    void handleRoute(const marti_nav_msgs::msg::Route::ConstSharedPtr route);
+    void handleRoutePosition(const marti_nav_msgs::msg::RoutePosition::ConstSharedPtr position);
+
   private:
     Ui::route_config ui_;
     QWidget* config_widget_;
@@ -113,13 +124,14 @@ class RoutePlugin : public mapviz::MapvizPlugin, protected QOpenGLFunctions_1_1
 
     swri_route_util::Route src_route_;
     // marti_nav_msgs::RoutePositionConstPtr src_route_position_;
-    marti_nav_msgs::msg::RoutePosition::SharedPtr src_route_position_;
+    marti_nav_msgs::msg::RoutePosition::ConstSharedPtr src_route_position_;
 
     void connectRouteCallback(const std::string& topic, const rmw_qos_profile_t& qos);
     void connectPositionCallback(const std::string& topic, const rmw_qos_profile_t& qos);
-    void RouteCallback(const marti_nav_msgs::msg::Route::SharedPtr msg);
-    void PositionCallback(const marti_nav_msgs::msg::RoutePosition::SharedPtr msg);
+    void RouteCallback(const marti_nav_msgs::msg::Route::ConstSharedPtr msg);
+    void PositionCallback(const marti_nav_msgs::msg::RoutePosition::ConstSharedPtr msg);
 };
 }   // namespace mapviz_plugins
+
 
 #endif  // MAPVIZ_PLUGINS__ROUTE_PLUGIN_HPP_

--- a/mapviz_plugins/include/mapviz_plugins/string_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/string_plugin.hpp
@@ -116,6 +116,11 @@ protected Q_SLOTS:
   void SetOffsetX(int offset);
   void SetOffsetY(int offset);
 
+Q_SIGNALS:
+  // Emitted from the ROS spin thread; delivered as a queued connection to
+  // SetText() on the GUI thread, which owns all plugin state.
+  void TextReceived(const QString& text);
+
 private:
   Ui::string_config ui_;
   QWidget* config_widget_;

--- a/mapviz_plugins/include/mapviz_plugins/tf_frame_plugin.hpp
+++ b/mapviz_plugins/include/mapviz_plugins/tf_frame_plugin.hpp
@@ -34,6 +34,7 @@
 #include <mapviz_plugins/point_drawing_plugin.hpp>
 // QT libraries
 #include <QOpenGLWidget>
+#include <QTimer>
 #include <QObject>
 #include <QWidget>
 
@@ -84,7 +85,7 @@ class TfFramePlugin : public mapviz_plugins::PointDrawingPlugin
   Ui::tf_frame_config ui_{};
   QWidget* config_widget_;
 
-  rclcpp::TimerBase::SharedPtr timer_;
+  QTimer timer_;
 
   void TimerCallback();
 };

--- a/mapviz_plugins/src/attitude_indicator_plugin.cpp
+++ b/mapviz_plugins/src/attitude_indicator_plugin.cpp
@@ -227,7 +227,9 @@ namespace mapviz_plugins
     pitch_ = pitch_ * (180.0 / M_PI);
     yaw_ = yaw_ * (180.0 / M_PI);
 
-    canvas_->update();
+    // Runs on the ROS spin thread; QWidget::update() must be invoked on the
+    // GUI thread.
+    QMetaObject::invokeMethod(canvas_, "update", Qt::QueuedConnection);
   }
 
   void AttitudeIndicatorPlugin::PrintError(const std::string& message)

--- a/mapviz_plugins/src/attitude_indicator_plugin.cpp
+++ b/mapviz_plugins/src/attitude_indicator_plugin.cpp
@@ -139,6 +139,22 @@ namespace mapviz_plugins
 
     QObject::connect(ui_.selecttopic, SIGNAL(clicked()), this, SLOT(SelectTopic()));
     QObject::connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; these connections are
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<sensor_msgs::msg::Imu::ConstSharedPtr>(
+        "sensor_msgs::msg::Imu::ConstSharedPtr");
+    qRegisterMetaType<nav_msgs::msg::Odometry::ConstSharedPtr>(
+        "nav_msgs::msg::Odometry::ConstSharedPtr");
+    qRegisterMetaType<geometry_msgs::msg::Pose::ConstSharedPtr>(
+        "geometry_msgs::msg::Pose::ConstSharedPtr");
+    QObject::connect(this, &AttitudeIndicatorPlugin::ImuReceived,
+                     this, &AttitudeIndicatorPlugin::handleImu);
+    QObject::connect(this, &AttitudeIndicatorPlugin::OdometryReceived,
+                     this, &AttitudeIndicatorPlugin::handleOdometry);
+    QObject::connect(this, &AttitudeIndicatorPlugin::PoseReceived,
+                     this, &AttitudeIndicatorPlugin::handlePose);
   }
 
   void AttitudeIndicatorPlugin::SelectTopic()
@@ -195,18 +211,37 @@ namespace mapviz_plugins
     }
   }
 
+  // These callbacks run on the ROS spin thread: they hand the message to the
+  // GUI thread and return immediately so message processing never blocks ROS
+  // spinning.
   void AttitudeIndicatorPlugin::AttitudeCallbackOdom(
     nav_msgs::msg::Odometry::ConstSharedPtr odometry)
   {
-    applyAttitudeOrientation(odometry->pose.pose.orientation);
+    Q_EMIT OdometryReceived(odometry);
   }
 
   void AttitudeIndicatorPlugin::AttitudeCallbackImu(sensor_msgs::msg::Imu::ConstSharedPtr imu)
   {
-    applyAttitudeOrientation(imu->orientation);
+    Q_EMIT ImuReceived(imu);
   }
 
   void AttitudeIndicatorPlugin::AttitudeCallbackPose(geometry_msgs::msg::Pose::ConstSharedPtr pose)
+  {
+    Q_EMIT PoseReceived(pose);
+  }
+
+  void AttitudeIndicatorPlugin::handleOdometry(
+    const nav_msgs::msg::Odometry::ConstSharedPtr odometry)
+  {
+    applyAttitudeOrientation(odometry->pose.pose.orientation);
+  }
+
+  void AttitudeIndicatorPlugin::handleImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu)
+  {
+    applyAttitudeOrientation(imu->orientation);
+  }
+
+  void AttitudeIndicatorPlugin::handlePose(const geometry_msgs::msg::Pose::ConstSharedPtr pose)
   {
     applyAttitudeOrientation(pose->orientation);
   }
@@ -227,9 +262,7 @@ namespace mapviz_plugins
     pitch_ = pitch_ * (180.0 / M_PI);
     yaw_ = yaw_ * (180.0 / M_PI);
 
-    // Runs on the ROS spin thread; QWidget::update() must be invoked on the
-    // GUI thread.
-    QMetaObject::invokeMethod(canvas_, "update", Qt::QueuedConnection);
+    canvas_->update();
   }
 
   void AttitudeIndicatorPlugin::PrintError(const std::string& message)

--- a/mapviz_plugins/src/coordinate_picker_plugin.cpp
+++ b/mapviz_plugins/src/coordinate_picker_plugin.cpp
@@ -130,6 +130,9 @@ bool CoordinatePickerPlugin::eventFilter(QObject* object, QEvent* event)
 
 bool CoordinatePickerPlugin::handleMousePress(QMouseEvent* event)
 {
+  // Uses tf_manager_, which is shared with callbacks on the ROS spin
+  // thread and is not thread safe.
+  std::lock_guard<std::recursive_mutex> lock(DataMutex());
   QPointF point = mapviz::MouseEventPosition(event);
   RCLCPP_DEBUG(node_->get_logger(), "Map point: %f %f", point.x(), point.y());
 

--- a/mapviz_plugins/src/coordinate_picker_plugin.cpp
+++ b/mapviz_plugins/src/coordinate_picker_plugin.cpp
@@ -130,9 +130,6 @@ bool CoordinatePickerPlugin::eventFilter(QObject* object, QEvent* event)
 
 bool CoordinatePickerPlugin::handleMousePress(QMouseEvent* event)
 {
-  // Uses tf_manager_, which is shared with callbacks on the ROS spin
-  // thread and is not thread safe.
-  std::lock_guard<std::recursive_mutex> lock(DataMutex());
   QPointF point = mapviz::MouseEventPosition(event);
   RCLCPP_DEBUG(node_->get_logger(), "Map point: %f %f", point.x(), point.y());
 

--- a/mapviz_plugins/src/disparity_plugin.cpp
+++ b/mapviz_plugins/src/disparity_plugin.cpp
@@ -97,6 +97,14 @@ namespace mapviz_plugins
     QObject::connect(ui_.width, SIGNAL(valueChanged(int)), this, SLOT(SetWidth(int)));
     QObject::connect(ui_.height, SIGNAL(valueChanged(int)), this, SLOT(SetHeight(int)));
     QObject::connect(this, SIGNAL(VisibleChanged(bool)), this, SLOT(SetSubscription(bool)));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; these connections are
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<stereo_msgs::msg::DisparityImage::ConstSharedPtr>(
+        "stereo_msgs::msg::DisparityImage::ConstSharedPtr");
+    QObject::connect(this, &DisparityPlugin::DisparityReceived,
+                     this, &DisparityPlugin::handleDisparity);
   }
 
   void DisparityPlugin::SetOffsetX(int offset)
@@ -229,8 +237,14 @@ namespace mapviz_plugins
     }
   }
 
-  void DisparityPlugin::disparityCallback(
-    const stereo_msgs::msg::DisparityImage::SharedPtr disparity)
+  void DisparityPlugin::disparityCallback(const stereo_msgs::msg::DisparityImage::ConstSharedPtr disparity)
+  {
+    // Runs on the ROS spin thread: hand the message to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning.
+    Q_EMIT DisparityReceived(disparity);
+  }
+
+  void DisparityPlugin::handleDisparity(const stereo_msgs::msg::DisparityImage::ConstSharedPtr disparity)
   {
     if (!has_message_)
     {

--- a/mapviz_plugins/src/draw_polygon_plugin.cpp
+++ b/mapviz_plugins/src/draw_polygon_plugin.cpp
@@ -202,6 +202,9 @@ namespace mapviz_plugins
 
   bool DrawPolygonPlugin::handleMousePress(QMouseEvent* event)
   {
+    // Uses tf_manager_, which is shared with callbacks on the ROS spin
+    // thread and is not thread safe.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     if(!this->Visible())
     {
       RCLCPP_DEBUG(node_->get_logger(), "Ignoring mouse press, since draw polygon plugin is hidden");
@@ -260,6 +263,9 @@ namespace mapviz_plugins
 
   bool DrawPolygonPlugin::handleMouseRelease(QMouseEvent* event)
   {
+    // Uses tf_manager_, which is shared with callbacks on the ROS spin
+    // thread and is not thread safe.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     std::string frame = ui_.frame->text().toStdString();
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
     {
@@ -320,6 +326,9 @@ namespace mapviz_plugins
 
   bool DrawPolygonPlugin::handleMouseMove(QMouseEvent* event)
   {
+    // Uses tf_manager_, which is shared with callbacks on the ROS spin
+    // thread and is not thread safe.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
     {
       QPointF point = mapviz::MouseEventPosition(event);

--- a/mapviz_plugins/src/draw_polygon_plugin.cpp
+++ b/mapviz_plugins/src/draw_polygon_plugin.cpp
@@ -202,9 +202,6 @@ namespace mapviz_plugins
 
   bool DrawPolygonPlugin::handleMousePress(QMouseEvent* event)
   {
-    // Uses tf_manager_, which is shared with callbacks on the ROS spin
-    // thread and is not thread safe.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     if(!this->Visible())
     {
       RCLCPP_DEBUG(node_->get_logger(), "Ignoring mouse press, since draw polygon plugin is hidden");
@@ -263,9 +260,6 @@ namespace mapviz_plugins
 
   bool DrawPolygonPlugin::handleMouseRelease(QMouseEvent* event)
   {
-    // Uses tf_manager_, which is shared with callbacks on the ROS spin
-    // thread and is not thread safe.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     std::string frame = ui_.frame->text().toStdString();
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
     {
@@ -326,9 +320,6 @@ namespace mapviz_plugins
 
   bool DrawPolygonPlugin::handleMouseMove(QMouseEvent* event)
   {
-    // Uses tf_manager_, which is shared with callbacks on the ROS spin
-    // thread and is not thread safe.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < vertices_.size())
     {
       QPointF point = mapviz::MouseEventPosition(event);

--- a/mapviz_plugins/src/float_plugin.cpp
+++ b/mapviz_plugins/src/float_plugin.cpp
@@ -83,6 +83,12 @@ namespace mapviz_plugins
     QObject::connect(ui_.color, SIGNAL(colorEdited(const QColor &)), this, SLOT(SelectColor()));
     QObject::connect(ui_.postfix, SIGNAL(editingFinished()), this, SLOT(PostfixEdited()));
 
+    // Values are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; this connection is
+    // queued because the emitting thread differs from this object's thread.
+    QObject::connect(this, &FloatPlugin::FloatReceived,
+                     this, &FloatPlugin::handleFloat);
+
     font_.setFamily(tr("Helvetica"));
     ui_.font_button->setFont(font_);
     ui_.font_button->setText(font_.family());
@@ -448,6 +454,13 @@ namespace mapviz_plugins
   }
 
   void FloatPlugin::floatCallback(double value)
+  {
+    // Runs on the ROS spin thread: hand the value to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning.
+    Q_EMIT FloatReceived(value);
+  }
+
+  void FloatPlugin::handleFloat(double value)
   {
 
     std::string str = std::to_string(value);

--- a/mapviz_plugins/src/gps_plugin.cpp
+++ b/mapviz_plugins/src/gps_plugin.cpp
@@ -88,6 +88,14 @@ namespace mapviz_plugins
             SLOT(LapToggled(bool)));
     QObject::connect(ui_.buttonResetBuffer, SIGNAL(pressed()), this,
                      SLOT(ClearPoints()));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; this connection is
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<gps_msgs::msg::GPSFix::ConstSharedPtr>(
+        "gps_msgs::msg::GPSFix::ConstSharedPtr");
+    QObject::connect(this, &GpsPlugin::GpsFixReceived,
+                     this, &GpsPlugin::handleGpsFix);
   }
 
   void GpsPlugin::SelectTopic()
@@ -134,7 +142,14 @@ namespace mapviz_plugins
     }
   }
 
-  void GpsPlugin::GPSFixCallback(const gps_msgs::msg::GPSFix::SharedPtr gps)
+  void GpsPlugin::GPSFixCallback(const gps_msgs::msg::GPSFix::ConstSharedPtr gps)
+  {
+    // Runs on the ROS spin thread: hand the message to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning.
+    Q_EMIT GpsFixReceived(gps);
+  }
+
+  void GpsPlugin::handleGpsFix(const gps_msgs::msg::GPSFix::ConstSharedPtr gps)
   {
     if (!tf_manager_->LocalXyUtil()->Initialized())
     {

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -100,6 +100,14 @@ namespace mapviz_plugins
 
     ui_.width->setKeyboardTracking(false);
     ui_.height->setKeyboardTracking(false);
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; these connections are
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<sensor_msgs::msg::Image::ConstSharedPtr>(
+        "sensor_msgs::msg::Image::ConstSharedPtr");
+    QObject::connect(this, &ImagePlugin::ImageReceived,
+                     this, &ImagePlugin::handleImage);
   }
 
   void ImagePlugin::SetOffsetX(int offset)
@@ -349,6 +357,13 @@ namespace mapviz_plugins
 
   void ImagePlugin::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr& image)
   {
+    // Runs on the ROS spin thread: hand the message to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning.
+    Q_EMIT ImageReceived(image);
+  }
+
+  void ImagePlugin::handleImage(const sensor_msgs::msg::Image::ConstSharedPtr image)
+  {
     if (!has_message_)
     {
       initialized_ = true;
@@ -384,15 +399,10 @@ namespace mapviz_plugins
     // Calculate aspect ratio after rotation
     original_aspect_ratio_ = static_cast<double>(cv_image_->image.rows) / static_cast<double>(cv_image_->image.cols);
 
-    // This callback runs on the ROS spin thread; reading keep_ratio and
-    // updating the height spin box must happen on the GUI thread.
-    QMetaObject::invokeMethod(this, [this]() {
-        std::lock_guard<std::recursive_mutex> lock(DataMutex());
-        if (ui_.keep_ratio->isChecked())
-        {
-          KeepRatioChanged(true);
-        }
-      }, Qt::QueuedConnection);
+    if (ui_.keep_ratio->isChecked())
+    {
+      KeepRatioChanged(true);
+    }
 
     has_image_ = true;
   }

--- a/mapviz_plugins/src/image_plugin.cpp
+++ b/mapviz_plugins/src/image_plugin.cpp
@@ -384,22 +384,15 @@ namespace mapviz_plugins
     // Calculate aspect ratio after rotation
     original_aspect_ratio_ = static_cast<double>(cv_image_->image.rows) / static_cast<double>(cv_image_->image.cols);
 
-    if( ui_.keep_ratio->isChecked() )
-    {
-      double height =  width_ * original_aspect_ratio_;
-      if (units_ == PERCENT)
-      {
-        height *= static_cast<double>(canvas_->width()) / static_cast<double>(canvas_->height());
-        // Round to 2 decimal places for percent
-        height = std::round(height * 100.0) / 100.0;
-      }
-      else
-      {
-        // Round to nearest whole number for pixels
-        height = std::round(height);
-      }
-      ui_.height->setValue(height);
-    }
+    // This callback runs on the ROS spin thread; reading keep_ratio and
+    // updating the height spin box must happen on the GUI thread.
+    QMetaObject::invokeMethod(this, [this]() {
+        std::lock_guard<std::recursive_mutex> lock(DataMutex());
+        if (ui_.keep_ratio->isChecked())
+        {
+          KeepRatioChanged(true);
+        }
+      }, Qt::QueuedConnection);
 
     has_image_ = true;
   }

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -154,6 +154,8 @@ namespace mapviz_plugins
   void LaserScanPlugin::ClearHistory()
   {
     RCLCPP_DEBUG(node_->get_logger(), "LaserScan::ClearHistory()");
+    // scans_ is shared with the message callback on the ROS spin thread.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     scans_.clear();
   }
 
@@ -273,6 +275,8 @@ namespace mapviz_plugins
     ui_.topic->setText(QString::fromStdString(topic));
     if ((topic != topic_) || !qosEqual(qos, qos_))
     {
+      std::lock_guard<std::recursive_mutex> lock(DataMutex());
+
       initialized_ = false;
       scans_.clear();
       has_message_ = false;
@@ -309,6 +313,7 @@ namespace mapviz_plugins
 
   void LaserScanPlugin::BufferSizeChanged(int value)
   {
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     buffer_size_ = static_cast<size_t>(value);
 
     if (buffer_size_ > 0)

--- a/mapviz_plugins/src/laserscan_plugin.cpp
+++ b/mapviz_plugins/src/laserscan_plugin.cpp
@@ -149,13 +149,19 @@ namespace mapviz_plugins
         SIGNAL(TargetFrameChanged(const std::string&)),
         this,
         SLOT(ResetTransformedScans()));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; these connections are
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<sensor_msgs::msg::LaserScan::ConstSharedPtr>(
+        "sensor_msgs::msg::LaserScan::ConstSharedPtr");
+    QObject::connect(this, &LaserScanPlugin::LaserScanReceived,
+                     this, &LaserScanPlugin::handleLaserScan);
   }
 
   void LaserScanPlugin::ClearHistory()
   {
     RCLCPP_DEBUG(node_->get_logger(), "LaserScan::ClearHistory()");
-    // scans_ is shared with the message callback on the ROS spin thread.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     scans_.clear();
   }
 
@@ -275,8 +281,6 @@ namespace mapviz_plugins
     ui_.topic->setText(QString::fromStdString(topic));
     if ((topic != topic_) || !qosEqual(qos, qos_))
     {
-      std::lock_guard<std::recursive_mutex> lock(DataMutex());
-
       initialized_ = false;
       scans_.clear();
       has_message_ = false;
@@ -313,7 +317,6 @@ namespace mapviz_plugins
 
   void LaserScanPlugin::BufferSizeChanged(int value)
   {
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     buffer_size_ = static_cast<size_t>(value);
 
     if (buffer_size_ > 0)
@@ -331,7 +334,7 @@ namespace mapviz_plugins
   }
 
   void LaserScanPlugin::updatePreComputedTriginometic(
-    const sensor_msgs::msg::LaserScan::SharedPtr msg)
+    const sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
   {
       if( msg->ranges.size() != prev_ranges_size_ ||
           msg->angle_min !=  prev_angle_min_  ||
@@ -372,7 +375,14 @@ namespace mapviz_plugins
       return has_tranform;
   }
 
-  void LaserScanPlugin::laserScanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+  void LaserScanPlugin::laserScanCallback(const sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
+  {
+    // Runs on the ROS spin thread: hand the message to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning.
+    Q_EMIT LaserScanReceived(msg);
+  }
+
+  void LaserScanPlugin::handleLaserScan(const sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
   {
     if (!has_message_)
     {

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -69,14 +69,24 @@ namespace mapviz_plugins
     QObject::connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
     QObject::connect(ui_.clear, SIGNAL(clicked()), this, SLOT(ClearHistory()));
 
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; these connections are
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<visualization_msgs::msg::Marker::ConstSharedPtr>(
+        "visualization_msgs::msg::Marker::ConstSharedPtr");
+    qRegisterMetaType<visualization_msgs::msg::MarkerArray::ConstSharedPtr>(
+        "visualization_msgs::msg::MarkerArray::ConstSharedPtr");
+    QObject::connect(this, &MarkerPlugin::MarkerReceived,
+                     this, &MarkerPlugin::handleMarker);
+    QObject::connect(this, &MarkerPlugin::MarkerArrayReceived,
+                     this, &MarkerPlugin::handleMarkerArray);
+
     startTimer(1000);
   }
 
   void MarkerPlugin::ClearHistory()
   {
     RCLCPP_DEBUG(node_->get_logger(), "MarkerPlugin::ClearHistory()");
-    // markers_ and marker_visible_ are shared with the ROS spin thread.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     markers_.clear();
     marker_visible_.clear();
     ui_.nsList->clear();
@@ -107,8 +117,6 @@ namespace mapviz_plugins
 
     if ((topic != topic_) || !qosEqual(qos, qos_))
     {
-      std::lock_guard<std::recursive_mutex> lock(DataMutex());
-
       initialized_ = false;
       markers_.clear();
       marker_visible_.clear();
@@ -141,14 +149,14 @@ namespace mapviz_plugins
           marker_sub_ = node_->create_subscription<visualization_msgs::msg::Marker>(
             topic_,
             rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos), qos),
-            std::bind(&MarkerPlugin::handleMarker, this, std::placeholders::_1));
+            std::bind(&MarkerPlugin::markerCallback, this, std::placeholders::_1));
         }
         else if (topic_type == "visualization_msgs/msg/MarkerArray")
         {
           marker_array_sub_ = node_->create_subscription<visualization_msgs::msg::MarkerArray>(
             topic_,
             rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos), qos),
-            std::bind(&MarkerPlugin::handleMarkerArray, this, std::placeholders::_1));
+            std::bind(&MarkerPlugin::markerArrayCallback, this, std::placeholders::_1));
         }
         else
         {
@@ -169,7 +177,21 @@ namespace mapviz_plugins
     }
   }
 
-  void MarkerPlugin::handleMarker(visualization_msgs::msg::Marker::ConstSharedPtr marker)
+  // These callbacks run on the ROS spin thread: they hand the message to the
+  // GUI thread and return immediately so message processing never blocks ROS
+  // spinning.
+  void MarkerPlugin::markerCallback(const visualization_msgs::msg::Marker::ConstSharedPtr marker)
+  {
+    Q_EMIT MarkerReceived(marker);
+  }
+
+  void MarkerPlugin::markerArrayCallback(
+      const visualization_msgs::msg::MarkerArray::ConstSharedPtr markers)
+  {
+    Q_EMIT MarkerArrayReceived(markers);
+  }
+
+  void MarkerPlugin::handleMarker(const visualization_msgs::msg::Marker::ConstSharedPtr marker)
   {
     processMarker(*marker);
   }
@@ -211,15 +233,11 @@ namespace mapviz_plugins
 
       if (marker_visible_.emplace(marker.ns, true).second)
       {
-        // This runs on the ROS spin thread; the namespace list widget can
-        // only be updated on the GUI thread.
         QString name_string(marker.ns.c_str());
-        QMetaObject::invokeMethod(this, [this, name_string]() {
-            auto* item = new QListWidgetItem(name_string, ui_.nsList);
-            item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-            item->setCheckState(Qt::Unchecked);
-            item->setCheckState(Qt::Checked);
-          }, Qt::QueuedConnection);
+        auto* item = new QListWidgetItem(name_string, ui_.nsList);
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        item->setCheckState(Qt::Unchecked);
+        item->setCheckState(Qt::Checked);
       }
 
 
@@ -420,7 +438,7 @@ namespace mapviz_plugins
     point.transformed_arrow_right = point.transformed_arrow_point + right_tf * arrowOffset;
   }
 
-  void MarkerPlugin::handleMarkerArray(visualization_msgs::msg::MarkerArray::ConstSharedPtr markers)
+  void MarkerPlugin::handleMarkerArray(const visualization_msgs::msg::MarkerArray::ConstSharedPtr markers)
   {
     for (const auto & marker : markers->markers)
     {

--- a/mapviz_plugins/src/marker_plugin.cpp
+++ b/mapviz_plugins/src/marker_plugin.cpp
@@ -75,6 +75,8 @@ namespace mapviz_plugins
   void MarkerPlugin::ClearHistory()
   {
     RCLCPP_DEBUG(node_->get_logger(), "MarkerPlugin::ClearHistory()");
+    // markers_ and marker_visible_ are shared with the ROS spin thread.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     markers_.clear();
     marker_visible_.clear();
     ui_.nsList->clear();
@@ -105,6 +107,8 @@ namespace mapviz_plugins
 
     if ((topic != topic_) || !qosEqual(qos, qos_))
     {
+      std::lock_guard<std::recursive_mutex> lock(DataMutex());
+
       initialized_ = false;
       markers_.clear();
       marker_visible_.clear();
@@ -207,11 +211,15 @@ namespace mapviz_plugins
 
       if (marker_visible_.emplace(marker.ns, true).second)
       {
+        // This runs on the ROS spin thread; the namespace list widget can
+        // only be updated on the GUI thread.
         QString name_string(marker.ns.c_str());
-        auto* item = new QListWidgetItem(name_string, ui_.nsList);
-        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-        item->setCheckState(Qt::Unchecked);
-        item->setCheckState(Qt::Checked);
+        QMetaObject::invokeMethod(this, [this, name_string]() {
+            auto* item = new QListWidgetItem(name_string, ui_.nsList);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+            item->setCheckState(Qt::Unchecked);
+            item->setCheckState(Qt::Checked);
+          }, Qt::QueuedConnection);
       }
 
 

--- a/mapviz_plugins/src/navsat_plugin.cpp
+++ b/mapviz_plugins/src/navsat_plugin.cpp
@@ -79,6 +79,14 @@ namespace mapviz_plugins
                      SLOT(SetColor(const QColor&)));
     QObject::connect(ui_.buttonResetBuffer, SIGNAL(pressed()), this,
                      SLOT(ClearPoints()));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; this connection is
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<sensor_msgs::msg::NavSatFix::ConstSharedPtr>(
+        "sensor_msgs::msg::NavSatFix::ConstSharedPtr");
+    QObject::connect(this, &NavSatPlugin::NavSatFixReceived,
+                     this, &NavSatPlugin::handleNavSatFix);
   }
 
   void NavSatPlugin::SelectTopic()
@@ -125,8 +133,14 @@ namespace mapviz_plugins
     }
   }
 
-  void NavSatPlugin::NavSatFixCallback(
-      const sensor_msgs::msg::NavSatFix::ConstSharedPtr navsat)
+  void NavSatPlugin::NavSatFixCallback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr navsat)
+  {
+    // Runs on the ROS spin thread: hand the message to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning.
+    Q_EMIT NavSatFixReceived(navsat);
+  }
+
+  void NavSatPlugin::handleNavSatFix(const sensor_msgs::msg::NavSatFix::ConstSharedPtr navsat)
   {
     if (!tf_manager_->LocalXyUtil()->Initialized())
     {

--- a/mapviz_plugins/src/occupancy_grid_plugin.cpp
+++ b/mapviz_plugins/src/occupancy_grid_plugin.cpp
@@ -152,8 +152,6 @@ namespace mapviz_plugins
     texture_x_(0.0),
     texture_y_(0.0),
     texture_size_(0),
-    color_scheme_("map"),
-    texture_stale_(false),
     map_palette_(makeMapPalette()),
     costmap_palette_( makeCostmapPalette()),
     topic_(""),
@@ -196,6 +194,19 @@ namespace mapviz_plugins
       SIGNAL(currentTextChanged(const QString &)),
       this,
       SLOT(colorSchemeUpdated(const QString &)));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state, the GL texture, and
+    // the color-scheme widget; these connections are queued because the
+    // emitting thread differs from this object's thread.
+    qRegisterMetaType<nav_msgs::msg::OccupancyGrid::ConstSharedPtr>(
+        "nav_msgs::msg::OccupancyGrid::ConstSharedPtr");
+    qRegisterMetaType<map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr>(
+        "map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr");
+    QObject::connect(this, &OccupancyGridPlugin::GridReceived,
+                     this, &OccupancyGridPlugin::handleGrid);
+    QObject::connect(this, &OccupancyGridPlugin::GridUpdateReceived,
+                     this, &OccupancyGridPlugin::handleGridUpdate);
   }
 
   void OccupancyGridPlugin::DrawIcon()
@@ -253,8 +264,6 @@ namespace mapviz_plugins
     ui_.topic_grid->setText(QString::fromStdString(topic));
     if ((topic_ != topic) || !qosEqual(qos, qos_))
     {
-      std::lock_guard<std::recursive_mutex> lock(DataMutex());
-
       initialized_ = false;
       grid_.reset();
       raw_buffer_.clear();
@@ -298,18 +307,12 @@ namespace mapviz_plugins
 
   void OccupancyGridPlugin::colorSchemeUpdated(const QString &)
   {
-    // Runs on the GUI thread; the buffers and cached scheme are shared with
-    // the message callbacks on the spin thread.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
-
-    color_scheme_ = ui_.color_scheme->currentText().toStdString();
-
     if( grid_ && !raw_buffer_.empty())
     {
       const size_t width  = grid_->info.width;
       const size_t height = grid_->info.height;
       const Palette& palette =
-        (color_scheme_ == "map") ?  map_palette_ : costmap_palette_;
+        (ui_.color_scheme->currentText() == "map") ?  map_palette_ : costmap_palette_;
 
       for (size_t row = 0; row < height;  row++)
       {
@@ -363,14 +366,7 @@ namespace mapviz_plugins
     }
 
     canvas_->makeCurrent();
-    rebuildTexture();
-    canvas_->doneCurrent();
-  }
 
-  // Requires the GL context to already be current; called directly from
-  // Draw(), where making/releasing the context would disrupt paintGL().
-  void OccupancyGridPlugin::rebuildTexture()
-  {
     texture_.reset();
 
     texture_ = std::make_unique<QOpenGLTexture>(QOpenGLTexture::Target2D);
@@ -386,9 +382,24 @@ namespace mapviz_plugins
       static_cast<const void*>(color_buffer_.data()));
 
     glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+    canvas_->doneCurrent();
   }
 
-  void OccupancyGridPlugin::Callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg)
+  // These callbacks run on the ROS spin thread: they hand the message to the
+  // GUI thread and return immediately so message processing never blocks ROS
+  // spinning.
+  void OccupancyGridPlugin::Callback(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg)
+  {
+    Q_EMIT GridReceived(msg);
+  }
+
+  void OccupancyGridPlugin::CallbackUpdate(
+      const map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr msg)
+  {
+    Q_EMIT GridUpdateReceived(msg);
+  }
+
+  void OccupancyGridPlugin::handleGrid(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg)
   {
     grid_ = msg;
     const int width  = grid_->info.width;
@@ -409,7 +420,7 @@ namespace mapviz_plugins
     }
 
     const Palette& palette =
-      (color_scheme_ == "map") ?  map_palette_ : costmap_palette_;
+      (ui_.color_scheme->currentText() == "map") ?  map_palette_ : costmap_palette_;
 
     raw_buffer_.resize(texture_size_*texture_size_, 0);
     color_buffer_.resize(texture_size_*texture_size_*CHANNELS, 0);
@@ -429,19 +440,19 @@ namespace mapviz_plugins
     texture_x_ = static_cast<float>(width) / static_cast<float>(texture_size_);
     texture_y_ = static_cast<float>(height) / static_cast<float>(texture_size_);
 
-    // The GL upload has to happen on the GUI thread; Draw() picks it up.
-    texture_stale_ = true;
+    updateTexture();
     PrintInfo("Map received");
   }
 
-  void OccupancyGridPlugin::CallbackUpdate(const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg)
+  void OccupancyGridPlugin::handleGridUpdate(
+      const map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr msg)
   {
     PrintInfo("Update Received");
 
     if( initialized_ )
     {
       const Palette& palette =
-        (color_scheme_ == "map") ?  map_palette_ : costmap_palette_;
+        (ui_.color_scheme->currentText() == "map") ?  map_palette_ : costmap_palette_;
 
       for (size_t row = 0; row < msg->height; row++)
       {
@@ -454,18 +465,12 @@ namespace mapviz_plugins
           memcpy( &color_buffer_[index_dst*CHANNELS], &palette[color*CHANNELS], CHANNELS);
         }
       }
-      texture_stale_ = true;
+      updateTexture();
     }
   }
 
   void OccupancyGridPlugin::Draw(double x, double y, double scale)
   {
-    if (texture_stale_)
-    {
-      rebuildTexture();
-      texture_stale_ = false;
-    }
-
     glPushMatrix();
 
     if( grid_ && transformed_)

--- a/mapviz_plugins/src/occupancy_grid_plugin.cpp
+++ b/mapviz_plugins/src/occupancy_grid_plugin.cpp
@@ -152,6 +152,8 @@ namespace mapviz_plugins
     texture_x_(0.0),
     texture_y_(0.0),
     texture_size_(0),
+    color_scheme_("map"),
+    texture_stale_(false),
     map_palette_(makeMapPalette()),
     costmap_palette_( makeCostmapPalette()),
     topic_(""),
@@ -251,6 +253,8 @@ namespace mapviz_plugins
     ui_.topic_grid->setText(QString::fromStdString(topic));
     if ((topic_ != topic) || !qosEqual(qos, qos_))
     {
+      std::lock_guard<std::recursive_mutex> lock(DataMutex());
+
       initialized_ = false;
       grid_.reset();
       raw_buffer_.clear();
@@ -294,12 +298,18 @@ namespace mapviz_plugins
 
   void OccupancyGridPlugin::colorSchemeUpdated(const QString &)
   {
+    // Runs on the GUI thread; the buffers and cached scheme are shared with
+    // the message callbacks on the spin thread.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
+
+    color_scheme_ = ui_.color_scheme->currentText().toStdString();
+
     if( grid_ && !raw_buffer_.empty())
     {
       const size_t width  = grid_->info.width;
       const size_t height = grid_->info.height;
       const Palette& palette =
-        (ui_.color_scheme->currentText() == "map") ?  map_palette_ : costmap_palette_;
+        (color_scheme_ == "map") ?  map_palette_ : costmap_palette_;
 
       for (size_t row = 0; row < height;  row++)
       {
@@ -353,7 +363,14 @@ namespace mapviz_plugins
     }
 
     canvas_->makeCurrent();
+    rebuildTexture();
+    canvas_->doneCurrent();
+  }
 
+  // Requires the GL context to already be current; called directly from
+  // Draw(), where making/releasing the context would disrupt paintGL().
+  void OccupancyGridPlugin::rebuildTexture()
+  {
     texture_.reset();
 
     texture_ = std::make_unique<QOpenGLTexture>(QOpenGLTexture::Target2D);
@@ -369,7 +386,6 @@ namespace mapviz_plugins
       static_cast<const void*>(color_buffer_.data()));
 
     glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-    canvas_->doneCurrent();
   }
 
   void OccupancyGridPlugin::Callback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg)
@@ -393,7 +409,7 @@ namespace mapviz_plugins
     }
 
     const Palette& palette =
-      (ui_.color_scheme->currentText() == "map") ?  map_palette_ : costmap_palette_;
+      (color_scheme_ == "map") ?  map_palette_ : costmap_palette_;
 
     raw_buffer_.resize(texture_size_*texture_size_, 0);
     color_buffer_.resize(texture_size_*texture_size_*CHANNELS, 0);
@@ -413,7 +429,8 @@ namespace mapviz_plugins
     texture_x_ = static_cast<float>(width) / static_cast<float>(texture_size_);
     texture_y_ = static_cast<float>(height) / static_cast<float>(texture_size_);
 
-    updateTexture();
+    // The GL upload has to happen on the GUI thread; Draw() picks it up.
+    texture_stale_ = true;
     PrintInfo("Map received");
   }
 
@@ -424,7 +441,7 @@ namespace mapviz_plugins
     if( initialized_ )
     {
       const Palette& palette =
-        (ui_.color_scheme->currentText() == "map") ?  map_palette_ : costmap_palette_;
+        (color_scheme_ == "map") ?  map_palette_ : costmap_palette_;
 
       for (size_t row = 0; row < msg->height; row++)
       {
@@ -437,12 +454,18 @@ namespace mapviz_plugins
           memcpy( &color_buffer_[index_dst*CHANNELS], &palette[color*CHANNELS], CHANNELS);
         }
       }
-      updateTexture();
+      texture_stale_ = true;
     }
   }
 
   void OccupancyGridPlugin::Draw(double x, double y, double scale)
   {
+    if (texture_stale_)
+    {
+      rebuildTexture();
+      texture_stale_ = false;
+    }
+
     glPushMatrix();
 
     if( grid_ && transformed_)

--- a/mapviz_plugins/src/odometry_plugin.cpp
+++ b/mapviz_plugins/src/odometry_plugin.cpp
@@ -102,6 +102,14 @@ namespace mapviz_plugins
                      SLOT(ShowAllCovariancesToggled(bool)));
     QObject::connect(ui_.buttonResetBuffer, SIGNAL(pressed()), this,
                      SLOT(ClearPoints()));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; this connection is
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<nav_msgs::msg::Odometry::ConstSharedPtr>(
+        "nav_msgs::msg::Odometry::ConstSharedPtr");
+    QObject::connect(this, &OdometryPlugin::OdometryReceived,
+                     this, &OdometryPlugin::handleOdometry);
   }
 
   void OdometryPlugin::SelectTopic()
@@ -150,7 +158,16 @@ namespace mapviz_plugins
   }
 
   void OdometryPlugin::odometryCallback(
-      const nav_msgs::msg::Odometry::SharedPtr odometry)
+      const nav_msgs::msg::Odometry::ConstSharedPtr odometry)
+  {
+    // Runs on the ROS spin thread: hand the message to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning
+    // (and vice versa: slow processing doesn't hold up the executor).
+    Q_EMIT OdometryReceived(odometry);
+  }
+
+  void OdometryPlugin::handleOdometry(
+      const nav_msgs::msg::Odometry::ConstSharedPtr odometry)
   {
     if (!has_message_)
     {

--- a/mapviz_plugins/src/path_plugin.cpp
+++ b/mapviz_plugins/src/path_plugin.cpp
@@ -75,6 +75,14 @@ namespace mapviz_plugins
     connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
     connect(ui_.path_color, SIGNAL(colorEdited(const QColor&)), this,
             SLOT(SetColor(const QColor&)));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; this connection is
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<nav_msgs::msg::Path::ConstSharedPtr>(
+        "nav_msgs::msg::Path::ConstSharedPtr");
+    QObject::connect(this, &PathPlugin::PathReceived,
+                     this, &PathPlugin::handlePath);
   }
 
   void PathPlugin::SelectTopic()
@@ -121,7 +129,14 @@ namespace mapviz_plugins
     }
   }
 
-  void PathPlugin::pathCallback(const nav_msgs::msg::Path::SharedPtr path)
+  void PathPlugin::pathCallback(const nav_msgs::msg::Path::ConstSharedPtr path)
+  {
+    // Runs on the ROS spin thread: hand the message to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning.
+    Q_EMIT PathReceived(path);
+  }
+
+  void PathPlugin::handlePath(const nav_msgs::msg::Path::ConstSharedPtr path)
   {
     if (!has_message_)
     {

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -101,6 +101,14 @@ namespace mapviz_plugins
                      SIGNAL(VisibleChanged(bool)),
                      this,
                      SLOT(VisibilityChanged(bool)));
+
+    // Service responses arrive on the ROS spin thread but must be processed
+    // on the GUI thread, which owns the plugin's state; this connection is
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<rclcpp::Client<marti_nav_msgs::srv::PlanRoute>::SharedFuture>(
+        "rclcpp::Client<marti_nav_msgs::srv::PlanRoute>::SharedFuture");
+    QObject::connect(this, &PlanRoutePlugin::PlanRouteCompleted,
+                     this, &PlanRoutePlugin::handlePlanRouteResponse);
   }
 
   PlanRoutePlugin::~PlanRoutePlugin()
@@ -177,6 +185,14 @@ namespace mapviz_plugins
   }
 
   void PlanRoutePlugin::ClientCallback(
+    rclcpp::Client<marti_nav_msgs::srv::PlanRoute>::SharedFuture future)
+  {
+    // Runs on the ROS spin thread: hand the response to the GUI thread and
+    // return immediately.
+    Q_EMIT PlanRouteCompleted(future);
+  }
+
+  void PlanRoutePlugin::handlePlanRouteResponse(
     rclcpp::Client<marti_nav_msgs::srv::PlanRoute>::SharedFuture future)
   {
     RCLCPP_ERROR(node_->get_logger(), "Request callback happened");
@@ -262,9 +278,6 @@ namespace mapviz_plugins
 
   bool PlanRoutePlugin::handleMousePress(QMouseEvent* event)
   {
-    // Uses tf_manager_, which is shared with callbacks on the ROS spin
-    // thread and is not thread safe.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     selected_point_ = -1;
     int closest_point = 0;
     double closest_distance = std::numeric_limits<double>::max();
@@ -320,9 +333,6 @@ namespace mapviz_plugins
 
   bool PlanRoutePlugin::handleMouseRelease(QMouseEvent* event)
   {
-    // Uses tf_manager_, which is shared with callbacks on the ROS spin
-    // thread and is not thread safe.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     QPointF point = mapviz::MouseEventPosition(event);
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < waypoints_.size())
     {
@@ -372,9 +382,6 @@ namespace mapviz_plugins
 
   bool PlanRoutePlugin::handleMouseMove(QMouseEvent* event)
   {
-    // Uses tf_manager_, which is shared with callbacks on the ROS spin
-    // thread and is not thread safe.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < waypoints_.size())
     {
       QPointF point = mapviz::MouseEventPosition(event);

--- a/mapviz_plugins/src/plan_route_plugin.cpp
+++ b/mapviz_plugins/src/plan_route_plugin.cpp
@@ -262,6 +262,9 @@ namespace mapviz_plugins
 
   bool PlanRoutePlugin::handleMousePress(QMouseEvent* event)
   {
+    // Uses tf_manager_, which is shared with callbacks on the ROS spin
+    // thread and is not thread safe.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     selected_point_ = -1;
     int closest_point = 0;
     double closest_distance = std::numeric_limits<double>::max();
@@ -317,6 +320,9 @@ namespace mapviz_plugins
 
   bool PlanRoutePlugin::handleMouseRelease(QMouseEvent* event)
   {
+    // Uses tf_manager_, which is shared with callbacks on the ROS spin
+    // thread and is not thread safe.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     QPointF point = mapviz::MouseEventPosition(event);
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < waypoints_.size())
     {
@@ -366,6 +372,9 @@ namespace mapviz_plugins
 
   bool PlanRoutePlugin::handleMouseMove(QMouseEvent* event)
   {
+    // Uses tf_manager_, which is shared with callbacks on the ROS spin
+    // thread and is not thread safe.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     if (selected_point_ >= 0 && static_cast<size_t>(selected_point_) < waypoints_.size())
     {
       QPointF point = mapviz::MouseEventPosition(event);

--- a/mapviz_plugins/src/point_click_publisher_plugin.cpp
+++ b/mapviz_plugins/src/point_click_publisher_plugin.cpp
@@ -118,6 +118,9 @@ namespace mapviz_plugins
 
   void PointClickPublisherPlugin::pointClicked(const QPointF& point)
   {
+    // Uses tf_manager_, which is shared with callbacks on the ROS spin
+    // thread and is not thread safe.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     QPointF transformed = canvas_->MapGlCoordToFixedFrame(point);
 
     std::string output_frame = ui_.outputframe->currentText().toStdString();
@@ -203,6 +206,9 @@ namespace mapviz_plugins
 
   void PointClickPublisherPlugin::updateFrames()
   {
+    // Uses tf_manager_, which is shared with callbacks on the ROS spin
+    // thread and is not thread safe.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     std::vector<std::string> frames;
     tf_buf_->_getFrameStrings(frames);
 

--- a/mapviz_plugins/src/point_click_publisher_plugin.cpp
+++ b/mapviz_plugins/src/point_click_publisher_plugin.cpp
@@ -118,9 +118,6 @@ namespace mapviz_plugins
 
   void PointClickPublisherPlugin::pointClicked(const QPointF& point)
   {
-    // Uses tf_manager_, which is shared with callbacks on the ROS spin
-    // thread and is not thread safe.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     QPointF transformed = canvas_->MapGlCoordToFixedFrame(point);
 
     std::string output_frame = ui_.outputframe->currentText().toStdString();
@@ -206,9 +203,6 @@ namespace mapviz_plugins
 
   void PointClickPublisherPlugin::updateFrames()
   {
-    // Uses tf_manager_, which is shared with callbacks on the ROS spin
-    // thread and is not thread safe.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     std::vector<std::string> frames;
     tf_buf_->_getFrameStrings(frames);
 

--- a/mapviz_plugins/src/point_drawing_plugin.cpp
+++ b/mapviz_plugins/src/point_drawing_plugin.cpp
@@ -67,6 +67,8 @@ namespace mapviz_plugins
   void PointDrawingPlugin::ClearHistory()
   {
     RCLCPP_INFO(node_->get_logger(), "PointDrawingPlugin::ClearHistory()");
+    // points_ is shared with message callbacks on the ROS spin thread.
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     points_.clear();
   }
 
@@ -160,6 +162,7 @@ namespace mapviz_plugins
 
   void PointDrawingPlugin::ResetTransformedPoints()
   {
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     for (std::deque<StampedPoint>& lap : laps_)
     {
       for (StampedPoint& point : lap)
@@ -196,6 +199,7 @@ namespace mapviz_plugins
 
   void PointDrawingPlugin::ClearPoints()
   {
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     points_.clear();
   }
 
@@ -221,6 +225,7 @@ namespace mapviz_plugins
 
   void PointDrawingPlugin::BufferSizeChanged(int value)
   {
+    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     buffer_size_ = value;
 
     if (buffer_size_ > 0)

--- a/mapviz_plugins/src/point_drawing_plugin.cpp
+++ b/mapviz_plugins/src/point_drawing_plugin.cpp
@@ -67,8 +67,6 @@ namespace mapviz_plugins
   void PointDrawingPlugin::ClearHistory()
   {
     RCLCPP_INFO(node_->get_logger(), "PointDrawingPlugin::ClearHistory()");
-    // points_ is shared with message callbacks on the ROS spin thread.
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     points_.clear();
   }
 
@@ -162,7 +160,6 @@ namespace mapviz_plugins
 
   void PointDrawingPlugin::ResetTransformedPoints()
   {
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     for (std::deque<StampedPoint>& lap : laps_)
     {
       for (StampedPoint& point : lap)
@@ -199,7 +196,6 @@ namespace mapviz_plugins
 
   void PointDrawingPlugin::ClearPoints()
   {
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     points_.clear();
   }
 
@@ -225,7 +221,6 @@ namespace mapviz_plugins
 
   void PointDrawingPlugin::BufferSizeChanged(int value)
   {
-    std::lock_guard<std::recursive_mutex> lock(DataMutex());
     buffer_size_ = value;
 
     if (buffer_size_ > 0)

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -569,7 +569,9 @@ namespace mapviz_plugins
       scans_.push_back( std::move(scan) );
     }
     new_topic_ = true;
-    canvas_->update();
+    // Runs on the ROS spin thread; QWidget::update() must be invoked on the
+    // GUI thread.
+    QMetaObject::invokeMethod(canvas_, "update", Qt::QueuedConnection);
   }
 
   float PointCloud2Plugin::PointFeature(const uint8_t* data, const FieldInfo& feature_info)

--- a/mapviz_plugins/src/pointcloud2_plugin.cpp
+++ b/mapviz_plugins/src/pointcloud2_plugin.cpp
@@ -62,7 +62,6 @@ namespace mapviz_plugins
     min_value_(0.0),
     point_size_(3),
     buffer_size_(1),
-    new_topic_(true),
     has_message_(false),
     num_of_feats_(0),
     need_new_list_(true),
@@ -161,6 +160,15 @@ namespace mapviz_plugins
                      SIGNAL(VisibleChanged(bool)),
                      this,
                      SLOT(SetSubscription(bool)));
+
+    // Scans are decoded on the ROS spin thread but must be finished
+    // (tf, coloring, widgets) on the GUI thread, which owns the plugin's
+    // state; this connection is queued because the emitting thread differs
+    // from this object's thread.
+    qRegisterMetaType<std::shared_ptr<mapviz_plugins::PointCloud2Plugin::Scan>>(
+        "std::shared_ptr<mapviz_plugins::PointCloud2Plugin::Scan>");
+    QObject::connect(this, &PointCloud2Plugin::ScanProcessed,
+                     this, &PointCloud2Plugin::handleScan);
   }
 
   void PointCloud2Plugin::ClearHistory()
@@ -205,7 +213,6 @@ namespace mapviz_plugins
 
   void PointCloud2Plugin::ResetTransformedPointClouds()
   {
-    QMutexLocker locker(&scan_mutex_);
     for (Scan& scan : scans_)
     {
       scan.transformed = false;
@@ -216,8 +223,7 @@ namespace mapviz_plugins
 
   void PointCloud2Plugin::ClearPointClouds()
   {
-      QMutexLocker locker(&scan_mutex_);
-      scans_.clear();
+    scans_.clear();
   }
 
   void PointCloud2Plugin::SetSubscription(bool subscribe)
@@ -231,7 +237,6 @@ namespace mapviz_plugins
         rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_)),
         std::bind(&PointCloud2Plugin::PointCloud2Callback, this, std::placeholders::_1)
       );
-      new_topic_ = true;
       need_new_list_ = true;
       max_.clear();
       min_.clear();
@@ -299,7 +304,7 @@ namespace mapviz_plugins
   }
 
   inline int32_t findChannelIndex(
-    const sensor_msgs::msg::PointCloud2::SharedPtr cloud,
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr& cloud,
     const std::string& channel)
   {
     for (int32_t i = 0; static_cast<size_t>(i) < cloud->fields.size(); ++i)
@@ -316,7 +321,6 @@ namespace mapviz_plugins
   void PointCloud2Plugin::UpdateColors()
   {
     {
-      QMutexLocker locker(&scan_mutex_);
       for (Scan& scan : scans_)
       {
         scan.gl_color.clear();
@@ -359,10 +363,7 @@ namespace mapviz_plugins
     if ((topic != topic_) || !qosEqual(qos, qos_))
     {
       initialized_ = false;
-      {
-        QMutexLocker locker(&scan_mutex_);
-        scans_.clear();
-      }
+      scans_.clear();
       has_message_ = false;
       PrintWarning("No messages received.");
 
@@ -391,7 +392,6 @@ namespace mapviz_plugins
 
     if (buffer_size_ > 0)
     {
-      QMutexLocker locker(&scan_mutex_);
       while (scans_.size() > buffer_size_)
       {
         scans_.pop_front();
@@ -408,49 +408,14 @@ namespace mapviz_plugins
     canvas_->update();
   }
 
-  void PointCloud2Plugin::PointCloud2Callback(const sensor_msgs::msg::PointCloud2::SharedPtr msg)
+  void PointCloud2Plugin::PointCloud2Callback(
+      const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
   {
-    if (!has_message_)
-    {
-      initialized_ = true;
-      has_message_ = true;
-    }
-
-    // Note that unlike some plugins, this one does not store nor rely on the
-    // source_frame_ member variable.  This one can potentially store many
-    // messages with different source frames, so we need to store and transform
-    // them individually.
-
-    Scan scan;
-    {
-        // recycle already allocated memory, reusing an old scan
-      QMutexLocker locker(&scan_mutex_);
-      if (buffer_size_ > 0 )
-      {
-          if( scans_.size() >= buffer_size_)
-          {
-              scan = std::move( scans_.front() );
-          }
-          while (scans_.size() >= buffer_size_)
-          {
-            scans_.pop_front();
-          }
-      }
-    }
-
-    scan.stamp = msg->header.stamp;
-    scan.color = QColor::fromRgbF(1.0f, 0.0f, 0.0f, 1.0f);
-    scan.source_frame = msg->header.frame_id;
-    scan.transformed = true;
-
-    swri_transform_util::Transform transform;
-    if (!GetTransform(scan.source_frame, msg->header.stamp, transform))
-    {
-      scan.transformed = false;
-      PrintError("No transform between " + scan.source_frame + " and " + target_frame_);
-      return;
-    }
-
+    // Runs on the ROS spin thread: the expensive decode of the raw point
+    // buffer happens here so it never stalls rendering, then the prepared
+    // scan is handed to handleScan() through a queued signal.  Everything
+    // that depends on tf, widgets, or user-editable settings stays on the
+    // GUI thread.
     int32_t xi = findChannelIndex(msg, "x");
     int32_t yi = findChannelIndex(msg, "y");
     int32_t zi = findChannelIndex(msg, "z");
@@ -460,56 +425,22 @@ namespace mapviz_plugins
       return;
     }
 
-    if (new_topic_)
+    // Note that unlike some plugins, this one does not store nor rely on the
+    // source_frame_ member variable.  This one can potentially store many
+    // messages with different source frames, so we need to store and transform
+    // them individually.
+    auto scan = std::make_shared<Scan>();
+    scan->stamp = msg->header.stamp;
+    scan->color = QColor::fromRgbF(1.0f, 0.0f, 0.0f, 1.0f);
+    scan->source_frame = msg->header.frame_id;
+    scan->transformed = false;
+
+    for (const auto& field : msg->fields)
     {
-      for (auto & field : msg->fields)
-      {
-        FieldInfo input;
-        std::string name = field.name;
-
-        uint32_t offset_value = field.offset;
-        uint8_t datatype_value = field.datatype;
-        input.offset = offset_value;
-        input.datatype = datatype_value;
-        scan.new_features.insert(std::pair<std::string, FieldInfo>(name, input));
-      }
-
-      new_topic_ = false;
-      num_of_feats_ = scan.new_features.size();
-
-      max_.resize(num_of_feats_);
-      min_.resize(num_of_feats_);
-
-      int label = 1;
-      if (need_new_list_)
-      {
-        int new_feature_index = ui_.color_transformer->currentIndex();
-        std::map<std::string, FieldInfo>::const_iterator it;
-        for (it = scan.new_features.begin(); it != scan.new_features.end(); ++it)
-        {
-          ui_.color_transformer->removeItem(static_cast<int>(num_of_feats_));
-          num_of_feats_--;
-        }
-
-        for (it = scan.new_features.begin(); it != scan.new_features.end(); ++it)
-        {
-          std::string const field = it->first;
-          if (field == saved_color_transformer_)
-          {
-            // The very first time we see a new set of features, that means the
-            // plugin was just created; if we have a saved value, set the current
-            // index to that and clear the saved value.
-            new_feature_index = label;
-            saved_color_transformer_ = "";
-          }
-
-          ui_.color_transformer->addItem(QString::fromStdString(field), QVariant(label));
-          num_of_feats_++;
-          label++;
-        }
-        ui_.color_transformer->setCurrentIndex(new_feature_index);
-        need_new_list_ = false;
-      }
+      FieldInfo input;
+      input.offset = field.offset;
+      input.datatype = field.datatype;
+      scan->new_features.insert(std::pair<std::string, FieldInfo>(field.name, input));
     }
 
     if (!msg->data.empty())
@@ -520,20 +451,15 @@ namespace mapviz_plugins
       const uint32_t yoff = msg->fields[yi].offset;
       const uint32_t zoff = msg->fields[zi].offset;
       const size_t num_points = msg->data.size() / point_step;
-      const size_t num_features = scan.new_features.size();
-      scan.points.resize(num_points);
+      const size_t num_features = scan->new_features.size();
+      scan->points.resize(num_points);
 
       std::vector<FieldInfo> field_infos;
       field_infos.reserve(num_features);
-      for (auto & new_feature : scan.new_features)
+      for (const auto& new_feature : scan->new_features)
       {
         field_infos.push_back(new_feature.second);
       }
-
-      scan.gl_point.clear();
-      scan.gl_point.reserve(num_points*2);
-      scan.gl_color.clear();
-      scan.gl_color.reserve(num_points*4);
 
       for (size_t i = 0; i < num_points; i++, ptr += point_step)
       {
@@ -541,37 +467,104 @@ namespace mapviz_plugins
         float y = *reinterpret_cast<const float*>(ptr + yoff);
         float z = *reinterpret_cast<const float*>(ptr + zoff);
 
-        StampedPoint& point = scan.points[i];
+        StampedPoint& point = scan->points[i];
         point.point = tf2::Vector3(x, y, z);
 
         point.features.resize(num_features);
 
-        for (int count=0; count < field_infos.size(); count++)
+        for (size_t count = 0; count < field_infos.size(); count++)
         {
           point.features[count] = PointFeature(ptr, field_infos[count]);
         }
-        if (scan.transformed)
-        {
-          const tf2::Vector3 transformed_point = transform * point.point;
-          scan.gl_point.push_back( transformed_point.getX() );
-          scan.gl_point.push_back( transformed_point.getY() );
-        }
-        const QColor color = CalculateColor(point);
-        scan.gl_color.push_back( color.red());
-        scan.gl_color.push_back( color.green());
-        scan.gl_color.push_back( color.blue());
-        scan.gl_color.push_back( static_cast<uint8_t>(alpha_ * 255.0 ) );
       }
     }
 
+    Q_EMIT ScanProcessed(scan);
+  }
+
+  void PointCloud2Plugin::handleScan(std::shared_ptr<mapviz_plugins::PointCloud2Plugin::Scan> scan)
+  {
+    // Runs on the GUI thread via a queued connection from
+    // PointCloud2Callback(), so tf, widgets, and user-editable settings are
+    // all safe to use here without locking.
+    if (!has_message_)
     {
-      QMutexLocker locker(&scan_mutex_);
-      scans_.push_back( std::move(scan) );
+      initialized_ = true;
+      has_message_ = true;
     }
-    new_topic_ = true;
-    // Runs on the ROS spin thread; QWidget::update() must be invoked on the
-    // GUI thread.
-    QMetaObject::invokeMethod(canvas_, "update", Qt::QueuedConnection);
+
+    num_of_feats_ = scan->new_features.size();
+
+    max_.resize(num_of_feats_);
+    min_.resize(num_of_feats_);
+
+    int label = 1;
+    if (need_new_list_)
+    {
+      int new_feature_index = ui_.color_transformer->currentIndex();
+      std::map<std::string, FieldInfo>::const_iterator it;
+      for (it = scan->new_features.begin(); it != scan->new_features.end(); ++it)
+      {
+        ui_.color_transformer->removeItem(static_cast<int>(num_of_feats_));
+        num_of_feats_--;
+      }
+
+      for (it = scan->new_features.begin(); it != scan->new_features.end(); ++it)
+      {
+        std::string const field = it->first;
+        if (field == saved_color_transformer_)
+        {
+          // The very first time we see a new set of features, that means the
+          // plugin was just created; if we have a saved value, set the current
+          // index to that and clear the saved value.
+          new_feature_index = label;
+          saved_color_transformer_ = "";
+        }
+
+        ui_.color_transformer->addItem(QString::fromStdString(field), QVariant(label));
+        num_of_feats_++;
+        label++;
+      }
+      ui_.color_transformer->setCurrentIndex(new_feature_index);
+      need_new_list_ = false;
+    }
+
+    swri_transform_util::Transform transform;
+    if (!GetTransform(scan->source_frame, scan->stamp, transform))
+    {
+      PrintError("No transform between " + scan->source_frame + " and " + target_frame_);
+      return;
+    }
+    scan->transformed = true;
+
+    scan->gl_point.clear();
+    scan->gl_point.reserve(scan->points.size()*2);
+    scan->gl_color.clear();
+    scan->gl_color.reserve(scan->points.size()*4);
+
+    for (const StampedPoint& point : scan->points)
+    {
+      const tf2::Vector3 transformed_point = transform * point.point;
+      scan->gl_point.push_back( transformed_point.getX() );
+      scan->gl_point.push_back( transformed_point.getY() );
+
+      const QColor color = CalculateColor(point);
+      scan->gl_color.push_back( color.red());
+      scan->gl_color.push_back( color.green());
+      scan->gl_color.push_back( color.blue());
+      scan->gl_color.push_back( static_cast<uint8_t>(alpha_ * 255.0 ) );
+    }
+
+    if (buffer_size_ > 0)
+    {
+      while (scans_.size() >= buffer_size_)
+      {
+        scans_.pop_front();
+      }
+    }
+    scans_.push_back( std::move(*scan) );
+
+    canvas_->update();
   }
 
   float PointCloud2Plugin::PointFeature(const uint8_t* data, const FieldInfo& feature_info)
@@ -649,8 +642,6 @@ namespace mapviz_plugins
     glEnableClientState(GL_COLOR_ARRAY);
 
     {
-      QMutexLocker locker(&scan_mutex_);
-
       for (Scan& scan : scans_)
       {
         if (scan.transformed && !scan.gl_color.empty())
@@ -702,8 +693,6 @@ namespace mapviz_plugins
   void PointCloud2Plugin::Transform()
   {
     {
-      QMutexLocker locker(&scan_mutex_);
-
       bool was_using_latest_transforms = use_latest_transforms_;
       use_latest_transforms_ = false;
       for (Scan& scan : scans_)

--- a/mapviz_plugins/src/pose_plugin.cpp
+++ b/mapviz_plugins/src/pose_plugin.cpp
@@ -98,6 +98,14 @@ namespace mapviz_plugins
             SLOT(LapToggled(bool)));
     QObject::connect(ui_.buttonResetBuffer, SIGNAL(pressed()), this,
                      SLOT(ClearPoints()));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; this connection is
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<geometry_msgs::msg::PoseStamped::ConstSharedPtr>(
+        "geometry_msgs::msg::PoseStamped::ConstSharedPtr");
+    QObject::connect(this, &PosePlugin::PoseReceived,
+                     this, &PosePlugin::handlePose);
   }
 
   void PosePlugin::SelectTopic()
@@ -145,7 +153,14 @@ namespace mapviz_plugins
     }
   }
 
-  void PosePlugin::PoseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr pose)
+  void PosePlugin::PoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr pose)
+  {
+    // Runs on the ROS spin thread: hand the message to the GUI thread and
+    // return immediately so message processing never blocks ROS spinning.
+    Q_EMIT PoseReceived(pose);
+  }
+
+  void PosePlugin::handlePose(const geometry_msgs::msg::PoseStamped::ConstSharedPtr pose)
   {
     if (!has_message_)
     {

--- a/mapviz_plugins/src/robot_model_plugin.cpp
+++ b/mapviz_plugins/src/robot_model_plugin.cpp
@@ -498,6 +498,14 @@ RobotModelPlugin::RobotModelPlugin()
   connect(ui_.topic, SIGNAL(editingFinished()), this, SLOT(TopicEdited()));
   connect(ui_.browsefile, SIGNAL(clicked()), this, SLOT(BrowseFile()));
   connect(ui_.filepath, SIGNAL(editingFinished()), this, SLOT(FileEdited()));
+
+  // The description is received on the ROS spin thread but parsed on the
+  // GUI thread, which owns the plugin's state; this connection is queued
+  // because the emitting thread differs from this object's thread.
+  qRegisterMetaType<std_msgs::msg::String::ConstSharedPtr>(
+      "std_msgs::msg::String::ConstSharedPtr");
+  connect(this, &RobotModelPlugin::DescriptionReceived,
+          this, &RobotModelPlugin::handleDescription);
 }
 
 bool RobotModelPlugin::Initialize(QOpenGLWidget* canvas) {
@@ -654,9 +662,16 @@ void RobotModelPlugin::TopicEdited() {
   PrintWarning("Waiting for description on " + topic_);
 }
 
+// Runs on the ROS spin thread: hand the message to the GUI thread and
+// return immediately so message processing never blocks ROS spinning.
 void RobotModelPlugin::robotDescriptionCallback(
-    const std_msgs::msg::String::SharedPtr msg) {
-  parseUrdf(msg->data);
+    const std_msgs::msg::String::ConstSharedPtr msg) {
+  Q_EMIT DescriptionReceived(msg);
+}
+
+void RobotModelPlugin::handleDescription(
+    const std_msgs::msg::String::ConstSharedPtr description) {
+  parseUrdf(description->data);
 }
 
 void RobotModelPlugin::parseUrdf(const std::string& xml) {

--- a/mapviz_plugins/src/route_plugin.cpp
+++ b/mapviz_plugins/src/route_plugin.cpp
@@ -92,6 +92,18 @@ namespace mapviz_plugins
                      SLOT(PositionTopicEdited()));
     QObject::connect(ui_.drawstyle, SIGNAL(activated(QString)), this,
                      SLOT(SetDrawStyle(QString)));
+
+    // Messages are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; these connections are
+    // queued because the emitting thread differs from this object's thread.
+    qRegisterMetaType<marti_nav_msgs::msg::Route::ConstSharedPtr>(
+        "marti_nav_msgs::msg::Route::ConstSharedPtr");
+    qRegisterMetaType<marti_nav_msgs::msg::RoutePosition::ConstSharedPtr>(
+        "marti_nav_msgs::msg::RoutePosition::ConstSharedPtr");
+    QObject::connect(this, &RoutePlugin::RouteReceived,
+                     this, &RoutePlugin::handleRoute);
+    QObject::connect(this, &RoutePlugin::RoutePositionReceived,
+                     this, &RoutePlugin::handleRoutePosition);
     QObject::connect(ui_.color, SIGNAL(colorEdited(const QColor&)), this,
                      SLOT(DrawIcon()));
   }
@@ -220,15 +232,29 @@ namespace mapviz_plugins
 
   }
 
+  // These callbacks run on the ROS spin thread: they hand the message to the
+  // GUI thread and return immediately so message processing never blocks ROS
+  // spinning.
   void RoutePlugin::PositionCallback(
-      const marti_nav_msgs::msg::RoutePosition::SharedPtr msg)
+      const marti_nav_msgs::msg::RoutePosition::ConstSharedPtr msg)
   {
-    src_route_position_ = msg;
+    Q_EMIT RoutePositionReceived(msg);
   }
 
-  void RoutePlugin::RouteCallback(const marti_nav_msgs::msg::Route::SharedPtr msg)
+  void RoutePlugin::RouteCallback(const marti_nav_msgs::msg::Route::ConstSharedPtr msg)
   {
-    src_route_ = sru::Route(*msg);
+    Q_EMIT RouteReceived(msg);
+  }
+
+  void RoutePlugin::handleRoutePosition(
+      const marti_nav_msgs::msg::RoutePosition::ConstSharedPtr position)
+  {
+    src_route_position_ = position;
+  }
+
+  void RoutePlugin::handleRoute(const marti_nav_msgs::msg::Route::ConstSharedPtr route)
+  {
+    src_route_ = sru::Route(*route);
   }
 
   void RoutePlugin::PrintError(const std::string& message)

--- a/mapviz_plugins/src/string_plugin.cpp
+++ b/mapviz_plugins/src/string_plugin.cpp
@@ -84,6 +84,12 @@ namespace mapviz_plugins
     QObject::connect(ui_.font_button, SIGNAL(clicked()), this, SLOT(SelectFont()));
     QObject::connect(ui_.color, SIGNAL(colorEdited(const QColor &)), this, SLOT(SelectColor()));
 
+    // Strings are received on the ROS spin thread but must be processed on
+    // the GUI thread, which owns the plugin's state; this connection is
+    // queued because the emitting thread differs from this object's thread.
+    QObject::connect(this, &StringPlugin::TextReceived,
+                     this, &StringPlugin::SetText);
+
     // Change the default font size to our desired size and update the UI with it
     font_.setPointSize(DEFAULT_FONT_SIZE);
     ui_.font_button->setFont(font_);
@@ -361,7 +367,8 @@ namespace mapviz_plugins
           string_sub_ = node_->create_subscription<std_msgs::msg::String>(topic_,
             rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos), qos),
               [this](const std_msgs::msg::String::ConstSharedPtr str) {
-            SetText(QString(str->data.c_str()));
+            // Runs on the ROS spin thread; SetText runs on the GUI thread.
+            Q_EMIT TextReceived(QString(str->data.c_str()));
           });
         }
         catch(...)
@@ -376,7 +383,8 @@ namespace mapviz_plugins
           string_stamped_sub_ = node_->create_subscription<marti_common_msgs::msg::StringStamped>(topic_,
             rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos), qos),
               [this](const marti_common_msgs::msg::StringStamped::ConstSharedPtr str) {
-            SetText(QString(str->value.c_str()));
+            // Runs on the ROS spin thread; SetText runs on the GUI thread.
+            Q_EMIT TextReceived(QString(str->value.c_str()));
           });
         }
         catch(...)

--- a/mapviz_plugins/src/tf_frame_plugin.cpp
+++ b/mapviz_plugins/src/tf_frame_plugin.cpp
@@ -152,8 +152,11 @@ namespace mapviz_plugins
     initializeOpenGLFunctions();
     canvas->doneCurrent();
 
-    timer_ = node_->create_wall_timer(std::chrono::milliseconds(100),
-        std::bind(&TfFramePlugin::TimerCallback, this));
+    // A QTimer (instead of a ROS wall timer) so TimerCallback() runs on the
+    // GUI thread, which owns the plugin's state and the TransformManager.
+    QObject::connect(&timer_, &QTimer::timeout,
+                     this, &TfFramePlugin::TimerCallback);
+    timer_.start(100);
 
     SetColor(ui_.color->color());
 


### PR DESCRIPTION
This separates out the processing done on callbacks and the ROS interface to its own thread, and lets the UI run independently on a separate thread. This should hopefully make the application more responsive.