### PR TITLE
mapviz: Export pkg-config dependency

### DIFF
--- a/mapviz/package.xml
+++ b/mapviz/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
+  <buildtool_export_depend>pkg-config</buildtool_export_depend>
 
   <build_depend>qt-base-dev</build_depend>
 


### PR DESCRIPTION
Mapviz uses pkg-config in its exported mapviz-extras.cmake. Therefore, all dependent packages, such as mapviz_plugins, need to have pkg-config available. Without it, mapviz_plugins compilation fails with the following error:

    CMake Error at /nix/store/jfdn7bk2k40afmmaqv85b8v043jrigm5-cmake-4.3.4/share/cmake-4.3/Modules/FindPackageHandleStandardArgs…
      Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
    Call Stack (most recent call first):
      /nix/store/jfdn7bk2k40afmmaqv85b8v043jrigm5-cmake-4.3.4/share/cmake-4.3/Modules/FindPackageHandleStandardArgs.cmake:654 (_…
      /nix/store/jfdn7bk2k40afmmaqv85b8v043jrigm5-cmake-4.3.4/share/cmake-4.3/Modules/FindPkgConfig.cmake:562 (find_package_hand…
      /nix/store/vikj9swn4fb2xkidb5qksnivixd48bpv-ros-humble-mapviz-4.0.1-r1/share/mapviz/cmake/mapviz-extras.cmake:34 (find_pac…
      /nix/store/vikj9swn4fb2xkidb5qksnivixd48bpv-ros-humble-mapviz-4.0.1-r1/share/mapviz/cmake/mapvizConfig.cmake:41 (include)
      CMakeLists.txt:66 (find_package)